### PR TITLE
Make vern reset if vern is missing from list

### DIFF
--- a/src/goals/MergeDupGoal/MergeDupStep/MergeRow/MergeRowComponent.tsx
+++ b/src/goals/MergeDupGoal/MergeDupStep/MergeRow/MergeRowComponent.tsx
@@ -60,11 +60,14 @@ export class MergeRow extends React.Component<
     }
 
     // reset vern if not in vern list
-    if (this.props.words[this.props.wordID] && !verns.includes(this.props.words[this.props.wordID].vern)){
+    if (
+      this.props.words[this.props.wordID] &&
+      !verns.includes(this.props.words[this.props.wordID].vern)
+    ) {
       // set vern
-      this.props.setVern(this.props.wordID, verns[0] || "")
+      this.props.setVern(this.props.wordID, verns[0] || "");
     }
-    
+
     return (
       <Droppable
         key={this.props.wordID}

--- a/src/goals/MergeDupGoal/MergeDupStep/MergeRow/MergeRowComponent.tsx
+++ b/src/goals/MergeDupGoal/MergeDupStep/MergeRow/MergeRowComponent.tsx
@@ -58,6 +58,13 @@ export class MergeRow extends React.Component<
         )
       ];
     }
+
+    // reset vern if not in vern list
+    if (this.props.words[this.props.wordID] && !verns.includes(this.props.words[this.props.wordID].vern)){
+      // set vern
+      this.props.setVern(this.props.wordID, verns[0] || "")
+    }
+    
     return (
       <Droppable
         key={this.props.wordID}


### PR DESCRIPTION
If a a column has more than one word and two of those
words have different verns and the last word that contains
the vern that is currently selected is removed from the column
it will reset the selected vern to a different one that is in the
list

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/242)
<!-- Reviewable:end -->
