### PR TITLE
Pr285 residuals

### DIFF
--- a/deploy/group_vars/nuc/main.yml
+++ b/deploy/group_vars/nuc/main.yml
@@ -7,7 +7,7 @@
 
 config_base_url: "https://thecombine.languagetechnology.org/v1"
 config_captcha_required: "false"
-config_captcha_sitekey: "''"
+config_captcha_sitekey: ""
 
 #wifi access point variables
 ap_ssid: "{{ ansible_hostname }}_ap"

--- a/deploy/group_vars/nuc/main.yml
+++ b/deploy/group_vars/nuc/main.yml
@@ -8,6 +8,7 @@
 config_base_url: "https://thecombine.languagetechnology.org/v1"
 config_captcha_required: "false"
 config_captcha_sitekey: "''"
+
 #wifi access point variables
 ap_ssid: "{{ ansible_hostname }}_ap"
 ap_gateway: "10.10.10.1"
@@ -18,3 +19,7 @@ ap_passphrase: "BigRed@1979"
 #apache web server config items
 apache_listen_address: "{{ ap_gateway }}"
 
+#set backend logging levels
+app_loglevel: "Debug"
+sys_loglevel: "Debug"
+ms_loglevel: "Debug"

--- a/deploy/group_vars/nuc/main.yml
+++ b/deploy/group_vars/nuc/main.yml
@@ -1,4 +1,20 @@
 ---
+#################################################
+# Group specific configuration items
+#
+# Group: nuc
+#################################################
+
 config_base_url: "https://thecombine.languagetechnology.org/v1"
 config_captcha_required: "false"
 config_captcha_sitekey: "''"
+#wifi access point variables
+ap_ssid: "{{ ansible_hostname }}_ap"
+ap_gateway: "10.10.10.1"
+ap_domain: "{{ url_domain }}"
+ap_hostname: "{{ url_hostname }}"
+ap_passphrase: "BigRed@1979"
+
+#apache web server config items
+apache_listen_address: "{{ ap_gateway }}"
+

--- a/deploy/group_vars/server/main.yml
+++ b/deploy/group_vars/server/main.yml
@@ -11,6 +11,13 @@ config_captcha_sitekey: "6LemQNgUAAAAAAwJ6dps-Uncg5xsNuDdMxehfW8d"
 
 #apache web server config items
 apache_listen_address: "*"
+
+#set backend logging levels
+app_loglevel: "Debug"
+sys_loglevel: "Debug"
+ms_loglevel: "Debug"
+
+
 certbot_install_from_source: no
 certbot_auto_renew: true
 certbot_auto_renew_user: root

--- a/deploy/group_vars/server/main.yml
+++ b/deploy/group_vars/server/main.yml
@@ -1,8 +1,16 @@
 ---
+#################################################
+# Group specific configuration items
+#
+# Group: server
+#################################################
+
 config_base_url: "https://thecombine.languagetechnology.org/v1"
 config_captcha_required: "true"
 config_captcha_sitekey: "6LemQNgUAAAAAAwJ6dps-Uncg5xsNuDdMxehfW8d"
 
+#apache web server config items
+apache_listen_address: "*"
 certbot_install_from_source: no
 certbot_auto_renew: true
 certbot_auto_renew_user: root

--- a/deploy/roles/the_combine_app/defaults/main.yml
+++ b/deploy/roles/the_combine_app/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
 
+
+#############################
+# installation file locations
 www_uploads_dir: /var/thecombine/uploads
 www_uploads_owner: www-data
 www_uploads_group: www-data
@@ -10,6 +13,15 @@ www_app_group: www-data
 
 combine_backend_dir: /home/combine/Backend
 
+#############################
+# setup logging
+combine_log_directory: /var/log
+combine_log_file:  combine.log
+combine_program_id: CombineBackend
+
+
+#############################
+# environment variables for service
 combine_env_vars:
   ASPNETCORE_ENVIRONMENT: Production
   DOTNET_PRINT_TELEMETRY_MESSAGE: false

--- a/deploy/roles/the_combine_app/handlers/main.yml
+++ b/deploy/roles/the_combine_app/handlers/main.yml
@@ -1,6 +1,11 @@
 ---
 
+- name: Restart rsyslog
+  service:
+    name: rsyslog
+    state: restarted
+
 - name: Restart combine_backend
   service:
-    name=combine_backend
-    state=restarted
+    name: combine_backend
+    state: restarted

--- a/deploy/roles/the_combine_app/tasks/backend_service.yml
+++ b/deploy/roles/the_combine_app/tasks/backend_service.yml
@@ -8,6 +8,24 @@
     group: root
     mode: 0755
 
+- name: Create logging directory for Combine Backend
+  file:
+    path: "{{ combine_log_directory }}/{{ combine_log_file }}"
+    state: touch
+    owner: syslog
+    group: adm
+    mode: 0640
+  notify: Restart rsyslog
+
+- name: Setup rsyslog to log to separate file
+  template:
+    src: rsyslog.conf.j2
+    dest: /etc/rsyslog.d/30-combinebackend.conf
+    owner: root
+    group: root
+    mode: 0644
+  notify: Restart rsyslog
+
 - name: install backend service file
   template:
     src: combine_backend.service.j2

