### PR TITLE
Fix register page submission and login page spinner

### DIFF
--- a/src/components/Login/LoginActions.tsx
+++ b/src/components/Login/LoginActions.tsx
@@ -15,6 +15,9 @@ export type LOGIN_FAILURE = typeof LOGIN_FAILURE;
 export const LOGIN_SUCCESS = "LOGIN_SUCCESS";
 export type LOGIN_SUCCESS = typeof LOGIN_SUCCESS;
 
+export const LOGIN_RESET = "LOGIN_RESET";
+export type LOGIN_RESET = typeof LOGIN_RESET;
+
 export const LOGOUT = "LOGOUT";
 export type LOGOUT = typeof LOGOUT;
 
@@ -39,6 +42,7 @@ type LoginType =
   | LOGIN_ATTEMPT
   | LOGIN_FAILURE
   | LOGIN_SUCCESS
+  | LOGIN_RESET
   | REGISTER_ATTEMPT
   | REGISTER_SUCCESS
   | REGISTER_FAILURE
@@ -87,6 +91,13 @@ export function loginSuccess(user: string): UserAction {
   return {
     type: LOGIN_SUCCESS,
     payload: { user }
+  };
+}
+
+export function loginReset(): UserAction {
+  return {
+    type: LOGIN_RESET,
+    payload: { user: "" }
   };
 }
 

--- a/src/components/Login/LoginPage/LoginComponent.tsx
+++ b/src/components/Login/LoginPage/LoginComponent.tsx
@@ -20,6 +20,7 @@ import history from "../../../history";
 export interface LoginDispatchProps {
   login?: (user: string, password: string) => void;
   logout: () => void;
+  reset: () => void;
 }
 
 export interface LoginStateProps {
@@ -47,6 +48,10 @@ export class Login extends React.Component<
       password: "",
       error: { password: false, username: false }
     };
+  }
+
+  componentDidMount() {
+    this.props.reset();
   }
 
   updateUser(

--- a/src/components/Login/LoginPage/index.tsx
+++ b/src/components/Login/LoginPage/index.tsx
@@ -1,9 +1,15 @@
-import Login, { LoginStateProps } from "./LoginComponent";
+import Login, { LoginStateProps, LoginDispatchProps } from "./LoginComponent";
 import { StoreState } from "../../../types";
 
 import { connect } from "react-redux";
 import { ThunkDispatch } from "redux-thunk";
-import { asyncLogin, UserAction, logout, asyncRegister } from "../LoginActions";
+import {
+  asyncLogin,
+  UserAction,
+  logout,
+  asyncRegister,
+  loginReset
+} from "../LoginActions";
 
 function mapStateToProps(state: StoreState): LoginStateProps {
   //console.log(state);
@@ -15,13 +21,16 @@ function mapStateToProps(state: StoreState): LoginStateProps {
 
 export function mapDispatchToProps(
   dispatch: ThunkDispatch<StoreState, any, UserAction>
-) {
+): LoginDispatchProps {
   return {
     login: (user: string, password: string) => {
       dispatch(asyncLogin(user, password));
     },
     logout: () => {
       dispatch(logout());
+    },
+    reset: () => {
+      dispatch(loginReset());
     }
   };
 }

--- a/src/components/Login/LoginPage/tests/LoginComponent.test.tsx
+++ b/src/components/Login/LoginPage/tests/LoginComponent.test.tsx
@@ -31,6 +31,7 @@ describe("Testing login component", () => {
           logout={LOGOUT}
           loginAttempt={false}
           loginFailure={false}
+          reset={LOGOUT}
         />
       );
     });
@@ -45,6 +46,7 @@ describe("Testing login component", () => {
         logout={LOGOUT}
         loginAttempt={false}
         loginFailure={false}
+        reset={LOGOUT}
       />,
       div
     );

--- a/src/components/Login/LoginReducer.tsx
+++ b/src/components/Login/LoginReducer.tsx
@@ -3,6 +3,7 @@ import {
   LOGIN_ATTEMPT,
   LOGIN_FAILURE,
   LOGIN_SUCCESS,
+  LOGIN_RESET,
   REGISTER_FAILURE,
   REGISTER_ATTEMPT,
   REGISTER_SUCCESS,
@@ -79,6 +80,7 @@ export const loginReducer = (
         registerSuccess: false,
         registerFailure: true
       };
+    case LOGIN_RESET:
     case REGISTER_RESET:
       return defaultState;
     default:

--- a/src/components/Login/RegisterPage/RegisterComponent.tsx
+++ b/src/components/Login/RegisterPage/RegisterComponent.tsx
@@ -273,7 +273,7 @@ class Register extends React.Component<
               <Grid container justify="flex-end" spacing={2}>
                 <Grid item>
                   <Button
-                    type="submit"
+                    type="button"
                     onClick={() => {
                       history.push("/login");
                     }}


### PR DESCRIPTION
- Keep the spinner from showing on the login page when you navigate back to it
- Fix issue: pressing enter on the register page would go back to login without submitting the form

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/124)
<!-- Reviewable:end -->
