### PR TITLE
Change semantic domain members to be lowercase initial

### DIFF
--- a/src/goals/MergeDupGoal/MergeDupStep/WordCard/component.tsx
+++ b/src/goals/MergeDupGoal/MergeDupStep/WordCard/component.tsx
@@ -44,7 +44,7 @@ class WordCard extends React.Component<
   getDomains(sense: Sense): string {
     if (sense.semanticDomains.length > 0) {
       return sense.semanticDomains
-        .map(domain => domain.Number + " " + domain.Name)
+        .map(domain => domain.number + " " + domain.name)
         .reduce((acc, val) => acc + ", " + val);
     } else {
       return "{no semantic domain}";

--- a/src/types/word.tsx
+++ b/src/types/word.tsx
@@ -11,8 +11,8 @@ export interface Gloss {
 }
 
 export interface SemanticDomain {
-  Name: string;
-  Number: string;
+  name: string;
+  number: string;
 }
 export interface Sense {
   glosses: Gloss[];


### PR DESCRIPTION
I should have included this in my last PR but I forgot.

The backend gives us a semantic domain object that has lowercase initial characters for it's members.
This changes the frontend's representation to match this

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/41)
<!-- Reviewable:end -->