--- a/deploy/roles/the_combine_app/tasks/backend_service.yml
+++ b/deploy/roles/the_combine_app/tasks/backend_service.yml
@@ -8,7 +8,7 @@
     group: root
     mode: 0755
 
-- name: Create logging directory for Combine Backend
+- name: Create logging file for Combine Backend
   file:
     path: "{{ combine_log_directory }}/{{ combine_log_file }}"
     state: touch

--- a/deploy/roles/the_combine_app/tasks/install.yml
+++ b/deploy/roles/the_combine_app/tasks/install.yml
@@ -21,6 +21,7 @@
     dest: "{{ combine_backend_dir }}"
     owner: "{{ combine_user }}"
     group: "{{ combine_group }}"
+  notify: Restart combine_backend
 
 - name: install runtime configuration
   template:

--- a/deploy/roles/the_combine_app/templates/combine_backend.service.j2
+++ b/deploy/roles/the_combine_app/templates/combine_backend.service.j2
@@ -14,7 +14,9 @@ ExecStart=/usr/bin/dotnet {{ combine_backend_dir }}/publish/BackendFramework.dll
 Restart=always
 # Restart service after 10 seconds if the dotnet service crashes:
 RestartSec=10
-SyslogIdentifier=CombineBackend
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier={{ combine_program_id }}
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/roles/the_combine_app/templates/config.js.j2
+++ b/deploy/roles/the_combine_app/templates/config.js.j2
@@ -1,5 +1,5 @@
 window['runtimeConfig'] = {
-    baseUrl: '{{ config_base_url }}',
+    baseUrl: "{{ config_base_url }}",
     captchaRequired: {{ config_captcha_required }},
-    captchaSiteKey: {{ config_captcha_sitekey }}
+    captchaSiteKey: "{{ config_captcha_sitekey }}"
 }

--- a/deploy/roles/the_combine_app/templates/rsyslog.conf.j2
+++ b/deploy/roles/the_combine_app/templates/rsyslog.conf.j2
@@ -1,0 +1,2 @@
+if $programname == '{{ combine_program_id }}' then {{ combine_log_directory }}/{{ combine_log_file }}
+& stop

--- a/deploy/vars/config_common.yml
+++ b/deploy/vars/config_common.yml
@@ -47,8 +47,8 @@ combine_group: combine
 #  -e app_loglevel='Debug'
 ###############################################
 backend_loglevel_default: "{{ app_loglevel | default('Information') }}"
-backend_loglevel_system: Information
-backend_loglevel_microsoft: Information
+backend_loglevel_system: "{{ sys_loglevel | default('Information') }}"
+backend_loglevel_microsoft: "{{ ms_loglevel | default('Information') }}"
 
 
 ###############################################

--- a/deploy/vars/config_common.yml
+++ b/deploy/vars/config_common.yml
@@ -6,12 +6,6 @@
 url_domain: "{{ lookup('env', 'TOPLEVELDOMAIN') | default('languagetechnology.org', true) }}"
 url_hostname: "thecombine"
 
-#wifi access point variables
-ap_ssid: "{{ ansible_hostname }}_ap"
-ap_gateway: "10.10.10.1"
-ap_domain: "{{ url_domain }}"
-ap_hostname: "{{ url_hostname }}"
-ap_passphrase: "BigRed@1979"
 
 www_app_dir: "/var/www/{{ url_hostname }}.org/htdocs"
 www_app_owner: www-data
@@ -121,12 +115,12 @@ apache_vhosts:
       - RewriteEngine On
     virtual_hosts:
       - has_ssl: false
-        listen: "{{ ap_gateway }}"
+        listen: "{{ apache_listen_address }}"
         port: 80
         has_redirect_permanent: true
 
       - has_ssl: true
