### PR TITLE
Install vm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,5 @@ Backend.Tests/bin/Avatars/*
 deploy/site_info/
 deploy/site_files/
 deploy/**/*.retry
-
+# host file to be used for ad hoc testing/development
+deploy/*.hosts

--- a/deploy/hosts
+++ b/deploy/hosts
@@ -2,16 +2,7 @@
 localhost ansible_connection=local
 
 [production]
-curly
-moe
-pils
-anglophone
+wordcombine[1:2]
 
-# anglophone IP address
-172.20.1.58
-
-# NUCs by access point IP address
-10.10.0.1
-
-# VM for setting up vagrant box
-10.10.0.2
+[production:vars]
+config=production

--- a/deploy/vagrant-installer/Vagrantfile
+++ b/deploy/vagrant-installer/Vagrantfile
@@ -1,0 +1,81 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "jmg227/combine-deploy"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+    # Display the VirtualBox GUI when booting the machine
+    vb.gui = true
+
+    # Customize the amount of memory on the VM:
+    vb.memory = "2048"
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    set -eux
+    git config --global user.email "#{`git config --get user.email`.strip}"
+    git config --global user.name "#{`git config --get user.name`.strip}"
+    if [ ! -f /home/vagrant/.ssh/id_rsa ] ; then
+        ssh-keygen -f /home/vagrant/.ssh/id_rsa -P ""
+    fi
+    if [ ! -d /home/vagrant/src ] ; then
+       mkdir -p /home/vagrant/src
+    fi
+    cd /home/vagrant/src
+    if [ ! -d TheCombine ] ; then
+      git clone --recurse-submodules https://github.com/sillsdev/TheCombine.git
+    fi
+  SHELL
+end

--- a/deploy/vagrant-installer/Vagrantfile
+++ b/deploy/vagrant-installer/Vagrantfile
@@ -13,7 +13,8 @@ Vagrant.configure("2") do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
   config.vm.box = "jmg227/combine-deploy"
-
+  config.vm.box_version = "1.0.1"
+  
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
   # `vagrant box outdated`. This is not recommended.

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -129,6 +129,28 @@ The following requirements are for the host system that is used to install the C
      1. *Make sure that you select the OpenSSH server when prompted to select the software for your server:*
   ![alt text](images/ubuntu-software-selection.png "Ubuntu Server Software Selection")
 
+### Note for Windows Users
+The scripts for installing TheCombine use *Ansible* to manage an installation of *TheCombine*.  *Ansible* is not available for Windows.  There is a *Vagrant* vm that is available to provide an Ubuntu environment to build and install the application on another PC, such as an *Intel NUC* to deploy to the field.  If you only have access to a Windows PC, follow these instructions to build and deploy *TheCombine*.
+
+  1. See the [System Requirements](#system-requirements) section for the minimum system for running the vagrant vm;
+  2. open a command prompt and change directory to deploy/vagrant-installer sub-folder of the cloned project directory, e.g.
+```
+    cd TheCombine/deploy/vagrant-installer
+```
+  3. create and provision the VM:
+```
+    vagrant up
+```
+  4. Once the vm is created, the Ubuntu login screen will be displayed.  Log in with the following credentials:
+```
+     Username: vagrant
+     Password: vagrant
+```
+  5. Open a terminal window (*Ctrl-Alt-T*).  This terminal window may be used to run the commands in the following sections.
+
+Note that *TheCombine* project is only cloned the first time the vm is created and provisioned.  If you have created a vagrant-installer vm in the past, use `git pull` to update your repo and install the updated software on a target.
+
+
 ### Build the App
 
 To build the Combine application in the Ubuntu Environment, run the following command (assumes the repo was cloned into ```$HOME/src```):
@@ -139,6 +161,8 @@ npm run build
 cd Backend
 dotnet publish -c Release
 ```
+
+Note: these commands are listed so that the application can be built independently of deploying it.  For normal updating of a NUC or other PC, it is simplest to use the `-b` option of the `setup-target.sh` script that is described in [Installing the App](#installing-the-app)
 
 ### Installing the App
 


### PR DESCRIPTION
Create a vagrant vm that can be used to install TheCombine on other targets, such as an Intel NUC for field use.  The vm allows users to install TheCombine when not running on a Linux platform.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/280)
<!-- Reviewable:end -->
