### PR TITLE
Clarify Windows development setup instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ deploy/_playbook*.yml
 
 # Emacs backup files (this is Jim's fault)
 *~
+
+# JetBrains Rider
+.idea

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ A rapid word collection tool.
    `git submodule update --init --recursive`<br>
    to pull and initialize them.
 2. Install:
-   - [Node.js 10](https://nodejs.org/en/) (LTS)
+   - [Node.js 12 (LTS)](https://nodejs.org/en/)
      - On Windows, if using [Chocolately][chocolatey]: `choco install nodejs-lts`
-   - [.NET Core SDK 2.1](https://dotnet.microsoft.com/download/dotnet-core/2.1) (LTS)
+   - [.NET Core SDK 2.1 (LTS)](https://dotnet.microsoft.com/download/dotnet-core/2.1)
    - [MongoDB Server](https://www.mongodb.com/download-center/community) and add /bin to PATH Environment Variable
      - On Windows, if using [Chocolately][chocolatey]: `choco install mongodb`
    - [VS Code](https://code.visualstudio.com/download) and Prettier code formatting extension

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ A rapid word collection tool.
    `git submodule update --init --recursive`<br>
    to pull and initialize them.
 2. Install:
-   - [Node.js](https://nodejs.org/en/) (LTS)
-     - On Windows, if using [Chocolately][chocolatey]: `choco install nodejs-lts`
+   - [Node.js 10](https://nodejs.org/en/) (LTS)
+     - On Windows, if using [Chocolately][chocolatey]: `choco install nodejs-lts  --version 10.20.1`
    - [.NET Core SDK 2.1](https://dotnet.microsoft.com/download/dotnet-core/2.1) (LTS)
    - [MongoDB Server](https://www.mongodb.com/download-center/community) and add /bin to PATH Environment Variable
      - On Windows, if using [Chocolately][chocolatey]: `choco install mongodb`

--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ A rapid word collection tool.
    to pull and initialize them.
 2. Install:
    - [Node.js 12 (LTS)](https://nodejs.org/en/)
-     - On Windows, if using [Chocolately][chocolatey]: `choco install nodejs-lts`
+     - On Windows, if using [Chocolately][chocolately]: `choco install nodejs-lts`
    - [.NET Core SDK 2.1 (LTS)](https://dotnet.microsoft.com/download/dotnet-core/2.1)
    - [MongoDB Server](https://www.mongodb.com/download-center/community) and add /bin to PATH Environment Variable
-     - On Windows, if using [Chocolately][chocolatey]: `choco install mongodb`
+     - On Windows, if using [Chocolately][chocolately]: `choco install mongodb`
    - [VS Code](https://code.visualstudio.com/download) and Prettier code formatting extension
 3. Run `dotnet dev-certs https` and `dotnet dev-certs https --trust` to generate and trust an SSL certificate
 4. Set the environment variable `ASPNETCORE_JWT_SECRET_KEY` to a string **containing at least 16 characters**, such as *This is a secret key*. Set it in your `.profile` (Linux) or the *System* app (Windows).
 5. Run `npm start` from the project directory to install dependencies and start the project
 
-[chocolatey]: https://chocolatey.org/
+[chocolately]: https://chocolatey.org/
 
 ## Available Scripts
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ A rapid word collection tool.
    to pull and initialize them.
 2. Install:
    - [Node.js 10](https://nodejs.org/en/) (LTS)
-     - On Windows, if using [Chocolately][chocolatey]: `choco install nodejs-lts  --version 10.20.1`
+     - On Windows, if using [Chocolately][chocolatey]: `choco install nodejs-lts`
    - [.NET Core SDK 2.1](https://dotnet.microsoft.com/download/dotnet-core/2.1) (LTS)
    - [MongoDB Server](https://www.mongodb.com/download-center/community) and add /bin to PATH Environment Variable
      - On Windows, if using [Chocolately][chocolatey]: `choco install mongodb`
    - [VS Code](https://code.visualstudio.com/download) and Prettier code formatting extension
 3. Run `dotnet dev-certs https` and `dotnet dev-certs https --trust` to generate and trust an SSL certificate
-4. Set the environment variable `ASPNETCORE_JWT_SECRET_KEY` to a string of your choice, such as *This is a secret key*.  Set it in your `.profile` (Linux) or the *System* app (Windows).
+4. Set the environment variable `ASPNETCORE_JWT_SECRET_KEY` to a string **containing at least 16 characters**, such as *This is a secret key*. Set it in your `.profile` (Linux) or the *System* app (Windows).
 5. Run `npm start` from the project directory to install dependencies and start the project
 
 [chocolatey]: https://chocolatey.org/

--- a/README.md
+++ b/README.md
@@ -11,12 +11,16 @@ A rapid word collection tool.
    to pull and initialize them.
 2. Install:
    - [Node.js](https://nodejs.org/en/) (LTS)
-   - [.NET Core Runtime](https://dotnet.microsoft.com/download)
+     - On Windows, if using [Chocolately][chocolatey]: `choco install nodejs-lts`
+   - [.NET Core SDK 2.1](https://dotnet.microsoft.com/download/dotnet-core/2.1) (LTS)
    - [MongoDB Server](https://www.mongodb.com/download-center/community) and add /bin to PATH Environment Variable
-   - [VS Code](https://code.visualstudio.com/download) and Pretter code formatting extension
+     - On Windows, if using [Chocolately][chocolatey]: `choco install mongodb`
+   - [VS Code](https://code.visualstudio.com/download) and Prettier code formatting extension
 3. Run `dotnet dev-certs https` and `dotnet dev-certs https --trust` to generate and trust an SSL certificate
 4. Set the environment variable `ASPNETCORE_JWT_SECRET_KEY` to a string of your choice, such as *This is a secret key*.  Set it in your `.profile` (Linux) or the *System* app (Windows).
 5. Run `npm start` from the project directory to install dependencies and start the project
+
+[chocolatey]: https://chocolatey.org/
 
 ## Available Scripts
 
@@ -29,6 +33,9 @@ Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
 The page will reload if you make edits.<br>
 You will also see any lint errors in the console.
+
+> Note: You may need to first browse to https://localhost:5001 and accept the certificate warning in your
+  browser if you get Network Errors the first time you try to run the application locally.
 
 #### `npm run frontend`
 


### PR DESCRIPTION
Clarify setup instructions to help make development setup more reproducible on Windows.

- State that `ASPNETCORE_JWT_SECRET_KEY` must be 16 characters long
- Provide optional install commands for the [Chocolately ](https://chocolatey.org/)package manager for Windows to ease dependency installation.
- Clarify that .NET Core 2.1 LTS should be used (currently)
- Mention you may need to trust the local self-signed cert in the browser
- Ignore [JetBrains Rider](https://www.jetbrains.com/rider/) IDE files. (Rider is [free for open source projects](https://www.jetbrains.com/opensource/)).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/289)
<!-- Reviewable:end -->