-        listen: "{{ ap_gateway }}"
+        listen: "{{ apache_listen_address }}"
         port: 443
         log_level: debug
         ssl_path: "/etc/letsencrypt/live/{{ apache_server_name }}"

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -89,11 +89,10 @@ These instructions are for installing *TheCombine* on a blank device. See [Updat
 | 1. Install Ubuntu Server 18.04; the machinename should be of the form thecombineN where 'N' is  a number between 1 and 100.                                                                                                                                   | See [Install Ubuntu Server](#install-ubuntu-bionic-server) for more details                                                                                                                                       |
 | 2. cd to <tt>${COMBINE}/deploy</tt> on the host system                                                                                                           |                                                                                                                                                                                                                   |
 | 3. ping the fully-qualified domain name of the new system (thecombineN.languagetechnolgy.org).  If the machine cannot be reached, add it to your <tt>/etc/hosts</tt> file.                                                               |                                                                                            |
-| 4. Run `./setup-nuc.sh --copyid user@machine`                                                                                                                    | <p>where <tt>user</tt> is your login on the NUC and <tt>machine</tt> is the machinename of the NUC that is in <tt>${COMBINE}/deploy/hosts</tt>.</p><p>  The <tt>BECOME password</tt> is your login password for the NUC.</p> <p>See [Setup NUC Options](#setup-nuc-options) for additional options</p> |
+| 4. Run `./setup-nuc.sh --copyid user@machine`                                                                                                                    | <p>where <tt>user</tt> is your login on the NUC and <tt>machine</tt> is the machinename of the NUC that is in <tt>${COMBINE}/deploy/hosts</tt>.</p><p>  The <tt>BECOME password</tt> is your login password for the NUC.</p><p>See [Setup NUC Options](#setup-nuc-options) for additional options</p> |
 | 5. Run `./build.sh`                                                                                                                                              | builds *TheCombine* frontend and backend applications                                                                                                                                                             |
-| 6. run `ansible-playbook playbook_publish.yml --limit <machine> -u <user> -K`                                                                                    | Installs *TheCombine* on the NUC. <tt>machine</tt> and user are the same as for the <tt>setup-nuc.sh</tt> script.                                                                                                 |
-| 7. See [Running *TheCombine*](#running-thecombine) for instructions on connecting to the newly installed application | |
-| 8. Open your browser, clear the cache, and navigate to "thecombine.languagetechnolgy.org".  Verify that you can register a new user, login and create a project. |   |
+| 6. run `ansible-playbook playbook_publish.yml --limit <machine> -u <user> -K --ask-vault-pass`                                                                                    | <p>Installs *TheCombine* on the NUC. <tt>machine</tt> and <tt>user</tt> are the same as for the <tt>setup-nuc.sh</tt> script.</p><p>See [Vault Password](#vault-password) for information on the vault password</p> |
+
 
 ### Running *TheCombine*
 
@@ -121,6 +120,16 @@ Once *TheCombine* has been installed on the NUC, you can update the application 
      1. *Make sure that you select the OpenSSH server when prompted to select the software for your server:*
   ![alt text](images/ubuntu-software-selection.png "Ubuntu Server Software Selection")
 
+## Vault Password
+The Ansible playbooks require that some of the variable files are encrypted.  When running one of the playbooks, you will need to provide the password for the encrypted files.  The password can be provided by:
+  1. entering the password when prompted.  Add the <tt>--ask-vault-pass</tt> option for <tt>ansible-playbook</tt> to be prompted for the password when it is required.  This is the default for <tt>./setup-nuc.sh</tt>
+  2. specify a file that has the password.  Add the <tt>--vault-password-file</tt> option for <tt>ansible-playbook</tt> followed by the path of a file that holds the vault password.
+  3. set the environment variable <tt>ANSIBLE_VAULT_PASSWORD_FILE</tt> to the path of a file that holds the vault password.  This prevents you from needing to provide the vault password whenever you run an ansible playbook, either directly or from within a script such as <tt>setup-nuc.sh</tt>.  *Make sure that you are the only one with read permission for the password file!*
+
+If you use a file to hold the vault password, then:
+  * *Make sure that you are the only one with read permission for the password file!*
+  * *Make sure that the password file is not tracked in the git repository!*  <p>For example, use hidden file in your home directory, such as <tt>$HOME/.ansible-vault</tt>, with mode of <tt>0600</tt>.</p>
+
 ## Setup NUC Options
 
 There are some additional options for using the <tt>setup-nuc.sh</tt> script
@@ -131,8 +140,6 @@ and the <tt>playbook_publish.yml</tt> playbook.
    - <tt>--vault</tt> or <tt>--vault-password-file</tt> allows you to specify the name of a file that holds the Ansible vault password as the next argumnt.
    - <tt>-h</tt> or <tt>--help</tt> prints the usage text and exits
 1. Any options that are not recognized by <tt>setup-nuc.sh</tt> are passed to the ansible playbooks that are called by <tt>setup-nuc.sh</tt>.  This is especially useful for specifying an alternate inventory file for development or testing purposes.  Note that files whose names end in <tt>".hosts"</tt> are ignored by git.
-1. You can set the environment variable <tt>ANSIBLE_VAULT_PASSWORD_FILE</tt> to the path of a file that holds the vault password.  This prevents you from needing to provide the vault password whenever you run an ansible playbook, either directly or from within a script such as <tt>setup-nuc.sh</tt>.  *Make sure that you are the only one with read permission for the password file!*
-
 
 ## Demo Server
 


### PR DESCRIPTION
This pull request includes residual fixes that were missed from the previous pull request, notably:
 * corrected the listen address for Apache on the demo server
 * corrected quoting in the template for the config.js configuration file
 * set the logging levels to "Debug" for Default, Microsoft, and System
 * added information about the Ansible vault password to `docs/deploy/README.md`
 * added restart of the combine backend service if the software is updated

In addition, the backend service has been setup to log messages to `/var/log/combine.log` (as well as `/var/log/syslog`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/286)
<!-- Reviewable:end -->
