### PR TITLE
Remove requirement for specific version of nodejs

### DIFF
--- a/deploy/roles/nodejs/defaults/main.yml
+++ b/deploy/roles/nodejs/defaults/main.yml
@@ -2,4 +2,4 @@
 
 nodejs_repo: node_10.x
 nodejs_name: "Node.js 10.x"
-nodejs_pkg:  nodejs=10.16.0-1nodesource1
+nodejs_pkg:  nodejs


### PR DESCRIPTION
The previous requirement that node.js 10.16.0 was too specific and is no 
longer available on the repo.  Now will install the current 10.x 
version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/274)
<!-- Reviewable:end -->
