### PR TITLE
Backend Cleanup

### DIFF
--- a/Backend.Tests/AudioControllerTests.cs
+++ b/Backend.Tests/AudioControllerTests.cs
@@ -34,7 +34,7 @@ namespace Backend.Tests
             _audioController = new AudioController(_wordrepo, _wordService, _permissionService);
 
             var util = new Utilities();
-            Directory.Delete(util.GenerateFilePath(Utilities.Filetype.dir, true, "", ""), true);
+            Directory.Delete(util.GenerateFilePath(Utilities.FileType.Dir, true, "", ""), true);
         }
 
         private static string RandomString(int length = 16)

--- a/Backend.Tests/AudioControllerTests.cs
+++ b/Backend.Tests/AudioControllerTests.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
 using System;
 using System.IO;
+using BackendFramework.Models;
 
 namespace Backend.Tests
 {

--- a/Backend.Tests/AudioControllerTests.cs
+++ b/Backend.Tests/AudioControllerTests.cs
@@ -53,18 +53,18 @@ namespace Backend.Tests
         public void TestAudioImport()
         {
             // Get path to sound in Assets folder, from debugging folder.
-            string filePath = Path.Combine(Directory.GetParent(Directory.GetParent(
+            var filePath = Path.Combine(Directory.GetParent(Directory.GetParent(
                 Directory.GetParent(Environment.CurrentDirectory).ToString()).ToString()).ToString(),
                 "Assets", "sound.mp3");
 
             // Open the file to read to controller.
-            FileStream fstream = File.OpenRead(filePath);
+            var fstream = File.OpenRead(filePath);
 
             // Generate parameters for controller call.
             var formFile = new FormFile(fstream, 0, fstream.Length, "name", "sound.mp3");
             var fileUpload = new FileUpload {Name = "FileName", File = formFile};
 
-            Word word = _wordrepo.Create(RandomWord()).Result;
+            var word = _wordrepo.Create(RandomWord()).Result;
 
             // `fileUpload` contains the file stream and the name of the file.
             _ = _audioController.UploadAudioFile(_projId, word.Id, fileUpload).Result;

--- a/Backend.Tests/AudioControllerTests.cs
+++ b/Backend.Tests/AudioControllerTests.cs
@@ -1,9 +1,7 @@
-﻿using BackendFramework.Context;
-using BackendFramework.Controllers;
+﻿using BackendFramework.Controllers;
 using BackendFramework.Helper;
 using BackendFramework.Interfaces;
 using BackendFramework.Services;
-using BackendFramework.ValueModels;
 using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
@@ -33,45 +31,42 @@ namespace Backend.Tests
             _projId = _projectService.Create(new Project()).Result.Id;
             _permissionService = new PermissionServiceMock();
             _wordController = new WordController(_wordrepo, _wordService, _projectService, _permissionService);
-
             _audioController = new AudioController(_wordrepo, _wordService, _permissionService);
 
-            Utilities util = new Utilities();
-
+            var util = new Utilities();
             Directory.Delete(util.GenerateFilePath(Utilities.Filetype.dir, true, "", ""), true);
         }
 
-
-        string RandomString(int length = 16)
+        private static string RandomString(int length = 16)
         {
             return Convert.ToBase64String(Guid.NewGuid().ToByteArray()).Substring(0, length);
         }
 
-        Word RandomWord()
+        private static Word RandomWord()
         {
-            Word word = new Word();
-            word.Vernacular = RandomString(4);
+            var word = new Word {Vernacular = RandomString(4)};
             return word;
         }
 
         [Test]
         public void TestAudioImport()
         {
-            //get path to sound in Assets folder, from debugging folder
-            string filePath = Path.Combine(Directory.GetParent(Directory.GetParent(Directory.GetParent(Environment.CurrentDirectory).ToString()).ToString()).ToString(), "Assets", "sound.mp3");
+            // Get path to sound in Assets folder, from debugging folder.
+            var filePath = Path.Combine(Directory.GetParent(Directory.GetParent(
+                Directory.GetParent(Environment.CurrentDirectory).ToString()).ToString()).ToString(),
+                "Assets", "sound.mp3");
 
-            //open the file to read to controller
+            // Open the file to read to controller.
             FileStream fstream = File.OpenRead(filePath);
 
-            //generate parameters for controller call 
-            FormFile formFile = new FormFile(fstream, 0, fstream.Length, "name", "sound.mp3");
-            FileUpload fileUpload = new FileUpload();
-            fileUpload.Name = "FileName";
-            fileUpload.File = formFile;
+            // Generate parameters for controller call.
+            var formFile = new FormFile(fstream, 0, fstream.Length, "name", "sound.mp3");
+            var fileUpload = new FileUpload {Name = "FileName", File = formFile};
 
             Word word = _wordrepo.Create(RandomWord()).Result;
 
-            _ = _audioController.UploadAudioFile(_projId, word.Id, fileUpload).Result;      //fileUpload contains the file stream and the name of the file
+            // `fileUpload` contains the file stream and the name of the file.
+            _ = _audioController.UploadAudioFile(_projId, word.Id, fileUpload).Result;
 
             var action = _wordController.Get(_projId, word.Id).Result;
 

--- a/Backend.Tests/AudioControllerTests.cs
+++ b/Backend.Tests/AudioControllerTests.cs
@@ -1,13 +1,13 @@
-﻿using BackendFramework.Controllers;
+﻿using System;
+using System.IO;
+using BackendFramework.Controllers;
 using BackendFramework.Helper;
 using BackendFramework.Interfaces;
+using BackendFramework.Models;
 using BackendFramework.Services;
 using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
-using System;
-using System.IO;
-using BackendFramework.Models;
 
 namespace Backend.Tests
 {

--- a/Backend.Tests/AudioControllerTests.cs
+++ b/Backend.Tests/AudioControllerTests.cs
@@ -34,7 +34,8 @@ namespace Backend.Tests
             _audioController = new AudioController(_wordrepo, _wordService, _permissionService);
 
             var util = new Utilities();
-            Directory.Delete(util.GenerateFilePath(Utilities.FileType.Dir, true, "", ""), true);
+            Directory.Delete(util.GenerateFilePath(
+                Utilities.FileType.Dir, true, "", ""), true);
         }
 
         private static string RandomString(int length = 16)
@@ -52,7 +53,7 @@ namespace Backend.Tests
         public void TestAudioImport()
         {
             // Get path to sound in Assets folder, from debugging folder.
-            var filePath = Path.Combine(Directory.GetParent(Directory.GetParent(
+            string filePath = Path.Combine(Directory.GetParent(Directory.GetParent(
                 Directory.GetParent(Environment.CurrentDirectory).ToString()).ToString()).ToString(),
                 "Assets", "sound.mp3");
 

--- a/Backend.Tests/AvatarControllerTests.cs
+++ b/Backend.Tests/AvatarControllerTests.cs
@@ -1,12 +1,12 @@
 ﻿using BackendFramework.Controllers;
 using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
 using System;
 using System.IO;
+using BackendFramework.Models;
 
 namespace Backend.Tests
 {

--- a/Backend.Tests/AvatarControllerTests.cs
+++ b/Backend.Tests/AvatarControllerTests.cs
@@ -1,12 +1,12 @@
-﻿using BackendFramework.Controllers;
+﻿using System;
+using System.IO;
+using BackendFramework.Controllers;
 using BackendFramework.Interfaces;
+using BackendFramework.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
-using System;
-using System.IO;
-using BackendFramework.Models;
 
 namespace Backend.Tests
 {

--- a/Backend.Tests/AvatarControllerTests.cs
+++ b/Backend.Tests/AvatarControllerTests.cs
@@ -16,7 +16,7 @@ namespace Backend.Tests
         private UserController _userController;
         private AvatarController _avatarController;
         private PermissionServiceMock _permissionService;
-        private User _JwtAuthenticatedUser;
+        private User _jwtAuthenticatedUser;
 
         [SetUp]
         public void Setup()
@@ -26,22 +26,18 @@ namespace Backend.Tests
             _userController = new UserController(_userService, _permissionService);
             _avatarController = new AvatarController(_userService, _permissionService);
 
-            //mock the Http Context because this isnt an actual call
-            //avatar controller
-            _avatarController.ControllerContext = new ControllerContext();
-            _avatarController.ControllerContext.HttpContext = new DefaultHttpContext();
-            //user controller
-            _userController.ControllerContext = new ControllerContext();
-            _userController.ControllerContext.HttpContext = new DefaultHttpContext();
-            
-            _JwtAuthenticatedUser = new User();
-            _JwtAuthenticatedUser.Username = "user";
-            _JwtAuthenticatedUser.Password = "pass";
-            _userService.Create(_JwtAuthenticatedUser);
-            _JwtAuthenticatedUser = _userService.Authenticate(_JwtAuthenticatedUser.Username, _JwtAuthenticatedUser.Password).Result;
+            // Mock the Http Context because this isn't an actual call avatar controller
+            _avatarController.ControllerContext = new ControllerContext {HttpContext = new DefaultHttpContext()};
+            // User controller
+            _userController.ControllerContext = new ControllerContext {HttpContext = new DefaultHttpContext()};
+
+            _jwtAuthenticatedUser = new User {Username = "user", Password = "pass"};
+            _userService.Create(_jwtAuthenticatedUser);
+            _jwtAuthenticatedUser = _userService.Authenticate(
+                _jwtAuthenticatedUser.Username, _jwtAuthenticatedUser.Password).Result;
         }
 
-        string RandomString(int length = 0)
+        private static string RandomString(int length = 0)
         {
             if (length == 0)
             {
@@ -50,29 +46,27 @@ namespace Backend.Tests
             return Convert.ToBase64String(Guid.NewGuid().ToByteArray()).Substring(0, length);
         }
 
-        User RandomUser()
+        private User RandomUser()
         {
-            User user = new User();
-            user.Username = RandomString(4);
-            user.Password = RandomString(4);
+            var user = new User {Username = RandomString(4), Password = RandomString(4)};
             return user;
         }
 
         [Test]
         public void TestAvatarImport()
         {
-            string filePath = Path.Combine(Directory.GetParent(Directory.GetParent(Directory.GetParent(Environment.CurrentDirectory).ToString()).ToString()).ToString(), "Assets", "combine.png");
+            string filePath = Path.Combine(Directory.GetParent(
+                Directory.GetParent(Directory.GetParent(
+                    Environment.CurrentDirectory).ToString()).ToString()).ToString(), "Assets", "combine.png");
 
             FileStream fstream = File.OpenRead(filePath);
 
-            FormFile formFile = new FormFile(fstream, 0, fstream.Length, "dave", "combine.png");
-            FileUpload fileUpload = new FileUpload();
-            fileUpload.Name = "FileName";
-            fileUpload.File = formFile;
+            var formFile = new FormFile(fstream, 0, fstream.Length, "dave", "combine.png");
+            var fileUpload = new FileUpload {Name = "FileName", File = formFile};
 
-            _ = _avatarController.UploadAvatar(_JwtAuthenticatedUser.Id, fileUpload).Result;
+            _ = _avatarController.UploadAvatar(_jwtAuthenticatedUser.Id, fileUpload).Result;
 
-            var action = _userController.Get(_JwtAuthenticatedUser.Id).Result;
+            IActionResult action = _userController.Get(_jwtAuthenticatedUser.Id).Result;
 
             var foundUser = (action as ObjectResult).Value as User;
             Assert.IsNotNull(foundUser.Avatar);

--- a/Backend.Tests/AvatarControllerTests.cs
+++ b/Backend.Tests/AvatarControllerTests.cs
@@ -24,10 +24,12 @@ namespace Backend.Tests
             _permissionService = new PermissionServiceMock();
             _userService = new UserServiceMock();
             _userController = new UserController(_userService, _permissionService);
-            _avatarController = new AvatarController(_userService, _permissionService);
+            _avatarController = new AvatarController(_userService, _permissionService)
+            {
+                // Mock the Http Context because this isn't an actual call avatar controller
+                ControllerContext = new ControllerContext {HttpContext = new DefaultHttpContext()}
+            };
 
-            // Mock the Http Context because this isn't an actual call avatar controller
-            _avatarController.ControllerContext = new ControllerContext {HttpContext = new DefaultHttpContext()};
             // User controller
             _userController.ControllerContext = new ControllerContext {HttpContext = new DefaultHttpContext()};
 
@@ -55,18 +57,18 @@ namespace Backend.Tests
         [Test]
         public void TestAvatarImport()
         {
-            string filePath = Path.Combine(Directory.GetParent(
+            var filePath = Path.Combine(Directory.GetParent(
                 Directory.GetParent(Directory.GetParent(
                     Environment.CurrentDirectory).ToString()).ToString()).ToString(), "Assets", "combine.png");
 
-            FileStream fstream = File.OpenRead(filePath);
+            var fstream = File.OpenRead(filePath);
 
             var formFile = new FormFile(fstream, 0, fstream.Length, "dave", "combine.png");
             var fileUpload = new FileUpload {Name = "FileName", File = formFile};
 
             _ = _avatarController.UploadAvatar(_jwtAuthenticatedUser.Id, fileUpload).Result;
 
-            IActionResult action = _userController.Get(_jwtAuthenticatedUser.Id).Result;
+            var action = _userController.Get(_jwtAuthenticatedUser.Id).Result;
 
             var foundUser = (action as ObjectResult).Value as User;
             Assert.IsNotNull(foundUser.Avatar);

--- a/Backend.Tests/LiftControllerTests.cs
+++ b/Backend.Tests/LiftControllerTests.cs
@@ -187,7 +187,7 @@ namespace Backend.Tests
             var result = _liftController.ExportLiftFile(proj.Id).Result;
 
             Utilities util = new Utilities();
-            var combinePath = util.GenerateFilePath(Utilities.Filetype.dir, true, "", "");
+            var combinePath = util.GenerateFilePath(Utilities.FileType.Dir, true, "", "");
             string exportPath = Path.Combine(combinePath, proj.Id, "Export", "LiftExport", Path.Combine("Lift", "NewLiftFile.lift"));
             string text = File.ReadAllText(exportPath, Encoding.UTF8);
             //there is only one deleted word

--- a/Backend.Tests/LiftControllerTests.cs
+++ b/Backend.Tests/LiftControllerTests.cs
@@ -2,7 +2,6 @@
 using BackendFramework.Helper;
 using BackendFramework.Interfaces;
 using BackendFramework.Services;
-using BackendFramework.ValueModels;
 using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
@@ -119,7 +118,7 @@ namespace Backend.Tests
             foreach (Sense sense in word.Senses)
             {
 
-                sense.Accessibility = (int)State.active;
+                sense.Accessibility = (int)State.Active;
                 sense.Glosses = new List<Gloss>() { new Gloss(), new Gloss(), new Gloss() };
 
                 foreach (Gloss gloss in sense.Glosses)
@@ -235,10 +234,10 @@ namespace Backend.Tests
                 var pathToStartZip = Path.Combine(pathToStartZips, actualFilename);
 
                 /*
-                 * Upload the zip file 
+                 * Upload the zip file
                  */
 
-                //init the project the .zip info is added to 
+                //init the project the .zip info is added to
                 var proj = RandomProject();
                 _projServ.Create(proj);
 
@@ -287,7 +286,7 @@ namespace Backend.Tests
                      */
 
                     //upload the exported words again
-                    //init the project the .zip info is added to 
+                    //init the project the .zip info is added to
                     var proj2 = RandomProject();
                     _projServ.Create(proj2);
 

--- a/Backend.Tests/LiftControllerTests.cs
+++ b/Backend.Tests/LiftControllerTests.cs
@@ -41,11 +41,11 @@ namespace Backend.Tests
 
         public string RandomLiftFile(string path)
         {
-            string name = "TEST-TO_BE_STREAMED-" + Util.randString() + ".lift";
+            string name = "TEST-TO_BE_STREAMED-" + Util.RandString() + ".lift";
             name = Path.Combine(path, name);
             FileStream fs = File.OpenWrite(name);
 
-            string header =
+            var header =
                 @"<?xml version=""1.0"" encoding=""UTF-8""?>
                 <lift producer = ""SIL.FLEx 8.3.12.43172"" version = ""0.13"">
                     <header>
@@ -61,25 +61,25 @@ namespace Backend.Tests
                     </header>
                 ";
 
-            byte[] headerArray = Encoding.ASCII.GetBytes(header);
+            var headerArray = Encoding.ASCII.GetBytes(header);
             fs.Write(headerArray);
 
-            for (int i = 0; i < 3; i++)
+            for (var i = 0; i < 3; i++)
             {
-                string dateCreated = $"\"{Util.randString(20)}\"";
-                string dateModified = $"\"{Util.randString(20)}\"";
-                string id = $"\"{Util.randString()}\"";
-                string guid = $"\"{Util.randString()}\"";
-                string vernLang = $"\"{Util.randString(3)}\"";
-                string vern = Util.randString(6);
-                string plural = Util.randString(8);
-                string audio = $"\"{Util.randString(3)}.mp3\"";
-                string senseId = $"\"{Util.randString()}\"";
-                string transLang1 = $"\"{Util.randString(3)}\"";
-                string transLang2 = $"\"{Util.randString(3)}\"";
-                string trans1 = Util.randString(6);
-                string trans2 = Util.randString(8);
-                string sdValue = $"\"{Util.randString(4)} {Util.randString(4)}\"";
+                string dateCreated = $"\"{Util.RandString(20)}\"";
+                string dateModified = $"\"{Util.RandString(20)}\"";
+                string id = $"\"{Util.RandString()}\"";
+                string guid = $"\"{Util.RandString()}\"";
+                string vernLang = $"\"{Util.RandString(3)}\"";
+                string vern = Util.RandString(6);
+                string plural = Util.RandString(8);
+                string audio = $"\"{Util.RandString(3)}.mp3\"";
+                string senseId = $"\"{Util.RandString()}\"";
+                string transLang1 = $"\"{Util.RandString(3)}\"";
+                string transLang2 = $"\"{Util.RandString(3)}\"";
+                string trans1 = Util.RandString(6);
+                string trans2 = Util.RandString(8);
+                string sdValue = $"\"{Util.RandString(4)} {Util.RandString(4)}\"";
 
                 string entry =
                     $@"<entry dateCreated = {dateCreated} dateModified = {dateModified} id = {id} guid = {guid}>
@@ -99,56 +99,57 @@ namespace Backend.Tests
                             </sense> 
                         </entry>
                         ";
-                byte[] entryArray = Encoding.ASCII.GetBytes(entry);
+                var entryArray = Encoding.ASCII.GetBytes(entry);
                 fs.Write(entryArray);
             }
 
-            byte[] close = Encoding.ASCII.GetBytes("</lift>");
+            var close = Encoding.ASCII.GetBytes("</lift>");
             fs.Write(close);
 
             fs.Close();
             return name;
         }
 
-        Word RandomWord(string projId)
+        private static Word RandomWord(string projId)
         {
-            Word word = new Word();
-            word.Senses = new List<Sense>() { new Sense(), new Sense(), new Sense() };
+            var word = new Word {Senses = new List<Sense>() {new Sense(), new Sense(), new Sense()}};
 
             foreach (Sense sense in word.Senses)
             {
-
                 sense.Accessibility = (int)State.Active;
                 sense.Glosses = new List<Gloss>() { new Gloss(), new Gloss(), new Gloss() };
 
                 foreach (Gloss gloss in sense.Glosses)
                 {
-                    gloss.Def = Util.randString();
-                    gloss.Language = Util.randString(3);
+                    gloss.Def = Util.RandString();
+                    gloss.Language = Util.RandString(3);
                 }
 
-                sense.SemanticDomains = new List<SemanticDomain>() { new SemanticDomain(), new SemanticDomain(), new SemanticDomain() };
+                sense.SemanticDomains = new List<SemanticDomain>()
+                {
+                    new SemanticDomain(), new SemanticDomain(), new SemanticDomain()
+                };
 
                 foreach (SemanticDomain semdom in sense.SemanticDomains)
                 {
-                    semdom.Name = Util.randString();
-                    semdom.Id = Util.randString();
-                    semdom.Description = Util.randString();
+                    semdom.Name = Util.RandString();
+                    semdom.Id = Util.RandString();
+                    semdom.Description = Util.RandString();
                 }
             }
 
-            word.Created = Util.randString();
-            word.Vernacular = Util.randString();
-            word.Modified = Util.randString();
-            word.PartOfSpeech = Util.randString();
-            word.Plural = Util.randString();
+            word.Created = Util.RandString();
+            word.Vernacular = Util.RandString();
+            word.Modified = Util.RandString();
+            word.PartOfSpeech = Util.RandString();
+            word.Plural = Util.RandString();
             word.History = new List<string>();
             word.ProjectId = projId;
 
             return word;
         }
 
-        private FileUpload InitFile(FileStream fstream, string filename)
+        private static FileUpload InitFile(FileStream fstream, string filename)
         {
             FormFile formFile = new FormFile(fstream, 0, fstream.Length, "name", filename);
             FileUpload fileUpload = new FileUpload { Name = "FileName", File = formFile };
@@ -156,175 +157,173 @@ namespace Backend.Tests
             return fileUpload;
         }
 
-        class RoundTripObj
+        private class RoundTripObj
         {
-            public string language { get; set; }
-            public List<string> audioFiles { get; set; }
-            public int numOfWords { get; set; }
+            public string Language { get; set; }
+            public List<string> AudioFiles { get; set; }
+            public int NumOfWords { get; set; }
 
             public RoundTripObj(string lang, List<string> audio, int words)
             {
-                language = lang;
-                audioFiles = audio;
-                numOfWords = words;
+                Language = lang;
+                AudioFiles = audio;
+                NumOfWords = words;
             }
         }
 
         [Test]
         public void TestExportDeleted()
         {
-            var proj = RandomProject();
+            Project proj = RandomProject();
             _projServ.Create(proj);
 
-            var word = RandomWord(proj.Id);
-            var createdWord = _wordrepo.Create(word).Result;
+            Word word = RandomWord(proj.Id);
+            Word createdWord = _wordrepo.Create(word).Result;
 
             word.Id = "";
             word.Vernacular = "updated";
 
             _wordService.Update(proj.Id, createdWord.Id, word);
 
-            var result = _liftController.ExportLiftFile(proj.Id).Result;
+            IActionResult result = _liftController.ExportLiftFile(proj.Id).Result;
 
-            Utilities util = new Utilities();
-            var combinePath = util.GenerateFilePath(Utilities.FileType.Dir, true, "", "");
-            string exportPath = Path.Combine(combinePath, proj.Id, "Export", "LiftExport", Path.Combine("Lift", "NewLiftFile.lift"));
+            var util = new Utilities();
+            string combinePath = util.GenerateFilePath(Utilities.FileType.Dir, true, "", "");
+            string exportPath = Path.Combine(combinePath, proj.Id, "Export", "LiftExport",
+                Path.Combine("Lift", "NewLiftFile.lift"));
             string text = File.ReadAllText(exportPath, Encoding.UTF8);
-            //there is only one deleted word
+            // There is only one deleted word
             Assert.AreEqual(text.IndexOf("dateDeleted"), text.LastIndexOf("dateDeleted"));
         }
 
         [Test]
         public void TestRoundtrip()
         {
-            /*
-             * This test assumes you have the starting .zip included in your project files.
-             */
+            // This test assumes you have the starting .zip included in your project files.
 
-            //get path to the starting dir
-            string pathToStartZips = Path.Combine(Directory.GetParent(Directory.GetParent(Directory.GetParent(Environment.CurrentDirectory).ToString()).ToString()).ToString(), "Assets");
+            // Get path to the starting dir
+            string pathToStartZips = Path.Combine(Directory.GetParent(Directory.GetParent(
+                Directory.GetParent(Environment.CurrentDirectory).ToString()).ToString()).ToString(), "Assets");
             var testZips = Directory.GetFiles(pathToStartZips, "*.zip");
 
-            Dictionary<string, RoundTripObj> fileMapping = new Dictionary<string, RoundTripObj>();
+            var fileMapping = new Dictionary<string, RoundTripObj>();
 
-            /*
-             * Add new .zip file information here
-             */
-            RoundTripObj Gusillaay = new RoundTripObj("gsl-Qaaa-x-orth", new List<string>(), 8045 /*number of words*/);
-            fileMapping.Add("Gusillaay.zip", Gusillaay);
-            RoundTripObj Lotad = new RoundTripObj("dtr", new List<string>(), 5400);
-            fileMapping.Add("Lotad.zip", Lotad);
-            RoundTripObj Natqgu = new RoundTripObj("qaa-x-stc-natqgu", new List<string>(), 11570 /*number of words*/);
-            fileMapping.Add("Natqgu.zip", Natqgu);
-            RoundTripObj Resembli = new RoundTripObj("ags", new List<string>(), 255 /*number of words*/);
-            fileMapping.Add("Resembli.zip", Resembli);
-            RoundTripObj RWC = new RoundTripObj("es", new List<string>(), 132 /*number of words*/);
-            fileMapping.Add("RWC.zip", RWC);
-            RoundTripObj Sena = new RoundTripObj("seh", new List<string>(), 1462 /*number of words*/);
-            fileMapping.Add("Sena.zip", Sena);
-            RoundTripObj SingleEntryLiftWithSound = new RoundTripObj("ptn", new List<string> { "short.mp3" }, 1 /*number of words*/);
-            fileMapping.Add("SingleEntryLiftWithSound.zip", SingleEntryLiftWithSound);
-            RoundTripObj SingleEntryLiftWithTwoSound = new RoundTripObj("ptn", new List<string> { "short.mp3", "short1.mp3" }, 1 /*number of words*/);
-            fileMapping.Add("SingleEntryLiftWithTwoSound.zip", SingleEntryLiftWithTwoSound);
+            // Add new .zip file information here
+            var gusillaay = new RoundTripObj("gsl-Qaaa-x-orth", new List<string>(), 8045 /*number of words*/);
+            fileMapping.Add("Gusillaay.zip", gusillaay);
+            var lotad = new RoundTripObj("dtr", new List<string>(), 5400);
+            fileMapping.Add("Lotad.zip", lotad);
+            var natqgu = new RoundTripObj("qaa-x-stc-natqgu", new List<string>(), 11570 /*number of words*/);
+            fileMapping.Add("Natqgu.zip", natqgu);
+            var resembli = new RoundTripObj("ags", new List<string>(), 255 /*number of words*/);
+            fileMapping.Add("Resembli.zip", resembli);
+            var rwc = new RoundTripObj("es", new List<string>(), 132 /*number of words*/);
+            fileMapping.Add("RWC.zip", rwc);
+            var sena = new RoundTripObj("seh", new List<string>(), 1462 /*number of words*/);
+            fileMapping.Add("Sena.zip", sena);
+            var singleEntryLiftWithSound = new RoundTripObj(
+                "ptn", new List<string> { "short.mp3" }, 1 /*number of words*/);
+            fileMapping.Add("SingleEntryLiftWithSound.zip", singleEntryLiftWithSound);
+            var singleEntryLiftWithTwoSound = new RoundTripObj(
+                "ptn",
+                new List<string> { "short.mp3", "short1.mp3" }, 1 /*number of words*/);
+            fileMapping.Add("SingleEntryLiftWithTwoSound.zip", singleEntryLiftWithTwoSound);
 
             foreach (var dataSet in fileMapping)
             {
                 string actualFilename = dataSet.Key;
 
-                var pathToStartZip = Path.Combine(pathToStartZips, actualFilename);
+                string pathToStartZip = Path.Combine(pathToStartZips, actualFilename);
 
-                /*
-                 * Upload the zip file
-                 */
+                // Upload the zip file
 
-                //init the project the .zip info is added to
-                var proj = RandomProject();
+                // Init the project the .zip info is added to
+                Project proj = RandomProject();
                 _projServ.Create(proj);
 
-                //generate api perameter with filestream
+                // Generate api parameter with filestream
                 if (File.Exists(pathToStartZip))
                 {
-
                     FileStream fstream = File.OpenRead(pathToStartZip);
-                    var fileUpload = InitFile(fstream, actualFilename);
+                    FileUpload fileUpload = InitFile(fstream, actualFilename);
 
-                    //make api call
-                    var result = _liftController.UploadLiftFile(proj.Id, fileUpload).Result;
-
+                    // Make api call
+                    IActionResult result = _liftController.UploadLiftFile(proj.Id, fileUpload).Result;
                     Assert.That(!(result is BadRequestObjectResult));
 
                     proj = _projServ.GetProject(proj.Id).Result;
-
-                    Assert.AreEqual(proj.VernacularWritingSystem, dataSet.Value.language);
+                    Assert.AreEqual(proj.VernacularWritingSystem, dataSet.Value.Language);
 
                     fstream.Close();
 
                     var allWords = _wordrepo.GetAllWords(proj.Id);
-                    //export
+                    // Export
                     string exportedFilePath = _liftController.CreateLiftExport(proj.Id);
                     string exportedDirectory = Path.GetDirectoryName(exportedFilePath);
 
-                    //Assert the file was created with desired heirarchy
+                    // Assert the file was created with desired heirarchy
                     Assert.That(Directory.Exists(exportedDirectory));
                     Assert.That(Directory.Exists(Path.Combine(exportedDirectory, "LiftExport", "Lift", "audio")));
-                    foreach (var audioFile in dataSet.Value.audioFiles)
+                    foreach (string audioFile in dataSet.Value.AudioFiles)
                     {
-                        Assert.That(File.Exists(Path.Combine(exportedDirectory, "LiftExport", "Lift", "audio", audioFile)));
+                        Assert.That(File.Exists(Path.Combine(
+                            exportedDirectory, "LiftExport", "Lift", "audio", audioFile)));
                     }
                     Assert.That(Directory.Exists(Path.Combine(exportedDirectory, "LiftExport", "Lift", "WritingSystems")));
-                    Assert.That(File.Exists(Path.Combine(exportedDirectory, "LiftExport", "Lift", "WritingSystems", dataSet.Value.language + ".ldml")));
+                    Assert.That(File.Exists(Path.Combine(
+                        exportedDirectory,
+                        "LiftExport", "Lift", "WritingSystems", dataSet.Value.Language + ".ldml")));
                     Assert.That(File.Exists(Path.Combine(exportedDirectory, "LiftExport", "Lift", "NewLiftFile.lift")));
-                    List<string> dirlst = new List<string>(Directory.GetDirectories(Path.GetDirectoryName(exportedDirectory)));
-                    dirlst.Remove(exportedDirectory);
-                    Assert.That(Directory.Exists(Path.Combine(Path.GetDirectoryName(exportedDirectory), dirlst.Single())));
-
+                    var dirList = new List<string>(
+                        Directory.GetDirectories(Path.GetDirectoryName(exportedDirectory)));
+                    dirList.Remove(exportedDirectory);
+                    Assert.That(Directory.Exists(Path.Combine(Path.GetDirectoryName(exportedDirectory), dirList.Single())));
 
                     _wordrepo.DeleteAllWords(proj.Id);
 
-                    /*
-                     * Roundtrip Part 2
-                     */
+                    // Roundtrip Part 2
 
-                    //upload the exported words again
-                    //init the project the .zip info is added to
-                    var proj2 = RandomProject();
+                    // Upload the exported words again
+                    // Init the project the .zip info is added to
+                    Project proj2 = RandomProject();
                     _projServ.Create(proj2);
 
-                    //generate api perameter with filestream
+                    // Generate api parameter with filestream
                     fstream = File.OpenRead(exportedFilePath);
                     fileUpload = InitFile(fstream, actualFilename);
 
-                    //make api call
+                    // Make api call
                     var result2 = _liftController.UploadLiftFile(proj2.Id, fileUpload).Result;
                     Assert.That(!(result is BadRequestObjectResult));
 
                     proj2 = _projServ.GetProject(proj2.Id).Result;
-
-                    Assert.AreEqual(proj2.VernacularWritingSystem, dataSet.Value.language);
+                    Assert.AreEqual(proj2.VernacularWritingSystem, dataSet.Value.Language);
 
                     fstream.Close();
 
                     allWords = _wordrepo.GetAllWords(proj2.Id);
-                    Assert.AreEqual(allWords.Result.Count, dataSet.Value.numOfWords);
+                    Assert.AreEqual(allWords.Result.Count, dataSet.Value.NumOfWords);
 
-                    //export
+                    // Export
                     exportedFilePath = _liftController.CreateLiftExport(proj2.Id);
                     exportedDirectory = Path.GetDirectoryName(exportedFilePath);
 
-                    //Assert the file was created with desired heirarchy
+                    // Assert the file was created with desired hierarchy
                     Assert.That(Directory.Exists(exportedDirectory));
                     Assert.That(Directory.Exists(Path.Combine(exportedDirectory, "LiftExport", "Lift", "audio")));
-                    foreach (var audioFile in dataSet.Value.audioFiles)
+                    foreach (string audioFile in dataSet.Value.AudioFiles)
                     {
-                        var path = Path.Combine(exportedDirectory, "LiftExport", "Lift", "audio", audioFile);
+                        string path = Path.Combine(exportedDirectory, "LiftExport", "Lift", "audio", audioFile);
                         Assert.That(File.Exists(path), "The file " + audioFile + " can not be found at this path: " + path);
                     }
                     Assert.That(Directory.Exists(Path.Combine(exportedDirectory, "LiftExport", "Lift", "WritingSystems")));
-                    Assert.That(File.Exists(Path.Combine(exportedDirectory, "LiftExport", "Lift", "WritingSystems", dataSet.Value.language + ".ldml")));
+                    Assert.That(File.Exists(Path.Combine(
+                        exportedDirectory,
+                        "LiftExport", "Lift", "WritingSystems", dataSet.Value.Language + ".ldml")));
                     Assert.That(File.Exists(Path.Combine(exportedDirectory, "LiftExport", "Lift", "NewLiftFile.lift")));
-                    dirlst = new List<string>(Directory.GetDirectories(Path.GetDirectoryName(exportedDirectory)));
-                    dirlst.Remove(exportedDirectory);
-                    Assert.That(Directory.Exists(Path.Combine(Path.GetDirectoryName(exportedDirectory), dirlst.Single())));
+                    dirList = new List<string>(Directory.GetDirectories(Path.GetDirectoryName(exportedDirectory)));
+                    dirList.Remove(exportedDirectory);
+                    Assert.That(Directory.Exists(Path.Combine(Path.GetDirectoryName(exportedDirectory), dirList.Single())));
 
                     _wordrepo.DeleteAllWords(proj.Id);
                 }

--- a/Backend.Tests/LiftControllerTests.cs
+++ b/Backend.Tests/LiftControllerTests.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using BackendFramework.Models;
 
 namespace Backend.Tests
 {

--- a/Backend.Tests/LiftControllerTests.cs
+++ b/Backend.Tests/LiftControllerTests.cs
@@ -34,19 +34,20 @@ namespace Backend.Tests
 
         Project RandomProject()
         {
-            Project project = new Project();
-            project.Name = Convert.ToBase64String(Guid.NewGuid().ToByteArray()).Substring(0, 4);
+            var project = new Project
+            {
+                Name = Convert.ToBase64String(Guid.NewGuid().ToByteArray()).Substring(0, 4)
+            };
             return project;
         }
 
         public string RandomLiftFile(string path)
         {
-            string name = "TEST-TO_BE_STREAMED-" + Util.RandString() + ".lift";
+            var name = "TEST-TO_BE_STREAMED-" + Util.RandString() + ".lift";
             name = Path.Combine(path, name);
-            FileStream fs = File.OpenWrite(name);
+            var fs = File.OpenWrite(name);
 
-            var header =
-                @"<?xml version=""1.0"" encoding=""UTF-8""?>
+            const string header = @"<?xml version=""1.0"" encoding=""UTF-8""?>
                 <lift producer = ""SIL.FLEx 8.3.12.43172"" version = ""0.13"">
                     <header>
                         <ranges>
@@ -66,22 +67,22 @@ namespace Backend.Tests
 
             for (var i = 0; i < 3; i++)
             {
-                string dateCreated = $"\"{Util.RandString(20)}\"";
-                string dateModified = $"\"{Util.RandString(20)}\"";
-                string id = $"\"{Util.RandString()}\"";
-                string guid = $"\"{Util.RandString()}\"";
-                string vernLang = $"\"{Util.RandString(3)}\"";
-                string vern = Util.RandString(6);
-                string plural = Util.RandString(8);
-                string audio = $"\"{Util.RandString(3)}.mp3\"";
-                string senseId = $"\"{Util.RandString()}\"";
-                string transLang1 = $"\"{Util.RandString(3)}\"";
-                string transLang2 = $"\"{Util.RandString(3)}\"";
-                string trans1 = Util.RandString(6);
-                string trans2 = Util.RandString(8);
-                string sdValue = $"\"{Util.RandString(4)} {Util.RandString(4)}\"";
+                var dateCreated = $"\"{Util.RandString(20)}\"";
+                var dateModified = $"\"{Util.RandString(20)}\"";
+                var id = $"\"{Util.RandString()}\"";
+                var guid = $"\"{Util.RandString()}\"";
+                var vernLang = $"\"{Util.RandString(3)}\"";
+                var vern = Util.RandString(6);
+                var plural = Util.RandString(8);
+                var audio = $"\"{Util.RandString(3)}.mp3\"";
+                var senseId = $"\"{Util.RandString()}\"";
+                var transLang1 = $"\"{Util.RandString(3)}\"";
+                var transLang2 = $"\"{Util.RandString(3)}\"";
+                var trans1 = Util.RandString(6);
+                var trans2 = Util.RandString(8);
+                var sdValue = $"\"{Util.RandString(4)} {Util.RandString(4)}\"";
 
-                string entry =
+                var entry =
                     $@"<entry dateCreated = {dateCreated} dateModified = {dateModified} id = {id} guid = {guid}>
                             <lexical-unit>
                                 <form lang = {vernLang}><text> {vern} </text></form>
@@ -114,7 +115,7 @@ namespace Backend.Tests
         {
             var word = new Word {Senses = new List<Sense>() {new Sense(), new Sense(), new Sense()}};
 
-            foreach (Sense sense in word.Senses)
+            foreach (var sense in word.Senses)
             {
                 sense.Accessibility = (int)State.Active;
                 sense.Glosses = new List<Gloss>() { new Gloss(), new Gloss(), new Gloss() };
@@ -130,7 +131,7 @@ namespace Backend.Tests
                     new SemanticDomain(), new SemanticDomain(), new SemanticDomain()
                 };
 
-                foreach (SemanticDomain semdom in sense.SemanticDomains)
+                foreach (var semdom in sense.SemanticDomains)
                 {
                     semdom.Name = Util.RandString();
                     semdom.Id = Util.RandString();
@@ -151,8 +152,8 @@ namespace Backend.Tests
 
         private static FileUpload InitFile(FileStream fstream, string filename)
         {
-            FormFile formFile = new FormFile(fstream, 0, fstream.Length, "name", filename);
-            FileUpload fileUpload = new FileUpload { Name = "FileName", File = formFile };
+            var formFile = new FormFile(fstream, 0, fstream.Length, "name", filename);
+            var fileUpload = new FileUpload { Name = "FileName", File = formFile };
 
             return fileUpload;
         }
@@ -174,24 +175,24 @@ namespace Backend.Tests
         [Test]
         public void TestExportDeleted()
         {
-            Project proj = RandomProject();
+            var proj = RandomProject();
             _projServ.Create(proj);
 
-            Word word = RandomWord(proj.Id);
-            Word createdWord = _wordrepo.Create(word).Result;
+            var word = RandomWord(proj.Id);
+            var createdWord = _wordrepo.Create(word).Result;
 
             word.Id = "";
             word.Vernacular = "updated";
 
             _wordService.Update(proj.Id, createdWord.Id, word);
 
-            IActionResult result = _liftController.ExportLiftFile(proj.Id).Result;
+            var result = _liftController.ExportLiftFile(proj.Id).Result;
 
             var util = new Utilities();
-            string combinePath = util.GenerateFilePath(Utilities.FileType.Dir, true, "", "");
-            string exportPath = Path.Combine(combinePath, proj.Id, "Export", "LiftExport",
+            var combinePath = util.GenerateFilePath(Utilities.FileType.Dir, true, "", "");
+            var exportPath = Path.Combine(combinePath, proj.Id, "Export", "LiftExport",
                 Path.Combine("Lift", "NewLiftFile.lift"));
-            string text = File.ReadAllText(exportPath, Encoding.UTF8);
+            var text = File.ReadAllText(exportPath, Encoding.UTF8);
             // There is only one deleted word
             Assert.AreEqual(text.IndexOf("dateDeleted"), text.LastIndexOf("dateDeleted"));
         }
@@ -202,7 +203,7 @@ namespace Backend.Tests
             // This test assumes you have the starting .zip included in your project files.
 
             // Get path to the starting dir
-            string pathToStartZips = Path.Combine(Directory.GetParent(Directory.GetParent(
+            var pathToStartZips = Path.Combine(Directory.GetParent(Directory.GetParent(
                 Directory.GetParent(Environment.CurrentDirectory).ToString()).ToString()).ToString(), "Assets");
             var testZips = Directory.GetFiles(pathToStartZips, "*.zip");
 
@@ -231,24 +232,23 @@ namespace Backend.Tests
 
             foreach (var dataSet in fileMapping)
             {
-                string actualFilename = dataSet.Key;
-
-                string pathToStartZip = Path.Combine(pathToStartZips, actualFilename);
+                var actualFilename = dataSet.Key;
+                var pathToStartZip = Path.Combine(pathToStartZips, actualFilename);
 
                 // Upload the zip file
 
                 // Init the project the .zip info is added to
-                Project proj = RandomProject();
+                var proj = RandomProject();
                 _projServ.Create(proj);
 
                 // Generate api parameter with filestream
                 if (File.Exists(pathToStartZip))
                 {
-                    FileStream fstream = File.OpenRead(pathToStartZip);
-                    FileUpload fileUpload = InitFile(fstream, actualFilename);
+                    var fstream = File.OpenRead(pathToStartZip);
+                    var fileUpload = InitFile(fstream, actualFilename);
 
                     // Make api call
-                    IActionResult result = _liftController.UploadLiftFile(proj.Id, fileUpload).Result;
+                    var result = _liftController.UploadLiftFile(proj.Id, fileUpload).Result;
                     Assert.That(!(result is BadRequestObjectResult));
 
                     proj = _projServ.GetProject(proj.Id).Result;
@@ -258,13 +258,13 @@ namespace Backend.Tests
 
                     var allWords = _wordrepo.GetAllWords(proj.Id);
                     // Export
-                    string exportedFilePath = _liftController.CreateLiftExport(proj.Id);
-                    string exportedDirectory = Path.GetDirectoryName(exportedFilePath);
+                    var exportedFilePath = _liftController.CreateLiftExport(proj.Id);
+                    var exportedDirectory = Path.GetDirectoryName(exportedFilePath);
 
                     // Assert the file was created with desired heirarchy
                     Assert.That(Directory.Exists(exportedDirectory));
                     Assert.That(Directory.Exists(Path.Combine(exportedDirectory, "LiftExport", "Lift", "audio")));
-                    foreach (string audioFile in dataSet.Value.AudioFiles)
+                    foreach (var audioFile in dataSet.Value.AudioFiles)
                     {
                         Assert.That(File.Exists(Path.Combine(
                             exportedDirectory, "LiftExport", "Lift", "audio", audioFile)));
@@ -285,7 +285,7 @@ namespace Backend.Tests
 
                     // Upload the exported words again
                     // Init the project the .zip info is added to
-                    Project proj2 = RandomProject();
+                    var proj2 = RandomProject();
                     _projServ.Create(proj2);
 
                     // Generate api parameter with filestream
@@ -311,10 +311,11 @@ namespace Backend.Tests
                     // Assert the file was created with desired hierarchy
                     Assert.That(Directory.Exists(exportedDirectory));
                     Assert.That(Directory.Exists(Path.Combine(exportedDirectory, "LiftExport", "Lift", "audio")));
-                    foreach (string audioFile in dataSet.Value.AudioFiles)
+                    foreach (var audioFile in dataSet.Value.AudioFiles)
                     {
-                        string path = Path.Combine(exportedDirectory, "LiftExport", "Lift", "audio", audioFile);
-                        Assert.That(File.Exists(path), "The file " + audioFile + " can not be found at this path: " + path);
+                        var path = Path.Combine(exportedDirectory, "LiftExport", "Lift", "audio", audioFile);
+                        Assert.That(File.Exists(path),
+                            "The file " + audioFile + " can not be found at this path: " + path);
                     }
                     Assert.That(Directory.Exists(Path.Combine(exportedDirectory, "LiftExport", "Lift", "WritingSystems")));
                     Assert.That(File.Exists(Path.Combine(

--- a/Backend.Tests/LiftControllerTests.cs
+++ b/Backend.Tests/LiftControllerTests.cs
@@ -1,16 +1,16 @@
-﻿using BackendFramework.Controllers;
-using BackendFramework.Helper;
-using BackendFramework.Interfaces;
-using BackendFramework.Services;
-using Microsoft.AspNetCore.Http.Internal;
-using Microsoft.AspNetCore.Mvc;
-using NUnit.Framework;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using BackendFramework.Controllers;
+using BackendFramework.Helper;
+using BackendFramework.Interfaces;
 using BackendFramework.Models;
+using BackendFramework.Services;
+using Microsoft.AspNetCore.Http.Internal;
+using Microsoft.AspNetCore.Mvc;
+using NUnit.Framework;
 
 namespace Backend.Tests
 {

--- a/Backend.Tests/PermissionServiceMock.cs
+++ b/Backend.Tests/PermissionServiceMock.cs
@@ -15,7 +15,7 @@ namespace Backend.Tests
             return true;
         }
 
-        public bool IsViolationEdit(HttpContext request, string userEditId, string ProjectId)
+        public bool IsViolationEdit(HttpContext request, string userEditId, string projectId)
         {
             return false;
         }

--- a/Backend.Tests/ProjectControllerTests.cs
+++ b/Backend.Tests/ProjectControllerTests.cs
@@ -1,12 +1,11 @@
-﻿using BackendFramework.Controllers;
+﻿using System.Collections.Generic;
+using BackendFramework.Controllers;
 using BackendFramework.Interfaces;
+using BackendFramework.Models;
 using BackendFramework.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
-using System.Collections.Generic;
-using BackendFramework.Models;
-using static BackendFramework.Controllers.ProjectController;
 
 namespace Backend.Tests
 {

--- a/Backend.Tests/ProjectControllerTests.cs
+++ b/Backend.Tests/ProjectControllerTests.cs
@@ -1,7 +1,6 @@
 ﻿using BackendFramework.Controllers;
 using BackendFramework.Interfaces;
 using BackendFramework.Services;
-using BackendFramework.ValueModels;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;

--- a/Backend.Tests/ProjectControllerTests.cs
+++ b/Backend.Tests/ProjectControllerTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
 using System.Collections.Generic;
+using BackendFramework.Models;
 using static BackendFramework.Controllers.ProjectController;
 
 namespace Backend.Tests

--- a/Backend.Tests/ProjectServiceMock.cs
+++ b/Backend.Tests/ProjectServiceMock.cs
@@ -23,7 +23,7 @@ namespace Backend.Tests
 
         public Task<Project> GetProject(string id)
         {
-            var foundProjects = _projects.Where(project => project.Id == id).Single();
+            Project foundProjects = _projects.Where(project => project.Id == id).Single();
             return Task.FromResult(foundProjects.Clone());
         }
 
@@ -40,17 +40,17 @@ namespace Backend.Tests
             return Task.FromResult(true);
         }
 
-        public Task<bool> Delete(string Id)
+        public Task<bool> Delete(string id)
         {
-            var foundProject = _projects.Single(project => project.Id == Id);
+            var foundProject = _projects.Single(project => project.Id == id);
             var success = _projects.Remove(foundProject);
             return Task.FromResult(success);
         }
 
-        public Task<ResultOfUpdate> Update(string Id, Project project)
+        public Task<ResultOfUpdate> Update(string id, Project project)
         {
-            var foundProject = _projects.Single(u => u.Id == Id);
-            var success = _projects.Remove(foundProject);
+            Project foundProject = _projects.Single(u => u.Id == id);
+            bool success = _projects.Remove(foundProject);
             if (success)
             {
                 _projects.Add(project.Clone());

--- a/Backend.Tests/ProjectServiceMock.cs
+++ b/Backend.Tests/ProjectServiceMock.cs
@@ -1,5 +1,4 @@
 ﻿using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Backend.Tests/ProjectServiceMock.cs
+++ b/Backend.Tests/ProjectServiceMock.cs
@@ -1,8 +1,8 @@
-﻿using BackendFramework.Interfaces;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using BackendFramework.Interfaces;
 using BackendFramework.Models;
 
 namespace Backend.Tests

--- a/Backend.Tests/ProjectServiceMock.cs
+++ b/Backend.Tests/ProjectServiceMock.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace Backend.Tests
 {

--- a/Backend.Tests/ProjectServiceMock.cs
+++ b/Backend.Tests/ProjectServiceMock.cs
@@ -23,7 +23,7 @@ namespace Backend.Tests
 
         public Task<Project> GetProject(string id)
         {
-            Project foundProjects = _projects.Where(project => project.Id == id).Single();
+            var foundProjects = _projects.Where(project => project.Id == id).Single();
             return Task.FromResult(foundProjects.Clone());
         }
 
@@ -49,8 +49,8 @@ namespace Backend.Tests
 
         public Task<ResultOfUpdate> Update(string id, Project project)
         {
-            Project foundProject = _projects.Single(u => u.Id == id);
-            bool success = _projects.Remove(foundProject);
+            var foundProject = _projects.Single(u => u.Id == id);
+            var success = _projects.Remove(foundProject);
             if (success)
             {
                 _projects.Add(project.Clone());

--- a/Backend.Tests/UserControllerTests.cs
+++ b/Backend.Tests/UserControllerTests.cs
@@ -25,8 +25,8 @@ namespace Backend.Tests
         User RandomUser()
         {
             User user = new User();
-            user.Username = Util.randString();
-            user.Password = Util.randString();
+            user.Username = Util.RandString();
+            user.Password = Util.RandString();
             return user;
         }
 

--- a/Backend.Tests/UserControllerTests.cs
+++ b/Backend.Tests/UserControllerTests.cs
@@ -21,11 +21,9 @@ namespace Backend.Tests
             _controller = new UserController(_userService, _permissionService);
         }
 
-        User RandomUser()
+        private static User RandomUser()
         {
-            User user = new User();
-            user.Username = Util.RandString();
-            user.Password = Util.RandString();
+            var user = new User {Username = Util.RandString(), Password = Util.RandString()};
             return user;
         }
 
@@ -44,7 +42,7 @@ namespace Backend.Tests
         [Test]
         public void TestGetUser()
         {
-            User user = _userService.Create(RandomUser()).Result;
+            var user = _userService.Create(RandomUser()).Result;
 
             _userService.Create(RandomUser());
             _userService.Create(RandomUser());
@@ -60,8 +58,8 @@ namespace Backend.Tests
         [Test]
         public void TestCreateUser()
         {
-            User user = RandomUser();
-            string id = (_controller.Post(user).Result as ObjectResult).Value as string;
+            var user = RandomUser();
+            var id = (_controller.Post(user).Result as ObjectResult).Value as string;
             user.Id = id;
             Assert.Contains(user, _userService.GetAllUsers().Result);
         }
@@ -69,14 +67,14 @@ namespace Backend.Tests
         [Test]
         public void TestUpdateUser()
         {
-            User origUser = _userService.Create(RandomUser()).Result;
+            var origUser = _userService.Create(RandomUser()).Result;
 
-            User modUser = origUser.Clone();
+            var modUser = origUser.Clone();
             modUser.Username = "Mark";
 
             _ = _controller.Put(modUser.Id, modUser);
 
-            List<User> users = _userService.GetAllUsers().Result;
+            var users = _userService.GetAllUsers().Result;
             Assert.That(users, Has.Count.EqualTo(1));
             Assert.Contains(modUser, users);
         }
@@ -84,7 +82,7 @@ namespace Backend.Tests
         [Test]
         public void TestDeleteUser()
         {
-            User origUser = _userService.Create(RandomUser()).Result;
+            var origUser = _userService.Create(RandomUser()).Result;
 
             Assert.That(_userService.GetAllUsers().Result, Has.Count.EqualTo(1));
 

--- a/Backend.Tests/UserControllerTests.cs
+++ b/Backend.Tests/UserControllerTests.cs
@@ -1,10 +1,10 @@
 ﻿using Backend.Tests;
 using BackendFramework.Controllers;
 using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
 using System.Collections.Generic;
+using BackendFramework.Models;
 
 namespace Backend.Tests
 {

--- a/Backend.Tests/UserControllerTests.cs
+++ b/Backend.Tests/UserControllerTests.cs
@@ -1,10 +1,9 @@
-﻿using Backend.Tests;
+﻿using System.Collections.Generic;
 using BackendFramework.Controllers;
 using BackendFramework.Interfaces;
+using BackendFramework.Models;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
-using System.Collections.Generic;
-using BackendFramework.Models;
 
 namespace Backend.Tests
 {

--- a/Backend.Tests/UserEditControllerTests.cs
+++ b/Backend.Tests/UserEditControllerTests.cs
@@ -41,7 +41,7 @@ namespace Backend.Tests
         private UserEdit RandomUserEdit()
         {
             var rnd = new Random();
-            int count = rnd.Next(0, 7);
+            var count = rnd.Next(0, 7);
 
             var userEdit = new UserEdit();
             var edit = new Edit
@@ -61,7 +61,7 @@ namespace Backend.Tests
             _userEditRepo.Create(RandomUserEdit());
             _userEditRepo.Create(RandomUserEdit());
 
-            IActionResult getResult = _userEditController.Get(_projId).Result;
+            var getResult = _userEditController.Get(_projId).Result;
             Assert.IsInstanceOf<ObjectResult>(getResult);
 
             var edits = (getResult as ObjectResult).Value as List<UserEdit>;
@@ -72,12 +72,12 @@ namespace Backend.Tests
         [Test]
         public void TestGetUserEdit()
         {
-            UserEdit userEdit = _userEditRepo.Create(RandomUserEdit()).Result;
+            var userEdit = _userEditRepo.Create(RandomUserEdit()).Result;
 
             _userEditRepo.Create(RandomUserEdit());
             _userEditRepo.Create(RandomUserEdit());
 
-            IActionResult action = _userEditController.Get(_projId, userEdit.Id).Result;
+            var action = _userEditController.Get(_projId, userEdit.Id).Result;
             Assert.That(action, Is.InstanceOf<ObjectResult>());
 
             var foundUserEdit = (action as ObjectResult).Value as UserEdit;
@@ -96,11 +96,11 @@ namespace Backend.Tests
         [Test]
         public void TestAddEditsToGoal()
         {
-            UserEdit userEdit = RandomUserEdit();
+            var userEdit = RandomUserEdit();
             _userEditRepo.Create(userEdit);
             var newEditStep = new Edit();
             newEditStep.StepData.Add("This is a new step");
-            UserEdit updateEdit = userEdit.Clone();
+            var updateEdit = userEdit.Clone();
             updateEdit.Edits.Add(newEditStep);
 
             _ = _userEditController.Post(_projId, userEdit.Id, newEditStep).Result;
@@ -114,16 +114,16 @@ namespace Backend.Tests
         {
             // Generate db entry to test
             var rnd = new Random();
-            int count = rnd.Next(1, 13);
+            var count = rnd.Next(1, 13);
 
             for (var i = 0; i < count; i++)
             {
                 _ = _userEditRepo.Create(RandomUserEdit()).Result;
             }
-            UserEdit origUserEdit = _userEditRepo.Create(RandomUserEdit()).Result;
+            var origUserEdit = _userEditRepo.Create(RandomUserEdit()).Result;
 
             // Generate correct result for comparison
-            UserEdit modUserEdit = origUserEdit.Clone();
+            var modUserEdit = origUserEdit.Clone();
             const string stringUserEdit = "This is another step added";
             modUserEdit.Edits[0].StepData.Add(stringUserEdit);
 
@@ -141,7 +141,7 @@ namespace Backend.Tests
         [Test]
         public void TestDeleteUserEdit()
         {
-            UserEdit origUserEdit = _userEditRepo.Create(RandomUserEdit()).Result;
+            var origUserEdit = _userEditRepo.Create(RandomUserEdit()).Result;
 
             Assert.That(_userEditRepo.GetAllUserEdits(_projId).Result, Has.Count.EqualTo(1));
 

--- a/Backend.Tests/UserEditControllerTests.cs
+++ b/Backend.Tests/UserEditControllerTests.cs
@@ -1,7 +1,6 @@
 ﻿using BackendFramework.Controllers;
 using BackendFramework.Interfaces;
 using BackendFramework.Services;
-using BackendFramework.ValueModels;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;

--- a/Backend.Tests/UserEditControllerTests.cs
+++ b/Backend.Tests/UserEditControllerTests.cs
@@ -1,12 +1,12 @@
-﻿using BackendFramework.Controllers;
+﻿using System;
+using System.Collections.Generic;
+using BackendFramework.Controllers;
 using BackendFramework.Interfaces;
+using BackendFramework.Models;
 using BackendFramework.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using BackendFramework.Models;
 
 namespace Backend.Tests
 {

--- a/Backend.Tests/UserEditControllerTests.cs
+++ b/Backend.Tests/UserEditControllerTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using BackendFramework.Models;
 
 namespace Backend.Tests
 {

--- a/Backend.Tests/UserEditRepositoryMock.cs
+++ b/Backend.Tests/UserEditRepositoryMock.cs
@@ -49,8 +49,8 @@ namespace Backend.Tests
 
         public Task<bool> Replace(string projectId, string userEditId, UserEdit userEdit)
         {
-            var foundUserEdit = _userEdits.Single(ue => ue.Id == userEditId);
-            var success = _userEdits.Remove(foundUserEdit);
+            UserEdit foundUserEdit = _userEdits.Single(ue => ue.Id == userEditId);
+            bool success = _userEdits.Remove(foundUserEdit);
             _userEdits.Add(userEdit);
             return Task.FromResult(success);
         }

--- a/Backend.Tests/UserEditRepositoryMock.cs
+++ b/Backend.Tests/UserEditRepositoryMock.cs
@@ -49,8 +49,8 @@ namespace Backend.Tests
 
         public Task<bool> Replace(string projectId, string userEditId, UserEdit userEdit)
         {
-            UserEdit foundUserEdit = _userEdits.Single(ue => ue.Id == userEditId);
-            bool success = _userEdits.Remove(foundUserEdit);
+            var foundUserEdit = _userEdits.Single(ue => ue.Id == userEditId);
+            var success = _userEdits.Remove(foundUserEdit);
             _userEdits.Add(userEdit);
             return Task.FromResult(success);
         }

--- a/Backend.Tests/UserEditRepositoryMock.cs
+++ b/Backend.Tests/UserEditRepositoryMock.cs
@@ -1,8 +1,8 @@
-﻿using BackendFramework.Interfaces;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using BackendFramework.Interfaces;
 using BackendFramework.Models;
 
 namespace Backend.Tests

--- a/Backend.Tests/UserEditRepositoryMock.cs
+++ b/Backend.Tests/UserEditRepositoryMock.cs
@@ -1,9 +1,9 @@
 ﻿using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace Backend.Tests
 {

--- a/Backend.Tests/UserRoleControllerTests.cs
+++ b/Backend.Tests/UserRoleControllerTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using BackendFramework.Models;
 
 namespace Backend.Tests
 {

--- a/Backend.Tests/UserRoleControllerTests.cs
+++ b/Backend.Tests/UserRoleControllerTests.cs
@@ -1,7 +1,6 @@
 ﻿using BackendFramework.Controllers;
 using BackendFramework.Interfaces;
 using BackendFramework.Services;
-using BackendFramework.ValueModels;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
 using System;

--- a/Backend.Tests/UserRoleControllerTests.cs
+++ b/Backend.Tests/UserRoleControllerTests.cs
@@ -26,9 +26,9 @@ namespace Backend.Tests
             _userRoleController = new UserRoleController(_userRoleService, _projectService, _permissionService);
         }
 
-        UserRole RandomUserRole()
+        private UserRole RandomUserRole()
         {
-            UserRole userRole = new UserRole
+            var userRole = new UserRole
             {
                 ProjectId = _projId,
                 Permissions = new List<int>()
@@ -58,12 +58,12 @@ namespace Backend.Tests
         [Test]
         public void TestGetUserRole()
         {
-            UserRole userRole = _userRoleService.Create(RandomUserRole()).Result;
+            var userRole = _userRoleService.Create(RandomUserRole()).Result;
 
             _userRoleService.Create(RandomUserRole());
             _userRoleService.Create(RandomUserRole());
 
-            IActionResult action = _userRoleController.Get(_projId, userRole.Id).Result;
+            var action = _userRoleController.Get(_projId, userRole.Id).Result;
 
             Assert.That(action, Is.InstanceOf<ObjectResult>());
 
@@ -74,7 +74,7 @@ namespace Backend.Tests
         [Test]
         public void TestCreateUserRole()
         {
-            UserRole userRole = RandomUserRole();
+            var userRole = RandomUserRole();
             var id = (_userRoleController.Post(_projId, userRole).Result as ObjectResult).Value as string;
             userRole.Id = id;
             Assert.Contains(userRole, _userRoleService.GetAllUserRoles(_projId).Result);
@@ -83,9 +83,9 @@ namespace Backend.Tests
         [Test]
         public void TestUpdateUserRole()
         {
-            UserRole userRole = RandomUserRole();
+            var userRole = RandomUserRole();
             _userRoleService.Create(userRole);
-            UserRole updateRole = userRole.Clone();
+            var updateRole = userRole.Clone();
             updateRole.Permissions.Add((int)Permission.WordEntry);
 
             _ = _userRoleController.Put(_projId ,userRole.Id, updateRole).Result;
@@ -98,7 +98,7 @@ namespace Backend.Tests
         [Test]
         public void TestDeleteUserRole()
         {
-            UserRole origUserRole = _userRoleService.Create(RandomUserRole()).Result;
+            var origUserRole = _userRoleService.Create(RandomUserRole()).Result;
 
             Assert.That(_userRoleService.GetAllUserRoles(_projId).Result, Has.Count.EqualTo(1));
 

--- a/Backend.Tests/UserRoleControllerTests.cs
+++ b/Backend.Tests/UserRoleControllerTests.cs
@@ -33,7 +33,10 @@ namespace Backend.Tests
             UserRole userRole = new UserRole
             {
                 ProjectId = _projId,
-                Permissions = new List<int>() { (int)Permission.EditSettingsNUsers, (int)Permission.ImportExport, (int)Permission.MergeNCharSet }
+                Permissions = new List<int>()
+                {
+                    (int)Permission.EditSettingsNUsers, (int)Permission.ImportExport, (int)Permission.MergeNCharSet
+                }
             };
             return userRole;
         }
@@ -49,9 +52,9 @@ namespace Backend.Tests
 
             Assert.IsInstanceOf<ObjectResult>(getResult);
 
-            var Roles = (getResult as ObjectResult).Value as List<UserRole>;
-            Assert.That(Roles, Has.Count.EqualTo(3));
-            _userRoleService.GetAllUserRoles(_projId).Result.ForEach(Role => Assert.Contains(Role, Roles));
+            var roles = (getResult as ObjectResult).Value as List<UserRole>;
+            Assert.That(roles, Has.Count.EqualTo(3));
+            _userRoleService.GetAllUserRoles(_projId).Result.ForEach(Role => Assert.Contains(Role, roles));
         }
 
         [Test]
@@ -62,7 +65,7 @@ namespace Backend.Tests
             _userRoleService.Create(RandomUserRole());
             _userRoleService.Create(RandomUserRole());
 
-            var action = _userRoleController.Get(_projId, userRole.Id).Result;
+            IActionResult action = _userRoleController.Get(_projId, userRole.Id).Result;
 
             Assert.That(action, Is.InstanceOf<ObjectResult>());
 
@@ -74,7 +77,7 @@ namespace Backend.Tests
         public void TestCreateUserRole()
         {
             UserRole userRole = RandomUserRole();
-            string id = (_userRoleController.Post(_projId, userRole).Result as ObjectResult).Value as string;
+            var id = (_userRoleController.Post(_projId, userRole).Result as ObjectResult).Value as string;
             userRole.Id = id;
             Assert.Contains(userRole, _userRoleService.GetAllUserRoles(_projId).Result);
         }

--- a/Backend.Tests/UserRoleControllerTests.cs
+++ b/Backend.Tests/UserRoleControllerTests.cs
@@ -1,11 +1,9 @@
-﻿using BackendFramework.Controllers;
+﻿using System.Collections.Generic;
+using BackendFramework.Controllers;
 using BackendFramework.Interfaces;
-using BackendFramework.Services;
+using BackendFramework.Models;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using BackendFramework.Models;
 
 namespace Backend.Tests
 {

--- a/Backend.Tests/UserRoleServiceMock.cs
+++ b/Backend.Tests/UserRoleServiceMock.cs
@@ -43,14 +43,14 @@ namespace Backend.Tests
 
         public Task<bool> Delete(string projectId, string userRoleId)
         {
-            var foundUserRole = _userRoles.Single(userRole => userRole.Id == userRoleId);
+            UserRole foundUserRole = _userRoles.Single(userRole => userRole.Id == userRoleId);
             return Task.FromResult(_userRoles.Remove(foundUserRole));
         }
 
         public Task<ResultOfUpdate> Update(string userRoleId, UserRole userRole)
         {
-            var foundUserRole = _userRoles.Single(ur => ur.Id == userRoleId);
-            var success = _userRoles.Remove(foundUserRole);
+            UserRole foundUserRole = _userRoles.Single(ur => ur.Id == userRoleId);
+            bool success = _userRoles.Remove(foundUserRole);
             if (success)
             {
                 _userRoles.Add(userRole.Clone());

--- a/Backend.Tests/UserRoleServiceMock.cs
+++ b/Backend.Tests/UserRoleServiceMock.cs
@@ -1,8 +1,8 @@
-﻿using BackendFramework.Interfaces;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using BackendFramework.Interfaces;
 using BackendFramework.Models;
 
 namespace Backend.Tests

--- a/Backend.Tests/UserRoleServiceMock.cs
+++ b/Backend.Tests/UserRoleServiceMock.cs
@@ -1,9 +1,9 @@
 ﻿using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace Backend.Tests
 {

--- a/Backend.Tests/UserRoleServiceMock.cs
+++ b/Backend.Tests/UserRoleServiceMock.cs
@@ -43,14 +43,14 @@ namespace Backend.Tests
 
         public Task<bool> Delete(string projectId, string userRoleId)
         {
-            UserRole foundUserRole = _userRoles.Single(userRole => userRole.Id == userRoleId);
+            var foundUserRole = _userRoles.Single(userRole => userRole.Id == userRoleId);
             return Task.FromResult(_userRoles.Remove(foundUserRole));
         }
 
         public Task<ResultOfUpdate> Update(string userRoleId, UserRole userRole)
         {
-            UserRole foundUserRole = _userRoles.Single(ur => ur.Id == userRoleId);
-            bool success = _userRoles.Remove(foundUserRole);
+            var foundUserRole = _userRoles.Single(ur => ur.Id == userRoleId);
+            var success = _userRoles.Remove(foundUserRole);
             if (success)
             {
                 _userRoles.Add(userRole.Clone());

--- a/Backend.Tests/UserServiceMock.cs
+++ b/Backend.Tests/UserServiceMock.cs
@@ -76,7 +76,7 @@ namespace Backend.Tests
                     return null;
                 }
 
-                foundUser = MakeJWT(foundUser).Result;
+                foundUser = MakeJwt(foundUser).Result;
                 return Task.FromResult(foundUser);
             }
             catch (InvalidOperationException)
@@ -85,7 +85,7 @@ namespace Backend.Tests
             }
         }
 
-        public Task<User> MakeJWT(User user)
+        public Task<User> MakeJwt(User user)
         {
             /*
              * The JWT Token below is generated here if you need to change its contents

--- a/Backend.Tests/UserServiceMock.cs
+++ b/Backend.Tests/UserServiceMock.cs
@@ -23,13 +23,13 @@ namespace Backend.Tests
 
         public Task<User> GetUser(string id)
         {
-            var foundUser = _users.Single(user => user.Id == id);
+            User foundUser = _users.Single(user => user.Id == id);
             return Task.FromResult(foundUser.Clone());
         }
 
         public Task<string> GetUserAvatar(string id)
         {
-            var foundUser = _users.Single(user => user.Id == id);
+            User foundUser = _users.Single(user => user.Id == id);
             return Task.FromResult(foundUser.Clone().Avatar);
         }
 
@@ -46,17 +46,17 @@ namespace Backend.Tests
             return Task.FromResult(true);
         }
 
-        public Task<bool> Delete(string Id)
+        public Task<bool> Delete(string id)
         {
-            var foundUser = _users.Single(user => user.Id == Id);
-            var success = _users.Remove(foundUser);
+            User foundUser = _users.Single(user => user.Id == id);
+            bool success = _users.Remove(foundUser);
             return Task.FromResult(success);
         }
 
-        public Task<ResultOfUpdate> Update(string Id, User user)
+        public Task<ResultOfUpdate> Update(string id, User user)
         {
-            var foundUser = _users.Single(u => u.Id == Id);
-            var success = _users.Remove(foundUser);
+            User foundUser = _users.Single(u => u.Id == id);
+            bool success = _users.Remove(foundUser);
             if (success)
             {
                 _users.Add(user.Clone());
@@ -69,7 +69,7 @@ namespace Backend.Tests
         {
             try
             {
-                var foundUser = _users.Single(u => u.Username == username && u.Password == password);
+                User foundUser = _users.Single(u => u.Username == username && u.Password == password);
 
                 if (foundUser == null)
                 {
@@ -87,10 +87,8 @@ namespace Backend.Tests
 
         public Task<User> MakeJwt(User user)
         {
-            /*
-             * The JWT Token below is generated here if you need to change its contents
-            * https://jwt.io/#debugger-io?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOiIxMjM0MzQ1NiIsIlBlcm1pc3Npb25zIjp7IlByb2plY3RJZCI6IiIsIlBlcm1pc3Npb24iOlsiMSIsIjIiLCIzIiwiNCIsIjUiXX19.nK2zBCYYlvoIkkfq5XwArEUewiDRz0kpPwP9NaacDLk
-            */
+            // The JWT Token below is generated here if you need to change its contents
+            // https://jwt.io/#debugger-io?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOiIxMjM0MzQ1NiIsIlBlcm1pc3Npb25zIjp7IlByb2plY3RJZCI6IiIsIlBlcm1pc3Npb24iOlsiMSIsIjIiLCIzIiwiNCIsIjUiXX19.nK2zBCYYlvoIkkfq5XwArEUewiDRz0kpPwP9NaacDLk
             user.Token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySWQiOiIxMjM0MzQ1NiIsIlBlcm1pc3Npb25zIjp7IlByb2plY3RJZCI6IiIsIlBlcm1pc3Npb24iOlsiMSIsIjIiLCIzIiwiNCIsIjUiXX19.nK2zBCYYlvoIkkfq5XwArEUewiDRz0kpPwP9NaacDLk";
             Update(user.Id, user);
             user.Password = "";

--- a/Backend.Tests/UserServiceMock.cs
+++ b/Backend.Tests/UserServiceMock.cs
@@ -1,8 +1,8 @@
-﻿using BackendFramework.Interfaces;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using BackendFramework.Interfaces;
 using BackendFramework.Models;
 
 namespace Backend.Tests

--- a/Backend.Tests/UserServiceMock.cs
+++ b/Backend.Tests/UserServiceMock.cs
@@ -1,9 +1,9 @@
 ﻿using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace Backend.Tests
 {

--- a/Backend.Tests/UserServiceMock.cs
+++ b/Backend.Tests/UserServiceMock.cs
@@ -23,7 +23,7 @@ namespace Backend.Tests
 
         public Task<User> GetUser(string id)
         {
-            User foundUser = _users.Single(user => user.Id == id);
+            var foundUser = _users.Single(user => user.Id == id);
             return Task.FromResult(foundUser.Clone());
         }
 
@@ -48,15 +48,15 @@ namespace Backend.Tests
 
         public Task<bool> Delete(string id)
         {
-            User foundUser = _users.Single(user => user.Id == id);
-            bool success = _users.Remove(foundUser);
+            var foundUser = _users.Single(user => user.Id == id);
+            var success = _users.Remove(foundUser);
             return Task.FromResult(success);
         }
 
         public Task<ResultOfUpdate> Update(string id, User user)
         {
-            User foundUser = _users.Single(u => u.Id == id);
-            bool success = _users.Remove(foundUser);
+            var foundUser = _users.Single(u => u.Id == id);
+            var success = _users.Remove(foundUser);
             if (success)
             {
                 _users.Add(user.Clone());
@@ -69,7 +69,7 @@ namespace Backend.Tests
         {
             try
             {
-                User foundUser = _users.Single(u => u.Username == username && u.Password == password);
+                var foundUser = _users.Single(u => u.Username == username && u.Password == password);
 
                 if (foundUser == null)
                 {

--- a/Backend.Tests/Util.cs
+++ b/Backend.Tests/Util.cs
@@ -3,23 +3,22 @@ using System.Text;
 
 namespace Backend.Tests
 {
-    public class Util
+    public static class Util
     {
-        public static string randString(int length)
+        public static string RandString(int length)
         {
-            Random rnd = new Random();
-            StringBuilder sb = new StringBuilder();
-            for (int i = 0; i < length; i++)
+            var rnd = new Random();
+            var sb = new StringBuilder();
+            for (var i = 0; i < length; i++)
             {
                 sb.Append((char)rnd.Next('a', 'z'));
             }
             return sb.ToString();
         }
-        public static string randString()
+        public static string RandString()
         {
-            Random rnd = new Random();
-            return randString(rnd.Next(4, 10));
+            var rnd = new Random();
+            return RandString(rnd.Next(4, 10));
         }
-
     }
 }

--- a/Backend.Tests/WordControllerTests.cs
+++ b/Backend.Tests/WordControllerTests.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using BackendFramework.Models;
 
 namespace Backend.Tests
 {

--- a/Backend.Tests/WordControllerTests.cs
+++ b/Backend.Tests/WordControllerTests.cs
@@ -1,7 +1,6 @@
 using BackendFramework.Controllers;
 using BackendFramework.Interfaces;
 using BackendFramework.Services;
-using BackendFramework.ValueModels;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
 using System;
@@ -40,7 +39,7 @@ namespace Backend.Tests
             foreach (Sense sense in word.Senses)
             {
 
-                sense.Accessibility = (int)State.active;
+                sense.Accessibility = (int)State.Active;
                 sense.Glosses = new List<Gloss>() { new Gloss(), new Gloss(), new Gloss() };
 
                 foreach (Gloss gloss in sense.Glosses)
@@ -188,7 +187,7 @@ namespace Backend.Tests
             {
                 new MergeSourceWord {
                     SrcWordId = thisWord.Id,
-                    SenseStates = new List<State> {State.sense, State.sense, State.sense }
+                    SenseStates = new List<State> {State.Sense, State.Sense, State.Sense }
                 }
             };
 
@@ -226,7 +225,7 @@ namespace Backend.Tests
                 //generate mergeSourceWord with new child Id and desired child state list 
                 MergeSourceWord newGenChild = new MergeSourceWord();
                 newGenChild.SrcWordId = _repo.Add(child).Result.Id;
-                newGenChild.SenseStates = new List<State> { State.duplicate, State.sense, State.separate };
+                newGenChild.SenseStates = new List<State> { State.Duplicate, State.Sense, State.Separate };
                 parentChildMergeObject.ChildrenWords.Add(newGenChild);
             }
 

--- a/Backend.Tests/WordControllerTests.cs
+++ b/Backend.Tests/WordControllerTests.cs
@@ -32,24 +32,26 @@ namespace Backend.Tests
 
         Word RandomWord()
         {
-            Word word = new Word();
-            word.Senses = new List<Sense>() { new Sense(), new Sense(), new Sense() };
+            var word = new Word {Senses = new List<Sense>() {new Sense(), new Sense(), new Sense()}};
 
-            foreach (Sense sense in word.Senses)
+            foreach (var sense in word.Senses)
             {
 
                 sense.Accessibility = (int)State.Active;
                 sense.Glosses = new List<Gloss>() { new Gloss(), new Gloss(), new Gloss() };
 
-                foreach (Gloss gloss in sense.Glosses)
+                foreach (var gloss in sense.Glosses)
                 {
                     gloss.Def = Util.RandString();
                     gloss.Language = Util.RandString(3);
                 }
 
-                sense.SemanticDomains = new List<SemanticDomain>() { new SemanticDomain(), new SemanticDomain(), new SemanticDomain() };
+                sense.SemanticDomains = new List<SemanticDomain>()
+                {
+                    new SemanticDomain(), new SemanticDomain(), new SemanticDomain()
+                };
 
-                foreach (SemanticDomain semdom in sense.SemanticDomains)
+                foreach (var semdom in sense.SemanticDomains)
                 {
                     semdom.Name = Util.RandString();
                     semdom.Id = Util.RandString();
@@ -83,7 +85,7 @@ namespace Backend.Tests
         [Test]
         public void TestGetWord()
         {
-            Word word = _repo.Create(RandomWord()).Result;
+            var word = _repo.Create(RandomWord()).Result;
 
             _repo.Create(RandomWord());
             _repo.Create(RandomWord());
@@ -99,16 +101,16 @@ namespace Backend.Tests
         [Test]
         public void AddWord()
         {
-            Word word = RandomWord();
+            var word = RandomWord();
 
-            string id = (_wordController.Post(_projId, word).Result as ObjectResult).Value as string;
+            var id = (_wordController.Post(_projId, word).Result as ObjectResult).Value as string;
             word.Id = id;
 
             Assert.AreEqual(word, _repo.GetAllWords(_projId).Result[0]);
             Assert.AreEqual(word, _repo.GetFrontier(_projId).Result[0]);
 
-            Word oldDuplicate = RandomWord();
-            Word newDuplicate = oldDuplicate.Clone();
+            var oldDuplicate = RandomWord();
+            var newDuplicate = oldDuplicate.Clone();
 
             _ = _wordController.Post(_projId, oldDuplicate).Result;
             var result = (_wordController.Post(_projId, newDuplicate).Result as ObjectResult).Value as string;
@@ -126,14 +128,14 @@ namespace Backend.Tests
         [Test]
         public void UpdateWord()
         {
-            Word origWord = _repo.Create(RandomWord()).Result;
+            var origWord = _repo.Create(RandomWord()).Result;
 
-            Word modWord = origWord.Clone();
+            var modWord = origWord.Clone();
             modWord.Vernacular = "Yoink";
 
-            string id = (_wordController.Put(_projId, modWord.Id, modWord).Result as ObjectResult).Value as string;
+            var id = (_wordController.Put(_projId, modWord.Id, modWord).Result as ObjectResult).Value as string;
 
-            Word finalWord = modWord.Clone();
+            var finalWord = modWord.Clone();
             finalWord.Id = id;
             finalWord.History = new List<string> { origWord.Id };
 
@@ -147,28 +149,27 @@ namespace Backend.Tests
         [Test]
         public void DeleteWord()
         {
-            //fill test database
-            Word origWord = _repo.Create(RandomWord()).Result;
+            // Fill test database
+            var origWord = _repo.Create(RandomWord()).Result;
 
-            //test delete function
+            // Test delete function
             var action = _wordController.Delete(_projId, origWord.Id).Result;
 
-            //original word persists
+            // Original word persists
             Assert.Contains(origWord, _repo.GetAllWords(_projId).Result);
 
-            //get the new deleted word from the database
+            // Get the new deleted word from the database
             var wordRepo = _repo.GetFrontier(_projId).Result;
 
-
-            //ensure the word is valid
+            // Ensure the word is valid
             Assert.IsTrue(wordRepo.Count == 1);
             Assert.IsTrue(wordRepo[0].Id != origWord.Id);
             Assert.IsTrue(wordRepo[0].History.Count == 1);
 
-            //test the fronteir
+            // Test the frontier
             Assert.That(_repo.GetFrontier(_projId).Result, Has.Count.EqualTo(1));
 
-            //ensure the deleted word is in the fronteir
+            // Ensure the deleted word is in the frontier
             Assert.IsTrue(wordRepo.Count == 1);
             Assert.IsTrue(wordRepo[0].Id != origWord.Id);
             Assert.IsTrue(wordRepo[0].History.Count == 1);
@@ -177,16 +178,19 @@ namespace Backend.Tests
         [Test]
         public void MergeWordsIdentity()
         {
-            Word thisWord = RandomWord();
+            var thisWord = RandomWord();
             thisWord = _repo.Create(thisWord).Result;
 
-            MergeWords mergeObject = new MergeWords();
-            mergeObject.Parent = thisWord;
-            mergeObject.ChildrenWords = new List<MergeSourceWord>
+            var mergeObject = new MergeWords
             {
-                new MergeSourceWord {
-                    SrcWordId = thisWord.Id,
-                    SenseStates = new List<State> {State.Sense, State.Sense, State.Sense }
+                Parent = thisWord,
+                ChildrenWords = new List<MergeSourceWord>
+                {
+                    new MergeSourceWord
+                    {
+                        SrcWordId = thisWord.Id,
+                        SenseStates = new List<State> {State.Sense, State.Sense, State.Sense}
+                    }
                 }
             };
 
@@ -201,7 +205,7 @@ namespace Backend.Tests
             Assert.That(frontier, Has.Count.EqualTo(1));
             Assert.AreEqual(frontier.First(), newWords.First());
 
-            // check that new word has the right history
+            // Check that new word has the right history
             Assert.That(newWords.First().History, Has.Count.EqualTo(1));
             var intermediateWord = _repo.GetWord(_projId, newWords.First().History.First()).Result;
             Assert.That(intermediateWord.History, Has.Count.EqualTo(1));
@@ -211,32 +215,35 @@ namespace Backend.Tests
         [Test]
         public void MergeWords()
         {
-            //the parent word is inherently correct as it is calculated by the frontend as the desired result of the merge
-            MergeWords parentChildMergeObject = new MergeWords();
-            parentChildMergeObject.Parent = RandomWord();
-            parentChildMergeObject.Time = Util.RandString();
-            parentChildMergeObject.ChildrenWords = new List<MergeSourceWord>();
-
-            //set the child info
-            List<Word> childWords = new List<Word> { RandomWord(), RandomWord(), RandomWord() };
-            foreach (Word child in childWords)
+            // The parent word is inherently correct as it is calculated by the frontend as the desired result of the
+            // merge
+            var parentChildMergeObject = new MergeWords
             {
-                //generate mergeSourceWord with new child Id and desired child state list 
-                MergeSourceWord newGenChild = new MergeSourceWord();
-                newGenChild.SrcWordId = _repo.Add(child).Result.Id;
-                newGenChild.SenseStates = new List<State> { State.Duplicate, State.Sense, State.Separate };
+                Parent = RandomWord(), Time = Util.RandString(), ChildrenWords = new List<MergeSourceWord>()
+            };
+
+            // Set the child info
+            var childWords = new List<Word> { RandomWord(), RandomWord(), RandomWord() };
+            foreach (var child in childWords)
+            {
+                // Generate mergeSourceWord with new child Id and desired child state list
+                var newGenChild = new MergeSourceWord
+                {
+                    SrcWordId = _repo.Add(child).Result.Id,
+                    SenseStates = new List<State> {State.Duplicate, State.Sense, State.Separate}
+                };
                 parentChildMergeObject.ChildrenWords.Add(newGenChild);
             }
 
             var newWordList = _wordService.Merge(_projId, parentChildMergeObject).Result;
 
-            //check for parent is in the db
+            // Check for parent is in the db
             var dbParent = newWordList.FirstOrDefault();
             Assert.IsNotNull(dbParent);
             Assert.AreEqual(dbParent.Senses.Count, 3);
             Assert.AreEqual(dbParent.History.Count, 3);
 
-            //check the separarte words were made
+            // Check the separarte words were made
             Assert.AreEqual(newWordList.Count, 4);
 
             foreach (var word in newWordList)

--- a/Backend.Tests/WordControllerTests.cs
+++ b/Backend.Tests/WordControllerTests.cs
@@ -1,12 +1,11 @@
+using System.Collections.Generic;
+using System.Linq;
 using BackendFramework.Controllers;
 using BackendFramework.Interfaces;
+using BackendFramework.Models;
 using BackendFramework.Services;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using BackendFramework.Models;
 
 namespace Backend.Tests
 {

--- a/Backend.Tests/WordControllerTests.cs
+++ b/Backend.Tests/WordControllerTests.cs
@@ -44,25 +44,25 @@ namespace Backend.Tests
 
                 foreach (Gloss gloss in sense.Glosses)
                 {
-                    gloss.Def = Util.randString();
-                    gloss.Language = Util.randString(3);
+                    gloss.Def = Util.RandString();
+                    gloss.Language = Util.RandString(3);
                 }
 
                 sense.SemanticDomains = new List<SemanticDomain>() { new SemanticDomain(), new SemanticDomain(), new SemanticDomain() };
 
                 foreach (SemanticDomain semdom in sense.SemanticDomains)
                 {
-                    semdom.Name = Util.randString();
-                    semdom.Id = Util.randString();
-                    semdom.Description = Util.randString();
+                    semdom.Name = Util.RandString();
+                    semdom.Id = Util.RandString();
+                    semdom.Description = Util.RandString();
                 }
             }
 
-            word.Created = Util.randString();
-            word.Vernacular = Util.randString();
-            word.Modified = Util.randString();
-            word.PartOfSpeech = Util.randString();
-            word.Plural = Util.randString();
+            word.Created = Util.RandString();
+            word.Vernacular = Util.RandString();
+            word.Modified = Util.RandString();
+            word.PartOfSpeech = Util.RandString();
+            word.Plural = Util.RandString();
             word.History = new List<string>();
             word.ProjectId = _projId;
 
@@ -215,7 +215,7 @@ namespace Backend.Tests
             //the parent word is inherently correct as it is calculated by the frontend as the desired result of the merge
             MergeWords parentChildMergeObject = new MergeWords();
             parentChildMergeObject.Parent = RandomWord();
-            parentChildMergeObject.Time = Util.randString();
+            parentChildMergeObject.Time = Util.RandString();
             parentChildMergeObject.ChildrenWords = new List<MergeSourceWord>();
 
             //set the child info

--- a/Backend.Tests/WordRepositoryMock.cs
+++ b/Backend.Tests/WordRepositoryMock.cs
@@ -25,7 +25,7 @@ namespace Backend.Tests
 
         public Task<Word> GetWord(string projectId, string wordId)
         {
-            var foundWord = _words.Where(word => word.Id == wordId).Single();
+            Word foundWord = _words.Where(word => word.Id == wordId).Single();
             return Task.FromResult(foundWord.Clone());
         }
 
@@ -57,7 +57,7 @@ namespace Backend.Tests
 
         public Task<bool> DeleteFrontier(string projectId, string wordId)
         {
-            var origLength = _frontier.Count;
+            int origLength = _frontier.Count;
             _frontier.RemoveAll(word => word.Id == wordId);
             return Task.FromResult(origLength != _frontier.Count);
 

--- a/Backend.Tests/WordRepositoryMock.cs
+++ b/Backend.Tests/WordRepositoryMock.cs
@@ -25,7 +25,7 @@ namespace Backend.Tests
 
         public Task<Word> GetWord(string projectId, string wordId)
         {
-            Word foundWord = _words.Where(word => word.Id == wordId).Single();
+            var foundWord = _words.Where(word => word.Id == wordId).Single();
             return Task.FromResult(foundWord.Clone());
         }
 
@@ -57,7 +57,7 @@ namespace Backend.Tests
 
         public Task<bool> DeleteFrontier(string projectId, string wordId)
         {
-            int origLength = _frontier.Count;
+            var origLength = _frontier.Count;
             _frontier.RemoveAll(word => word.Id == wordId);
             return Task.FromResult(origLength != _frontier.Count);
 

--- a/Backend.Tests/WordRepositoryMock.cs
+++ b/Backend.Tests/WordRepositoryMock.cs
@@ -1,8 +1,8 @@
-﻿using BackendFramework.Interfaces;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using BackendFramework.Interfaces;
 using BackendFramework.Models;
 
 namespace Backend.Tests

--- a/Backend.Tests/WordRepositoryMock.cs
+++ b/Backend.Tests/WordRepositoryMock.cs
@@ -1,9 +1,9 @@
 ﻿using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace Backend.Tests
 {

--- a/Backend/Contexts/ProjectContext.cs
+++ b/Backend/Contexts/ProjectContext.cs
@@ -6,7 +6,6 @@ using static BackendFramework.Startup;
 
 namespace BackendFramework.Contexts
 {
-
     public class ProjectContext : IProjectContext
     {
         private readonly IMongoDatabase _db;
@@ -19,5 +18,4 @@ namespace BackendFramework.Contexts
 
         public IMongoCollection<Project> Projects => _db.GetCollection<Project>("ProjectsCollection");
     }
-
 }

--- a/Backend/Contexts/ProjectContext.cs
+++ b/Backend/Contexts/ProjectContext.cs
@@ -1,4 +1,5 @@
 ﻿using BackendFramework.Interfaces;
+using BackendFramework.Models;
 using BackendFramework.ValueModels;
 using Microsoft.Extensions.Options;
 using MongoDB.Driver;

--- a/Backend/Contexts/ProjectContext.cs
+++ b/Backend/Contexts/ProjectContext.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using static BackendFramework.Startup;
 
-namespace BackendFramework.Context
+namespace BackendFramework.Contexts
 {
 
     public class ProjectContext : IProjectContext

--- a/Backend/Contexts/ProjectContext.cs
+++ b/Backend/Contexts/ProjectContext.cs
@@ -1,6 +1,5 @@
 ﻿using BackendFramework.Interfaces;
 using BackendFramework.Models;
-using BackendFramework.ValueModels;
 using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using static BackendFramework.Startup;

--- a/Backend/Contexts/UserContext.cs
+++ b/Backend/Contexts/UserContext.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using static BackendFramework.Startup;
 
-namespace BackendFramework.Context
+namespace BackendFramework.Contexts
 {
 
     public class UserContext : IUserContext

--- a/Backend/Contexts/UserContext.cs
+++ b/Backend/Contexts/UserContext.cs
@@ -6,7 +6,6 @@ using static BackendFramework.Startup;
 
 namespace BackendFramework.Contexts
 {
-
     public class UserContext : IUserContext
     {
         private readonly IMongoDatabase _db;
@@ -19,5 +18,4 @@ namespace BackendFramework.Contexts
 
         public IMongoCollection<User> Users => _db.GetCollection<User>("UsersCollection");
     }
-
 }

--- a/Backend/Contexts/UserContext.cs
+++ b/Backend/Contexts/UserContext.cs
@@ -1,5 +1,5 @@
 ﻿using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
+using BackendFramework.Models;
 using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using static BackendFramework.Startup;

--- a/Backend/Contexts/UserEditContext.cs
+++ b/Backend/Contexts/UserEditContext.cs
@@ -6,7 +6,6 @@ using static BackendFramework.Startup;
 
 namespace BackendFramework.Contexts
 {
-
     public class UserEditContext : IUserEditContext
     {
         private readonly IMongoDatabase _db;
@@ -19,5 +18,4 @@ namespace BackendFramework.Contexts
 
         public IMongoCollection<UserEdit> UserEdits => _db.GetCollection<UserEdit>("UserEditsCollection");
     }
-
 }

--- a/Backend/Contexts/UserEditContext.cs
+++ b/Backend/Contexts/UserEditContext.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using static BackendFramework.Startup;
 
-namespace BackendFramework.Context
+namespace BackendFramework.Contexts
 {
 
     public class UserEditContext : IUserEditContext

--- a/Backend/Contexts/UserEditContext.cs
+++ b/Backend/Contexts/UserEditContext.cs
@@ -1,5 +1,5 @@
 ﻿using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
+using BackendFramework.Models;
 using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using static BackendFramework.Startup;

--- a/Backend/Contexts/UserRoleContext.cs
+++ b/Backend/Contexts/UserRoleContext.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using static BackendFramework.Startup;
 
-namespace BackendFramework.Context
+namespace BackendFramework.Contexts
 {
 
     public class UserRoleContext : IUserRoleContext

--- a/Backend/Contexts/UserRoleContext.cs
+++ b/Backend/Contexts/UserRoleContext.cs
@@ -1,5 +1,5 @@
 ﻿using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
+using BackendFramework.Models;
 using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using static BackendFramework.Startup;

--- a/Backend/Contexts/UserRoleContext.cs
+++ b/Backend/Contexts/UserRoleContext.cs
@@ -6,7 +6,6 @@ using static BackendFramework.Startup;
 
 namespace BackendFramework.Contexts
 {
-
     public class UserRoleContext : IUserRoleContext
     {
         private readonly IMongoDatabase _db;
@@ -19,5 +18,4 @@ namespace BackendFramework.Contexts
 
         public IMongoCollection<UserRole> UserRoles => _db.GetCollection<UserRole>("UserRolesCollection");
     }
-
 }

--- a/Backend/Contexts/WordContext.cs
+++ b/Backend/Contexts/WordContext.cs
@@ -6,7 +6,6 @@ using static BackendFramework.Startup;
 
 namespace BackendFramework.Contexts
 {
-
     public class WordContext : IWordContext
     {
         private readonly IMongoDatabase _db;
@@ -20,5 +19,4 @@ namespace BackendFramework.Contexts
         public IMongoCollection<Word> Words => _db.GetCollection<Word>("WordsCollection");
         public IMongoCollection<Word> Frontier => _db.GetCollection<Word>("FrontierCollection");
     }
-
 }

--- a/Backend/Contexts/WordContext.cs
+++ b/Backend/Contexts/WordContext.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using static BackendFramework.Startup;
 
-namespace BackendFramework.Context
+namespace BackendFramework.Contexts
 {
 
     public class WordContext : IWordContext

--- a/Backend/Contexts/WordContext.cs
+++ b/Backend/Contexts/WordContext.cs
@@ -1,5 +1,5 @@
 ﻿using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
+using BackendFramework.Models;
 using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using static BackendFramework.Startup;

--- a/Backend/Controllers/AudioController.cs
+++ b/Backend/Controllers/AudioController.cs
@@ -37,7 +37,8 @@ namespace BackendFramework.Controllers
         [HttpGet("{wordId}/download/audio/{fileName}")]
         public async Task<IActionResult> DownloadAudioFile(string projectId, string wordId, string fileName)
         {
-            // if we require authorization and authentication for audio files, the frontend cannot just use the api endpoint as the src
+            // if we require authorization and authentication for audio files, the frontend cannot just use the api
+            // endpoint as the src
             //if (!_permissionService.IsProjectAuthorized("1", HttpContext))
             //{
             //    return new ForbidResult();
@@ -60,11 +61,15 @@ namespace BackendFramework.Controllers
             return File(stream, "video/webm");
         }
 
-        /// <summary> Adds a pronunciation <see cref="FileUpload"/> to a <see cref="Word"/> and saves locally to ~/.CombineFiles/{ProjectId}/ExtractedLocation/Import/Audio </summary>
+        /// <summary>
+        /// Adds a pronunciation <see cref="FileUpload"/> to a <see cref="Word"/> and saves locally to
+        /// ~/.CombineFiles/{ProjectId}/ExtractedLocation/Import/Audio
+        /// </summary>
         /// <remarks> POST: v1/projects/{projectId}/words/{wordId}/upload/audio </remarks>
         /// <returns> Path to local audio file </returns>
         [HttpPost("{wordId}/upload/audio")]
-        public async Task<IActionResult> UploadAudioFile(string projectId, string wordId, [FromForm] FileUpload fileUpload)
+        public async Task<IActionResult> UploadAudioFile(string projectId, string wordId,
+            [FromForm] FileUpload fileUpload)
         {
             if (!_permissionService.IsProjectAuthorized("1", HttpContext))
             {

--- a/Backend/Controllers/AudioController.cs
+++ b/Backend/Controllers/AudioController.cs
@@ -85,7 +85,7 @@ namespace BackendFramework.Controllers
 
             //get path to home
             Utilities util = new Utilities();
-            fileUpload.FilePath = util.GenerateFilePath(Filetype.audio, false, wordId, Path.Combine(projectId, Path.Combine("Import", "ExtractedLocation", "Lift"), "Audio"));
+            fileUpload.FilePath = util.GenerateFilePath(FileType.Audio, false, wordId, Path.Combine(projectId, Path.Combine("Import", "ExtractedLocation", "Lift"), "Audio"));
 
             //copy the file data to a new local file
             using (var fs = new FileStream(fileUpload.FilePath, FileMode.Create))

--- a/Backend/Controllers/AudioController.cs
+++ b/Backend/Controllers/AudioController.cs
@@ -1,13 +1,12 @@
-﻿using System;
+﻿using System.IO;
+using System.Threading.Tasks;
 using BackendFramework.Helper;
 using BackendFramework.Interfaces;
+using BackendFramework.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
-using Microsoft.AspNetCore.Mvc;
-using System.IO;
-using System.Threading.Tasks;
-using BackendFramework.Models;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using static BackendFramework.Helper.Utilities;
 
 namespace BackendFramework.Controllers

--- a/Backend/Controllers/AudioController.cs
+++ b/Backend/Controllers/AudioController.cs
@@ -44,15 +44,13 @@ namespace BackendFramework.Controllers
             //    return new ForbidResult();
             //}
 
-            string filePath = _wordService.GetAudioFilePath(projectId, wordId, fileName);
-
+            var filePath = _wordService.GetAudioFilePath(projectId, wordId, fileName);
             if (filePath == null)
             {
                 return new BadRequestObjectResult("There was more than one subDir of the extracted zip");
             }
 
             Stream stream = System.IO.File.OpenRead(filePath);
-
             if (stream == null)
             {
                 return new BadRequestObjectResult("The file does not exist");
@@ -75,8 +73,8 @@ namespace BackendFramework.Controllers
             {
                 return new ForbidResult();
             }
-            IFormFile file = fileUpload.File;
-            string requestedFileName = fileUpload.File?.FileName;
+            var file = fileUpload.File;
+            var requestedFileName = fileUpload.File?.FileName;
             if (string.IsNullOrEmpty(requestedFileName))
             {
                 requestedFileName = wordId + ".webm";
@@ -101,7 +99,7 @@ namespace BackendFramework.Controllers
             }
 
             // Add the relative path to the audio field
-            Word gotWord = await _wordRepo.GetWord(projectId, wordId);
+            var gotWord = await _wordRepo.GetWord(projectId, wordId);
             gotWord.Audio.Add(Path.GetFileName(fileUpload.FilePath));
 
             // Update the word with new audio file

--- a/Backend/Controllers/AudioController.cs
+++ b/Backend/Controllers/AudioController.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using BackendFramework.Helper;
 using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using System.IO;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 using static BackendFramework.Helper.Utilities;
 
 namespace BackendFramework.Controllers

--- a/Backend/Controllers/AvatarController.cs
+++ b/Backend/Controllers/AvatarController.cs
@@ -1,11 +1,11 @@
 ﻿using BackendFramework.Helper;
 using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using System.IO;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace BackendFramework.Controllers
 {

--- a/Backend/Controllers/AvatarController.cs
+++ b/Backend/Controllers/AvatarController.cs
@@ -31,14 +31,13 @@ namespace BackendFramework.Controllers
         [HttpGet("{userId}/download/avatar")]
         public async Task<IActionResult> DownloadAvatar(string userId)
         {
-            string avatar = await _userService.GetUserAvatar(userId);
-
+            var avatar = await _userService.GetUserAvatar(userId);
             if (avatar == null)
             {
                 return new NotFoundObjectResult(userId);
             }
 
-            FileStream image = System.IO.File.OpenRead(avatar);
+            var image = System.IO.File.OpenRead(avatar);
             return File(image, "image/jpeg");
         }
 
@@ -55,7 +54,7 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            IFormFile file = fileUpload.File;
+            var file = fileUpload.File;
 
             // Ensure file is not empty
             if (file.Length == 0)
@@ -64,7 +63,7 @@ namespace BackendFramework.Controllers
             }
 
             // Get user to apply avatar to
-            User gotUser = await _userService.GetUser(userId);
+            var gotUser = await _userService.GetUser(userId);
             if (gotUser == null)
             {
                 return new NotFoundObjectResult(gotUser.Id);

--- a/Backend/Controllers/AvatarController.cs
+++ b/Backend/Controllers/AvatarController.cs
@@ -71,7 +71,7 @@ namespace BackendFramework.Controllers
 
             //get path to home
             Utilities util = new Utilities();
-            fileUpload.FilePath = util.GenerateFilePath(Utilities.Filetype.avatar, false, userId, "Avatars");
+            fileUpload.FilePath = util.GenerateFilePath(Utilities.FileType.Avatar, false, userId, "Avatars");
 
             //copy file data to a new local file
             using (var fs = new FileStream(fileUpload.FilePath, FileMode.OpenOrCreate))

--- a/Backend/Controllers/AvatarController.cs
+++ b/Backend/Controllers/AvatarController.cs
@@ -1,12 +1,12 @@
-﻿using BackendFramework.Helper;
+﻿using System.IO;
+using System.Threading.Tasks;
+using BackendFramework.Helper;
 using BackendFramework.Interfaces;
+using BackendFramework.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
-using Microsoft.AspNetCore.Mvc;
-using System.IO;
-using System.Threading.Tasks;
-using BackendFramework.Models;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 
 namespace BackendFramework.Controllers
 {

--- a/Backend/Controllers/FrontierController.cs
+++ b/Backend/Controllers/FrontierController.cs
@@ -1,9 +1,9 @@
 using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace BackendFramework.Controllers
 {

--- a/Backend/Controllers/FrontierController.cs
+++ b/Backend/Controllers/FrontierController.cs
@@ -34,7 +34,7 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            //ensure project exists
+            // Ensure project exists
             var project = _projectService.GetProject(projectId);
             if (project == null)
             {
@@ -56,7 +56,7 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            //ensure project exists
+            // Ensure project exists
             var project = _projectService.GetProject(projectId);
             if (project == null)
             {
@@ -82,7 +82,7 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            //ensure project exists
+            // Ensure project exists
             var project = _projectService.GetProject(projectId);
             if (project == null)
             {

--- a/Backend/Controllers/FrontierController.cs
+++ b/Backend/Controllers/FrontierController.cs
@@ -1,9 +1,9 @@
+using System.Threading.Tasks;
 using BackendFramework.Interfaces;
+using BackendFramework.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
-using System.Threading.Tasks;
-using BackendFramework.Models;
 
 namespace BackendFramework.Controllers
 {

--- a/Backend/Controllers/LiftController.cs
+++ b/Backend/Controllers/LiftController.cs
@@ -48,7 +48,6 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-
             // Ensure project exists
             var project = _projectService.GetProject(projectId);
             if (project == null)

--- a/Backend/Controllers/LiftController.cs
+++ b/Backend/Controllers/LiftController.cs
@@ -1,17 +1,18 @@
-﻿using BackendFramework.Helper;
-using BackendFramework.Interfaces;
-using BackendFramework.Services;
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Cors;
-using Microsoft.AspNetCore.Mvc;
-using SIL.Lift.Parsing;
-using System;
+﻿using System;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using BackendFramework.Helper;
+using BackendFramework.Interfaces;
 using BackendFramework.Models;
+using BackendFramework.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using SIL.Lift.Parsing;
 using static BackendFramework.Helper.Utilities;
 
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Backend.Tests")]

--- a/Backend/Controllers/LiftController.cs
+++ b/Backend/Controllers/LiftController.cs
@@ -55,7 +55,7 @@ namespace BackendFramework.Controllers
                 return new NotFoundObjectResult(projectId);
             }
 
-            IFormFile file = fileUpload.File;
+            var file = fileUpload.File;
 
             // Ensure file is not empty
             if (file.Length == 0)
@@ -78,7 +78,7 @@ namespace BackendFramework.Controllers
             }
 
             // Make destination for extracted files
-            string zipDest = Path.GetDirectoryName(fileUpload.FilePath);
+            var zipDest = Path.GetDirectoryName(fileUpload.FilePath);
             Directory.CreateDirectory(zipDest);
             if (Directory.Exists(Path.Combine(zipDest, "ExtractedLocation")))
             {
@@ -86,7 +86,7 @@ namespace BackendFramework.Controllers
             }
 
             // Extract the zip to new directory
-            string extractDir = Path.Combine(zipDest, "ExtractedLocation");
+            var extractDir = Path.Combine(zipDest, "ExtractedLocation");
             Directory.CreateDirectory(extractDir);
             ZipFile.ExtractToDirectory(fileUpload.FilePath, extractDir);
 
@@ -103,7 +103,7 @@ namespace BackendFramework.Controllers
             else if (directoriesExtracted.Length == 2)
             {
                 var numDirs = 0;
-                foreach (string dir in directoriesExtracted)
+                foreach (var dir in directoriesExtracted)
                 {
                     if (dir.EndsWith("__MACOSX"))
                     {
@@ -145,10 +145,10 @@ namespace BackendFramework.Controllers
                 var parser = new LiftParser<LiftObject, LiftEntry, LiftSense, LiftExample>(_liftService);
 
                 // Import words from lift file
-                int resp = parser.ReadLiftFile(extractedLiftPath.FirstOrDefault());
+                var resp = parser.ReadLiftFile(extractedLiftPath.FirstOrDefault());
 
                 // Add character set to project from ldml file
-                Project proj = _projectService.GetProject(projectId).Result;
+                var proj = _projectService.GetProject(projectId).Result;
                 _liftService.LdmlImport(
                     Path.Combine(extractedDirPath, "WritingSystems"), proj.VernacularWritingSystem);
 
@@ -185,10 +185,10 @@ namespace BackendFramework.Controllers
                 return new BadRequestResult();
             }
             // Export the data to a zip directory
-            string exportedFilepath = CreateLiftExport(projectId);
+            var exportedFilepath = CreateLiftExport(projectId);
 
             var file = System.IO.File.ReadAllBytes(exportedFilepath);
-            string encodedFile = Convert.ToBase64String(file);
+            var encodedFile = Convert.ToBase64String(file);
             return new OkObjectResult(encodedFile);
         }
 
@@ -196,7 +196,7 @@ namespace BackendFramework.Controllers
         internal string CreateLiftExport(string projectId)
         {
             _liftService.SetProject(projectId);
-            string exportedFilepath = _liftService.LiftExport(projectId);
+            var exportedFilepath = _liftService.LiftExport(projectId);
             return exportedFilepath;
         }
     }

--- a/Backend/Controllers/LiftController.cs
+++ b/Backend/Controllers/LiftController.cs
@@ -1,7 +1,6 @@
 ﻿using BackendFramework.Helper;
 using BackendFramework.Interfaces;
 using BackendFramework.Services;
-using BackendFramework.ValueModels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
@@ -11,6 +10,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 using static BackendFramework.Helper.Utilities;
 
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Backend.Tests")]

--- a/Backend/Controllers/LiftController.cs
+++ b/Backend/Controllers/LiftController.cs
@@ -64,7 +64,7 @@ namespace BackendFramework.Controllers
 
             //get path to where we will copy the zip file
             Utilities util = new Utilities();
-            fileUpload.FilePath = util.GenerateFilePath(Filetype.zip, false, "Compressed-Upload-" + string.Format("{0:yyyy-MM-dd_hh-mm-ss-fff}", DateTime.Now), Path.Combine(projectId, "Import"));
+            fileUpload.FilePath = util.GenerateFilePath(FileType.Zip, false, "Compressed-Upload-" + string.Format("{0:yyyy-MM-dd_hh-mm-ss-fff}", DateTime.Now), Path.Combine(projectId, "Import"));
 
             //copy file data to a new local file
             using (var fs = new FileStream(fileUpload.FilePath, FileMode.OpenOrCreate))

--- a/Backend/Controllers/LiftController.cs
+++ b/Backend/Controllers/LiftController.cs
@@ -11,6 +11,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
 using BackendFramework.Models;
+using Microsoft.AspNetCore.Http;
 using static BackendFramework.Helper.Utilities;
 
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Backend.Tests")]
@@ -47,32 +48,36 @@ namespace BackendFramework.Controllers
             }
 
 
-            //ensure project exists
+            // Ensure project exists
             var project = _projectService.GetProject(projectId);
             if (project == null)
             {
                 return new NotFoundObjectResult(projectId);
             }
 
-            var file = fileUpload.File;
+            IFormFile file = fileUpload.File;
 
-            //ensure file is not empty
+            // Ensure file is not empty
             if (file.Length == 0)
             {
                 return new BadRequestObjectResult("Empty File");
             }
 
-            //get path to where we will copy the zip file
-            Utilities util = new Utilities();
-            fileUpload.FilePath = util.GenerateFilePath(FileType.Zip, false, "Compressed-Upload-" + string.Format("{0:yyyy-MM-dd_hh-mm-ss-fff}", DateTime.Now), Path.Combine(projectId, "Import"));
+            // Get path to where we will copy the zip file
+            var util = new Utilities();
+            fileUpload.FilePath = util.GenerateFilePath(
+                FileType.Zip,
+                false,
+                "Compressed-Upload-" + string.Format("{0:yyyy-MM-dd_hh-mm-ss-fff}", DateTime.Now),
+                Path.Combine(projectId, "Import"));
 
-            //copy file data to a new local file
+            // Copy file data to a new local file
             using (var fs = new FileStream(fileUpload.FilePath, FileMode.OpenOrCreate))
             {
                 await file.CopyToAsync(fs);
             }
 
-            //make destination for extracted files
+            // Make destination for extracted files
             string zipDest = Path.GetDirectoryName(fileUpload.FilePath);
             Directory.CreateDirectory(zipDest);
             if (Directory.Exists(Path.Combine(zipDest, "ExtractedLocation")))
@@ -80,48 +85,48 @@ namespace BackendFramework.Controllers
                 return new BadRequestObjectResult("A file has already been uploaded");
             }
 
-            //extract the zip to new directory
-            var extractDir = Path.Combine(zipDest, "ExtractedLocation");
+            // Extract the zip to new directory
+            string extractDir = Path.Combine(zipDest, "ExtractedLocation");
             Directory.CreateDirectory(extractDir);
             ZipFile.ExtractToDirectory(fileUpload.FilePath, extractDir);
 
-            //check number of directories extracted
+            // Check number of directories extracted
             var directoriesExtracted = Directory.GetDirectories(extractDir);
-            string extractedDirPath = "";
+            var extractedDirPath = "";
 
-            //if there was one directory, we're good
+            // If there was one directory, we're good
             if (directoriesExtracted.Length == 1)
             {
                 extractedDirPath = directoriesExtracted.FirstOrDefault();
             }
-            //if there were two, and there was a __MACOSX directory, ignore it
+            // If there were two, and there was a __MACOSX directory, ignore it
             else if (directoriesExtracted.Length == 2)
             {
-                int numDirs = 0;
-                foreach (var dir in directoriesExtracted)
+                var numDirs = 0;
+                foreach (string dir in directoriesExtracted)
                 {
                     if (dir.EndsWith("__MACOSX"))
                     {
                         Directory.Delete(dir, true);
                     }
-                    else //this directory probably matters
+                    else // This directory probably matters
                     {
                         extractedDirPath = dir;
                         numDirs++;
                     }
                 }
-                //both directories seemed important
+                // Both directories seemed important
                 if (numDirs == 2)
                 {
                     return new BadRequestObjectResult("Your zip file should have one directory");
                 }
             }
-            else //there were 0 or more than 2 directories
+            else // There were 0 or more than 2 directories
             {
                 return new BadRequestObjectResult("Your zip file structure has the wrong number of directories");
             }
 
-            //search for the lift file within the extracted files
+            // Search for the lift file within the extracted files
             var extractedLiftNameArr = Directory.GetFiles(extractedDirPath);
             var extractedLiftPath = Array.FindAll(extractedLiftNameArr, x => x.EndsWith(".lift"));
             if (extractedLiftPath.Length > 1)
@@ -135,20 +140,21 @@ namespace BackendFramework.Controllers
 
             try
             {
-                //sets the projectId of our parser to add words to that project
+                // Sets the projectId of our parser to add words to that project
                 _liftService.SetProject(projectId);
                 var parser = new LiftParser<LiftObject, LiftEntry, LiftSense, LiftExample>(_liftService);
 
-                //import words from lift file
-                var resp = parser.ReadLiftFile(extractedLiftPath.FirstOrDefault());
+                // Import words from lift file
+                int resp = parser.ReadLiftFile(extractedLiftPath.FirstOrDefault());
 
-                //add character set to project from ldml file
-                var proj = _projectService.GetProject(projectId).Result;
-                _liftService.LdmlImport(Path.Combine(extractedDirPath, "WritingSystems"), proj.VernacularWritingSystem);
+                // Add character set to project from ldml file
+                Project proj = _projectService.GetProject(projectId).Result;
+                _liftService.LdmlImport(
+                    Path.Combine(extractedDirPath, "WritingSystems"), proj.VernacularWritingSystem);
 
                 return new ObjectResult(resp);
             }
-            //if anything wrong happened, it's probably something wrong with the file itself
+            // If anything wrong happened, it's probably something wrong with the file itself
             catch (Exception)
             {
                 return new UnsupportedMediaTypeResult();
@@ -165,24 +171,24 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            //ensure project exists
+            // Ensure project exists
             var proj = _projectService.GetProject(projectId);
             if (proj == null)
             {
                 return new NotFoundObjectResult(projectId);
             }
 
-            //ensure there are words in the project
+            // Ensure there are words in the project
             var words = await _wordRepo.GetAllWords(projectId);
             if (words.Count == 0)
             {
                 return new BadRequestResult();
             }
-            //export the data to a zip directory
+            // Export the data to a zip directory
             string exportedFilepath = CreateLiftExport(projectId);
 
             var file = System.IO.File.ReadAllBytes(exportedFilepath);
-            var encodedFile = Convert.ToBase64String(file);
+            string encodedFile = Convert.ToBase64String(file);
             return new OkObjectResult(encodedFile);
         }
 

--- a/Backend/Controllers/ProjectController.cs
+++ b/Backend/Controllers/ProjectController.cs
@@ -1,10 +1,10 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using BackendFramework.Interfaces;
+using BackendFramework.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using BackendFramework.Models;
 
 namespace BackendFramework.Controllers
 {

--- a/Backend/Controllers/ProjectController.cs
+++ b/Backend/Controllers/ProjectController.cs
@@ -1,5 +1,4 @@
 using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
@@ -141,7 +140,7 @@ namespace BackendFramework.Controllers
             currentUser = await _userService.MakeJWT(currentUser);
             await _userService.Update(currentUserId, currentUser);
 
-            var output = new ProjectWithUser(project) { __UpdatedUser = currentUser };
+            var output = new ProjectWithUser(project) { UpdatedUser = currentUser };
 
             return new OkObjectResult(output);
         }

--- a/Backend/Controllers/ProjectController.cs
+++ b/Backend/Controllers/ProjectController.cs
@@ -250,7 +250,7 @@ namespace BackendFramework.Controllers
             }
             else
             {
-                UserRole usersRole = new UserRole();
+                var usersRole = new UserRole();
                 userRoleId = usersRole.Id;
                 usersRole.ProjectId = projectId;
 
@@ -288,6 +288,5 @@ namespace BackendFramework.Controllers
 
             return new OkObjectResult(_projectService.CanImportLift(projectId));
         }
-
     }
 }

--- a/Backend/Controllers/ProjectController.cs
+++ b/Backend/Controllers/ProjectController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace BackendFramework.Controllers
 {

--- a/Backend/Controllers/ProjectController.cs
+++ b/Backend/Controllers/ProjectController.cs
@@ -86,7 +86,7 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            Project project = await _projectService.GetProject(projectId);
+            var project = await _projectService.GetProject(projectId);
             if (project == null)
             {
                 return new NotFoundResult();
@@ -109,8 +109,8 @@ namespace BackendFramework.Controllers
             await _projectService.Create(project);
 
             // Get user
-            string currentUserId = _permissionService.GetUserId(HttpContext);
-            User currentUser = await _userService.GetUser(currentUserId);
+            var currentUserId = _permissionService.GetUserId(HttpContext);
+            var currentUser = await _userService.GetUser(currentUserId);
 
             // Give admin privileges
             var usersRole = new UserRole
@@ -157,7 +157,7 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            ResultOfUpdate result = await _projectService.Update(projectId, project);
+            var result = await _projectService.Update(projectId, project);
             if (result == ResultOfUpdate.NotFound)
             {
                 return new NotFoundObjectResult(projectId);
@@ -182,7 +182,7 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            Project currentProj = await _projectService.GetProject(projectId);
+            var currentProj = await _projectService.GetProject(projectId);
             currentProj.ValidCharacters = project.ValidCharacters;
             currentProj.RejectedCharacters = project.RejectedCharacters;
             await _projectService.Update(projectId, currentProj);
@@ -260,10 +260,10 @@ namespace BackendFramework.Controllers
                 changeUser.ProjectRoles.Add(projectId, usersRole.Id);
                 await _userService.Update(changeUser.Id, changeUser);
             }
-            UserRole userRole = await _userRoleService.GetUserRole(projectId, userRoleId);
+            var userRole = await _userRoleService.GetUserRole(projectId, userRoleId);
             userRole.Permissions = new List<int>(permissions);
 
-            ResultOfUpdate result = await _userRoleService.Update(userRoleId, userRole);
+            var result = await _userRoleService.Update(userRoleId, userRole);
 
             if (result == ResultOfUpdate.NotFound)
             {

--- a/Backend/Controllers/ProjectController.cs
+++ b/Backend/Controllers/ProjectController.cs
@@ -137,7 +137,7 @@ namespace BackendFramework.Controllers
             currentUser.ProjectRoles.Add(project.Id, usersRole.Id);
             await _userService.Update(currentUserId, currentUser);
             //Generate the JWT based on those new userRoles
-            currentUser = await _userService.MakeJWT(currentUser);
+            currentUser = await _userService.MakeJwt(currentUser);
             await _userService.Update(currentUserId, currentUser);
 
             var output = new ProjectWithUser(project) { UpdatedUser = currentUser };

--- a/Backend/Controllers/ProjectController.cs
+++ b/Backend/Controllers/ProjectController.cs
@@ -20,7 +20,8 @@ namespace BackendFramework.Controllers
         private readonly IUserService _userService;
         private readonly IPermissionService _permissionService;
 
-        public ProjectController(IProjectService projectService, ISemDomParser semDomParser, IUserRoleService userRoleService, IUserService userService, IPermissionService permissionService)
+        public ProjectController(IProjectService projectService, ISemDomParser semDomParser,
+            IUserRoleService userRoleService, IUserService userService, IPermissionService permissionService)
         {
             _projectService = projectService;
             _semDomParser = semDomParser;
@@ -85,7 +86,7 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            var project = await _projectService.GetProject(projectId);
+            Project project = await _projectService.GetProject(projectId);
             if (project == null)
             {
                 return new NotFoundResult();
@@ -107,12 +108,12 @@ namespace BackendFramework.Controllers
         {
             await _projectService.Create(project);
 
-            //get user 
-            var currentUserId = _permissionService.GetUserId(HttpContext);
-            var currentUser = await _userService.GetUser(currentUserId);
+            // Get user
+            string currentUserId = _permissionService.GetUserId(HttpContext);
+            User currentUser = await _userService.GetUser(currentUserId);
 
-            //give admin privileges
-            UserRole usersRole = new UserRole
+            // Give admin privileges
+            var usersRole = new UserRole
             {
                 Permissions = new List<int>
                 {
@@ -127,16 +128,16 @@ namespace BackendFramework.Controllers
 
             usersRole = await _userRoleService.Create(usersRole);
 
-            //update user with userRole
+            // Update user with userRole
             if (currentUser.ProjectRoles.Equals(null))
             {
                 currentUser.ProjectRoles = new Dictionary<string, string>();
             }
 
-            //Generate the userRoles and update the user
+            // Generate the userRoles and update the user
             currentUser.ProjectRoles.Add(project.Id, usersRole.Id);
             await _userService.Update(currentUserId, currentUser);
-            //Generate the JWT based on those new userRoles
+            // Generate the JWT based on those new userRoles
             currentUser = await _userService.MakeJwt(currentUser);
             await _userService.Update(currentUserId, currentUser);
 
@@ -156,7 +157,7 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            var result = await _projectService.Update(projectId, project);
+            ResultOfUpdate result = await _projectService.Update(projectId, project);
             if (result == ResultOfUpdate.NotFound)
             {
                 return new NotFoundObjectResult(projectId);
@@ -181,7 +182,7 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            var currentProj = await _projectService.GetProject(projectId);
+            Project currentProj = await _projectService.GetProject(projectId);
             currentProj.ValidCharacters = project.ValidCharacters;
             currentProj.RejectedCharacters = project.RejectedCharacters;
             await _projectService.Update(projectId, currentProj);
@@ -206,7 +207,9 @@ namespace BackendFramework.Controllers
             return new NotFoundResult();
         }
 
-        /// <summary> UNUSED: Returns tree of <see cref="SemanticDomainWithSubdomains"/> for specified <see cref="Project"/> </summary>
+        /// <summary>
+        /// UNUSED: Returns tree of <see cref="SemanticDomainWithSubdomains"/> for specified <see cref="Project"/>
+        /// </summary>
         /// <remarks> GET: v1/projects/{projectId}/semanticdomains </remarks>
         [AllowAnonymous]
         [HttpGet("{projectId}/semanticdomains")]
@@ -223,7 +226,7 @@ namespace BackendFramework.Controllers
             }
         }
 
-        //change user role using project Id
+        // Change user role using project Id
         [HttpPut("{projectId}/users/{userId}")]
         public async Task<IActionResult> UpdateUserRole(string projectId, string userId, [FromBody]int[] permissions)
         {
@@ -238,7 +241,7 @@ namespace BackendFramework.Controllers
                 return new NotFoundObjectResult(projectId);
             }
 
-            //fetch the user -> fetch user role -> update user role
+            // Fetch the user -> fetch user role -> update user role
             var changeUser = await _userService.GetUser(userId);
             string userRoleId;
             if (changeUser.ProjectRoles.ContainsKey(projectId))
@@ -246,21 +249,21 @@ namespace BackendFramework.Controllers
                 userRoleId = changeUser.ProjectRoles[projectId];
             }
             else
-            { 
+            {
                 UserRole usersRole = new UserRole();
                 userRoleId = usersRole.Id;
                 usersRole.ProjectId = projectId;
 
                 usersRole = await _userRoleService.Create(usersRole);
 
-                //Generate the userRoles and update the user
+                // Generate the userRoles and update the user
                 changeUser.ProjectRoles.Add(projectId, usersRole.Id);
                 await _userService.Update(changeUser.Id, changeUser);
             }
-            var userRole = await _userRoleService.GetUserRole(projectId, userRoleId);
+            UserRole userRole = await _userRoleService.GetUserRole(projectId, userRoleId);
             userRole.Permissions = new List<int>(permissions);
 
-            var result = await _userRoleService.Update(userRoleId, userRole);
+            ResultOfUpdate result = await _userRoleService.Update(userRoleId, userRole);
 
             if (result == ResultOfUpdate.NotFound)
             {

--- a/Backend/Controllers/UserController.cs
+++ b/Backend/Controllers/UserController.cs
@@ -86,7 +86,7 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            var user = await _userService.GetUser(userId);
+            User user = await _userService.GetUser(userId);
             if (user == null)
             {
                 return new NotFoundResult();
@@ -166,7 +166,7 @@ namespace BackendFramework.Controllers
             //     return new ForbidResult();
             // }
 
-            var result = await _userService.Update(userId, user);
+            ResultOfUpdate result = await _userService.Update(userId, user);
             if (result == ResultOfUpdate.NotFound)
             {
                 return new NotFoundObjectResult(userId);

--- a/Backend/Controllers/UserController.cs
+++ b/Backend/Controllers/UserController.cs
@@ -62,7 +62,7 @@ namespace BackendFramework.Controllers
         {
             try
             {
-                User user = await _userService.Authenticate(cred.Username, cred.Password);
+                var user = await _userService.Authenticate(cred.Username, cred.Password);
                 if (user == null)
                 {
                     return new UnauthorizedResult();
@@ -86,7 +86,7 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            User user = await _userService.GetUser(userId);
+            var user = await _userService.GetUser(userId);
             if (user == null)
             {
                 return new NotFoundResult();
@@ -118,8 +118,7 @@ namespace BackendFramework.Controllers
         [HttpPost("checkusername/{username}")]
         public async Task<IActionResult> CheckUsername(string username)
         {
-            bool usernameTaken = (await _userService.GetAllUsers()).Find(x => x.Username == username) != null;
-
+            var usernameTaken = (await _userService.GetAllUsers()).Find(x => x.Username == username) != null;
             if (usernameTaken)
             {
                 return BadRequest();
@@ -137,8 +136,7 @@ namespace BackendFramework.Controllers
         [HttpPost("checkemail/{email}")]
         public async Task<IActionResult> CheckEmail(string email)
         {
-            bool emailTaken = (await _userService.GetAllUsers()).Find(x => x.Email == email) != null;
-
+            var emailTaken = (await _userService.GetAllUsers()).Find(x => x.Email == email) != null;
             if (emailTaken)
             {
                 return BadRequest();
@@ -166,7 +164,7 @@ namespace BackendFramework.Controllers
             //     return new ForbidResult();
             // }
 
-            ResultOfUpdate result = await _userService.Update(userId, user);
+            var result = await _userService.Update(userId, user);
             if (result == ResultOfUpdate.NotFound)
             {
                 return new NotFoundObjectResult(userId);

--- a/Backend/Controllers/UserController.cs
+++ b/Backend/Controllers/UserController.cs
@@ -1,10 +1,10 @@
-﻿using BackendFramework.Interfaces;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using BackendFramework.Interfaces;
+using BackendFramework.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using BackendFramework.Models;
 
 namespace BackendFramework.Controllers
 {

--- a/Backend/Controllers/UserController.cs
+++ b/Backend/Controllers/UserController.cs
@@ -1,10 +1,10 @@
 ﻿using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace BackendFramework.Controllers
 {

--- a/Backend/Controllers/UserEditController.cs
+++ b/Backend/Controllers/UserEditController.cs
@@ -84,14 +84,14 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            //ensure project exists
+            // Ensure project exists
             var proj = _projectService.GetProject(projectId);
             if (proj == null)
             {
                 return new NotFoundObjectResult(projectId);
             }
 
-            var userEdit = await _repo.GetUserEdit(projectId, userEditId);
+            UserEdit userEdit = await _repo.GetUserEdit(projectId, userEditId);
             if (userEdit == null)
             {
                 return new NotFoundObjectResult(userEditId);
@@ -110,8 +110,7 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            UserEdit userEdit = new UserEdit();
-            userEdit.ProjectId = projectId;
+            var userEdit = new UserEdit {ProjectId = projectId};
             await _repo.Create(userEdit);
             return new OkObjectResult(userEdit.Id);
         }
@@ -127,30 +126,29 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            //check to see if user is changing the correct user edit
+            // Check to see if user is changing the correct user edit
             if (_permissionService.IsViolationEdit(HttpContext, userEditId, projectId))
             {
                 return new BadRequestObjectResult("You can not edit another users UserEdit");
             }
 
-
-            //ensure project exists
+            // Ensure project exists
             var proj = _projectService.GetProject(projectId);
             if (proj == null)
             {
                 return new NotFoundObjectResult(projectId);
             }
 
-            //ensure userEdit exists
+            // Ensure userEdit exists
             UserEdit toBeMod = await _repo.GetUserEdit(projectId, userEditId);
             if (toBeMod == null)
             {
                 return new NotFoundObjectResult(userEditId);
             }
 
-            Tuple<bool, int> result = await _userEditService.AddGoalToUserEdit(projectId, userEditId, newEdit);
+            var result = await _userEditService.AddGoalToUserEdit(projectId, userEditId, newEdit);
 
-            //if the replacement was successful
+            // If the replacement was successful
             if (result.Item1)
             {
                 return new OkObjectResult(result.Item2);
@@ -165,34 +163,35 @@ namespace BackendFramework.Controllers
         /// <remarks> PUT: v1/projects/{projectId}/useredits/{userEditId} </remarks>
         /// <returns> Index of newest edit </returns>
         [HttpPut("{userEditId}")]
-        public async Task<IActionResult> Put(string projectId, string userEditId, [FromBody] UserEditObjectWrapper userEdit)
+        public async Task<IActionResult> Put(string projectId, string userEditId,
+            [FromBody] UserEditObjectWrapper userEdit)
         {
             if (!_permissionService.IsProjectAuthorized("1", HttpContext))
             {
                 return new ForbidResult();
             }
 
-            //check to see if user is changing the correct user edit
+            // Check to see if user is changing the correct user edit
             if (_permissionService.IsViolationEdit(HttpContext, userEditId, projectId))
             {
                 return new BadRequestObjectResult("You can not edit another users UserEdit");
             }
 
-            //ensure project exists
+            // Ensure project exists
             var proj = _projectService.GetProject(projectId);
             if (proj == null)
             {
                 return new NotFoundObjectResult(projectId);
             }
 
-            //ensure userEdit exists
-            var document = await _repo.GetUserEdit(projectId, userEditId);
+            // Ensure userEdit exists
+            UserEdit document = await _repo.GetUserEdit(projectId, userEditId);
             if (document == null)
             {
                 return new NotFoundResult();
             }
 
-            //ensure index exists
+            // Ensure index exists
             if (userEdit.GoalIndex >= document.Edits.Count)
             {
                 return new BadRequestObjectResult("Goal index out of range");
@@ -213,7 +212,7 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            //ensure project exists
+            // Ensure project exists
             var proj = _projectService.GetProject(projectId);
             if (proj == null)
             {

--- a/Backend/Controllers/UserEditController.cs
+++ b/Backend/Controllers/UserEditController.cs
@@ -1,10 +1,9 @@
-﻿using BackendFramework.Interfaces;
+﻿using System.Threading.Tasks;
+using BackendFramework.Interfaces;
+using BackendFramework.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
-using System;
-using System.Threading.Tasks;
-using BackendFramework.Models;
 
 namespace BackendFramework.Controllers
 {

--- a/Backend/Controllers/UserEditController.cs
+++ b/Backend/Controllers/UserEditController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace BackendFramework.Controllers
 {

--- a/Backend/Controllers/UserEditController.cs
+++ b/Backend/Controllers/UserEditController.cs
@@ -39,7 +39,7 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            //ensure project exists
+            // Ensure project exists
             var proj = _projectService.GetProject(projectId);
             if (proj == null)
             {
@@ -61,7 +61,7 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            //ensure project exists
+            // Ensure project exists
             var proj = _projectService.GetProject(projectId);
             if (proj == null)
             {
@@ -91,7 +91,7 @@ namespace BackendFramework.Controllers
                 return new NotFoundObjectResult(projectId);
             }
 
-            UserEdit userEdit = await _repo.GetUserEdit(projectId, userEditId);
+            var userEdit = await _repo.GetUserEdit(projectId, userEditId);
             if (userEdit == null)
             {
                 return new NotFoundObjectResult(userEditId);
@@ -140,7 +140,7 @@ namespace BackendFramework.Controllers
             }
 
             // Ensure userEdit exists
-            UserEdit toBeMod = await _repo.GetUserEdit(projectId, userEditId);
+            var toBeMod = await _repo.GetUserEdit(projectId, userEditId);
             if (toBeMod == null)
             {
                 return new NotFoundObjectResult(userEditId);
@@ -185,7 +185,7 @@ namespace BackendFramework.Controllers
             }
 
             // Ensure userEdit exists
-            UserEdit document = await _repo.GetUserEdit(projectId, userEditId);
+            var document = await _repo.GetUserEdit(projectId, userEditId);
             if (document == null)
             {
                 return new NotFoundResult();

--- a/Backend/Controllers/UserEditController.cs
+++ b/Backend/Controllers/UserEditController.cs
@@ -1,5 +1,4 @@
 ﻿using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;

--- a/Backend/Controllers/UserEditController.cs
+++ b/Backend/Controllers/UserEditController.cs
@@ -19,7 +19,8 @@ namespace BackendFramework.Controllers
         private readonly IPermissionService _permissionService;
         private readonly IUserService _userService;
 
-        public UserEditController(IUserEditRepository repo, IUserEditService userEditService, IProjectService projectService, IPermissionService permissionService, IUserService userService)
+        public UserEditController(IUserEditRepository repo, IUserEditService userEditService,
+            IProjectService projectService, IPermissionService permissionService, IUserService userService)
         {
             _repo = repo;
             _userService = userService;

--- a/Backend/Controllers/UserRoleController.cs
+++ b/Backend/Controllers/UserRoleController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace BackendFramework.Controllers
 {

--- a/Backend/Controllers/UserRoleController.cs
+++ b/Backend/Controllers/UserRoleController.cs
@@ -35,7 +35,7 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            //ensure project exists
+            // Ensure project exists
             var proj = _projectService.GetProject(projectId);
             if (proj == null)
             {
@@ -87,7 +87,7 @@ namespace BackendFramework.Controllers
                 return new NotFoundObjectResult(projectId);
             }
 
-            UserRole userRole = await _userRoleService.GetUserRole(projectId, userRoleId);
+            var userRole = await _userRoleService.GetUserRole(projectId, userRoleId);
             if (userRole == null)
             {
                 return new NotFoundObjectResult(userRoleId);
@@ -116,7 +116,7 @@ namespace BackendFramework.Controllers
                 return new NotFoundObjectResult(projectId);
             }
 
-            UserRole returnUserRole = await _userRoleService.Create(userRole);
+            var returnUserRole = await _userRoleService.Create(userRole);
             if (returnUserRole == null)
             {
                 return BadRequest();
@@ -167,7 +167,7 @@ namespace BackendFramework.Controllers
                 return new NotFoundObjectResult(projectId);
             }
 
-            ResultOfUpdate result = await _userRoleService.Update(userRoleId, userRole);
+            var result = await _userRoleService.Update(userRoleId, userRole);
             if (result == ResultOfUpdate.NotFound)
             {
                 return new NotFoundObjectResult(userRoleId);

--- a/Backend/Controllers/UserRoleController.cs
+++ b/Backend/Controllers/UserRoleController.cs
@@ -1,9 +1,9 @@
-﻿using BackendFramework.Interfaces;
+﻿using System.Threading.Tasks;
+using BackendFramework.Interfaces;
+using BackendFramework.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
-using System.Threading.Tasks;
-using BackendFramework.Models;
 
 namespace BackendFramework.Controllers
 {

--- a/Backend/Controllers/UserRoleController.cs
+++ b/Backend/Controllers/UserRoleController.cs
@@ -17,7 +17,8 @@ namespace BackendFramework.Controllers
         private readonly IProjectService _projectService;
         private readonly IPermissionService _permissionService;
 
-        public UserRoleController(IUserRoleService userRoleService, IProjectService projectService, IPermissionService permissionService)
+        public UserRoleController(IUserRoleService userRoleService, IProjectService projectService,
+            IPermissionService permissionService)
         {
             _userRoleService = userRoleService;
             _projectService = projectService;

--- a/Backend/Controllers/UserRoleController.cs
+++ b/Backend/Controllers/UserRoleController.cs
@@ -46,7 +46,7 @@ namespace BackendFramework.Controllers
 
         /// <summary> Deletes all <see cref="UserRole"/>s for specified <see cref="Project"/></summary>
         /// <remarks> DELETE: v1/projects/{projectId}/userroles </remarks>
-        /// <returns> true: if success, false: if there were no UserRoles </returns> 
+        /// <returns> true: if success, false: if there were no UserRoles </returns>
         [HttpDelete]
         public async Task<IActionResult> Delete(string projectId)
         {
@@ -56,7 +56,7 @@ namespace BackendFramework.Controllers
             }
 
 #if DEBUG
-            //ensure project exists
+            // Ensure project exists
             var proj = _projectService.GetProject(projectId);
             if (proj == null)
             {
@@ -79,14 +79,14 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            //ensure project exists
+            // Ensure project exists
             var proj = _projectService.GetProject(projectId);
             if (proj == null)
             {
                 return new NotFoundObjectResult(projectId);
             }
 
-            var userRole = await _userRoleService.GetUserRole(projectId, userRoleId);
+            UserRole userRole = await _userRoleService.GetUserRole(projectId, userRoleId);
             if (userRole == null)
             {
                 return new NotFoundObjectResult(userRoleId);
@@ -108,14 +108,14 @@ namespace BackendFramework.Controllers
 
             userRole.ProjectId = projectId;
 
-            //ensure project exists
+            // Ensure project exists
             var proj = _projectService.GetProject(projectId);
             if (proj == null)
             {
                 return new NotFoundObjectResult(projectId);
             }
 
-            var returnUserRole = await _userRoleService.Create(userRole);
+            UserRole returnUserRole = await _userRoleService.Create(userRole);
             if (returnUserRole == null)
             {
                 return BadRequest();
@@ -134,7 +134,7 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            //ensure project exists
+            // Ensure project exists
             var proj = _projectService.GetProject(projectId);
             if (proj == null)
             {
@@ -159,14 +159,14 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            //ensure project exists
+            // Ensure project exists
             var proj = _projectService.GetProject(projectId);
             if (proj == null)
             {
                 return new NotFoundObjectResult(projectId);
             }
 
-            var result = await _userRoleService.Update(userRoleId, userRole);
+            ResultOfUpdate result = await _userRoleService.Update(userRoleId, userRole);
             if (result == ResultOfUpdate.NotFound)
             {
                 return new NotFoundObjectResult(userRoleId);

--- a/Backend/Controllers/UserRoleController.cs
+++ b/Backend/Controllers/UserRoleController.cs
@@ -1,5 +1,4 @@
 ﻿using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;

--- a/Backend/Controllers/WordController.cs
+++ b/Backend/Controllers/WordController.cs
@@ -91,7 +91,7 @@ namespace BackendFramework.Controllers
                 return new NotFoundObjectResult(projectId);
             }
 
-            Word word = await _wordRepo.GetWord(projectId, wordId);
+            var word = await _wordRepo.GetWord(projectId, wordId);
             if (word == null)
             {
                 return new NotFoundObjectResult(wordId);
@@ -151,7 +151,7 @@ namespace BackendFramework.Controllers
             }
 
             // Ensure word exists
-            Word document = await _wordRepo.GetWord(projectId, wordId);
+            var document = await _wordRepo.GetWord(projectId, wordId);
             if (document == null)
             {
                 return new NotFoundResult();

--- a/Backend/Controllers/WordController.cs
+++ b/Backend/Controllers/WordController.cs
@@ -38,7 +38,7 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            //ensure project exists
+            // Ensure project exists
             var proj = _projectService.GetProject(projectId);
             if (proj == null)
             {
@@ -50,7 +50,7 @@ namespace BackendFramework.Controllers
 
         /// <summary> Deletes all <see cref="Word"/>s for specified <see cref="Project"/> </summary>
         /// <remarks> DELETE: v1/projects/{projectId}/words </remarks>
-        /// <returns> true: if success, false: if there were no words </returns> 
+        /// <returns> true: if success, false: if there were no words </returns>
         [HttpDelete]
         public async Task<IActionResult> Delete(string projectId)
         {
@@ -60,7 +60,7 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            //ensure project exists
+            // Ensure project exists
             var proj = _projectService.GetProject(projectId);
             if (proj == null)
             {
@@ -83,14 +83,14 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            //ensure project exists
+            // Ensure project exists
             var proj = _projectService.GetProject(projectId);
             if (proj == null)
             {
                 return new NotFoundObjectResult(projectId);
             }
 
-            var word = await _wordRepo.GetWord(projectId, wordId);
+            Word word = await _wordRepo.GetWord(projectId, wordId);
             if (word == null)
             {
                 return new NotFoundObjectResult(wordId);
@@ -109,7 +109,7 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            //ensure project exists
+            // Ensure project exists
             var proj = _projectService.GetProject(projectId);
             if (proj == null)
             {
@@ -118,12 +118,12 @@ namespace BackendFramework.Controllers
 
             word.ProjectId = projectId;
 
-            //if word is not already in frontier, add it
+            // If word is not already in frontier, add it
             if (await _wordService.WordIsUnique(word))
             {
                 await _wordRepo.Create(word);
             }
-            else //otherwise it is a duplicate
+            else // Otherwise it is a duplicate
             {
                 return new OkObjectResult("Duplicate");
             }
@@ -142,15 +142,15 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            //ensure project exists
+            // Ensure project exists
             var proj = _projectService.GetProject(projectId);
             if (proj == null)
             {
                 return new NotFoundObjectResult(projectId);
             }
 
-            //ensure word exists
-            var document = await _wordRepo.GetWord(projectId, wordId);
+            // Ensure word exists
+            Word document = await _wordRepo.GetWord(projectId, wordId);
             if (document == null)
             {
                 return new NotFoundResult();
@@ -173,7 +173,7 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            //ensure project exists
+            // Ensure project exists
             var proj = _projectService.GetProject(projectId);
             if (proj == null)
             {
@@ -198,14 +198,14 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            //ensure project exists
+            // Ensure project exists
             var proj = _projectService.GetProject(projectId);
             if (proj == null)
             {
                 return new NotFoundObjectResult(projectId);
             }
 
-            //ensure MergeWords is alright
+            // Ensure MergeWords is alright
             if (mergeWords == null || mergeWords.Parent == null)
             {
                 return new BadRequestResult();

--- a/Backend/Controllers/WordController.cs
+++ b/Backend/Controllers/WordController.cs
@@ -20,7 +20,8 @@ namespace BackendFramework.Controllers
         private readonly IProjectService _projectService;
         private readonly IPermissionService _permissionService;
 
-        public WordController(IWordRepository repo, IWordService wordService, IProjectService projectService, IPermissionService permissionService)
+        public WordController(IWordRepository repo, IWordService wordService, IProjectService projectService,
+            IPermissionService permissionService)
         {
             _wordRepo = repo;
             _wordService = wordService;

--- a/Backend/Controllers/WordController.cs
+++ b/Backend/Controllers/WordController.cs
@@ -1,11 +1,11 @@
-﻿using BackendFramework.Interfaces;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using BackendFramework.Interfaces;
+using BackendFramework.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
-using System;
-using System.Linq;
-using System.Threading.Tasks;
-using BackendFramework.Models;
 
 namespace BackendFramework.Controllers
 {

--- a/Backend/Controllers/WordController.cs
+++ b/Backend/Controllers/WordController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace BackendFramework.Controllers
 {

--- a/Backend/Controllers/WordController.cs
+++ b/Backend/Controllers/WordController.cs
@@ -1,5 +1,4 @@
 ﻿using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;

--- a/Backend/Helper/Utilities.cs
+++ b/Backend/Helper/Utilities.cs
@@ -19,7 +19,7 @@ namespace BackendFramework.Helper
             string customDirPath = "")
         {
             // Generate path to home on linux
-            string pathToHome = Environment.GetEnvironmentVariable("HOME");
+            var pathToHome = Environment.GetEnvironmentVariable("HOME");
 
             // Generate home on windows
             if (pathToHome == null)
@@ -34,7 +34,7 @@ namespace BackendFramework.Helper
             }
 
             // Path to the base data folder
-            string returnFilepath = Path.Combine(pathToHome, ".CombineFiles", customDirPath);
+            var returnFilepath = Path.Combine(pathToHome, ".CombineFiles", customDirPath);
 
             // Establish path to the typed file in the base folder
 

--- a/Backend/Helper/Utilities.cs
+++ b/Backend/Helper/Utilities.cs
@@ -5,62 +5,62 @@ namespace BackendFramework.Helper
 {
     public class Utilities
     {
-        public enum Filetype
+        public enum FileType
         {
-            audio,
-            avatar,
-            lift,
-            zip,
-            dir
+            Audio,
+            Avatar,
+            Lift,
+            Zip,
+            Dir
         }
 
-
-        //TODO: split this function in two that generate directories or files
-        public string GenerateFilePath(Filetype type, bool isDirectory, string customFileName = "", string customDirPath = "")
+        // TODO: split this function in two that generate directories or files
+        public string GenerateFilePath(FileType type, bool isDirectory, string customFileName = "",
+            string customDirPath = "")
         {
-            //generate path to home on linux
-            var pathToHome = Environment.GetEnvironmentVariable("HOME");
+            // Generate path to home on linux
+            string pathToHome = Environment.GetEnvironmentVariable("HOME");
 
-            //generate home on windows
+            // Generate home on windows
             if (pathToHome == null)
             {
                 pathToHome = Environment.GetEnvironmentVariable("UserProfile");
             }
 
-            //something is wrong
+            // Something is wrong
             if (pathToHome == null)
             {
                 throw new DesktopNotFoundException();
             }
 
-            //path to the base data folder
+            // Path to the base data folder
             string returnFilepath = Path.Combine(pathToHome, ".CombineFiles", customDirPath);
 
-            //establish path to the typed file in the base folder
+            // Establish path to the typed file in the base folder
 
-            //creates the directory if it doesn't exist
+            // Creates the directory if it doesn't exist
             Directory.CreateDirectory(returnFilepath);
 
-            //if the path being generated is to a dir and not a file then don't add an extension
+            // If the path being generated is to a dir and not a file then don't add an extension
             returnFilepath = Path.Combine(returnFilepath, customFileName + (isDirectory ? "" : FileTypeExtension(type)));
 
             return returnFilepath;
         }
 
-        private string FileTypeFolder(Filetype type)
+        private string FileTypeFolder(FileType type)
         {
             switch (type)
             {
-                case Filetype.audio:
+                case FileType.Audio:
                     return "Audios";
 
-                case Filetype.avatar:
+                case FileType.Avatar:
                     return "Avatars";
 
-                case Filetype.lift:
+                case FileType.Lift:
                     return "lifts";
 
-                case Filetype.zip:
+                case FileType.Zip:
                     return "zips";
 
                 default:
@@ -68,20 +68,20 @@ namespace BackendFramework.Helper
             }
         }
 
-        private string FileTypeExtension(Filetype type)
+        private static string FileTypeExtension(FileType type)
         {
             switch (type)
             {
-                case Filetype.audio:
+                case FileType.Audio:
                     return ".webm";
 
-                case Filetype.avatar:
+                case FileType.Avatar:
                     return ".jpg";
 
-                case Filetype.lift:
+                case FileType.Lift:
                     return ".lift";
 
-                case Filetype.zip:
+                case FileType.Zip:
                     return ".zip";
 
                 default:
@@ -91,7 +91,6 @@ namespace BackendFramework.Helper
 
         public class DesktopNotFoundException : Exception
         {
-            public DesktopNotFoundException() { }
         }
     }
 }

--- a/Backend/Interfaces/IPermissionService.cs
+++ b/Backend/Interfaces/IPermissionService.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.AspNetCore.Http;
-using System.Threading.Tasks;
 
 namespace BackendFramework.Interfaces
 {

--- a/Backend/Interfaces/IPermissionService.cs
+++ b/Backend/Interfaces/IPermissionService.cs
@@ -7,7 +7,7 @@ namespace BackendFramework.Interfaces
     {
         bool IsProjectAuthorized(string value, HttpContext request);
         bool IsUserIdAuthorized(HttpContext request, string userId);
-        bool IsViolationEdit(HttpContext request, string userEditId, string ProjectId);
+        bool IsViolationEdit(HttpContext request, string userEditId, string projectId);
         string GetUserId(HttpContext request);
     }
 }

--- a/Backend/Interfaces/IProjectContext.cs
+++ b/Backend/Interfaces/IProjectContext.cs
@@ -1,4 +1,5 @@
-﻿using BackendFramework.ValueModels;
+﻿using BackendFramework.Models;
+using BackendFramework.ValueModels;
 using MongoDB.Driver;
 
 namespace BackendFramework.Interfaces

--- a/Backend/Interfaces/IProjectContext.cs
+++ b/Backend/Interfaces/IProjectContext.cs
@@ -1,5 +1,4 @@
 ﻿using BackendFramework.Models;
-using BackendFramework.ValueModels;
 using MongoDB.Driver;
 
 namespace BackendFramework.Interfaces

--- a/Backend/Interfaces/IProjectService.cs
+++ b/Backend/Interfaces/IProjectService.cs
@@ -1,5 +1,4 @@
-﻿using BackendFramework.ValueModels;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using BackendFramework.Models;
 

--- a/Backend/Interfaces/IProjectService.cs
+++ b/Backend/Interfaces/IProjectService.cs
@@ -1,6 +1,7 @@
 ﻿using BackendFramework.ValueModels;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace BackendFramework.Interfaces
 {

--- a/Backend/Interfaces/ISemDomParser.cs
+++ b/Backend/Interfaces/ISemDomParser.cs
@@ -1,5 +1,4 @@
-﻿using BackendFramework.ValueModels;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using BackendFramework.Models;
 

--- a/Backend/Interfaces/ISemDomParser.cs
+++ b/Backend/Interfaces/ISemDomParser.cs
@@ -1,6 +1,7 @@
 ﻿using BackendFramework.ValueModels;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace BackendFramework.Interfaces
 {

--- a/Backend/Interfaces/IUserContext.cs
+++ b/Backend/Interfaces/IUserContext.cs
@@ -1,4 +1,4 @@
-﻿using BackendFramework.ValueModels;
+﻿using BackendFramework.Models;
 using MongoDB.Driver;
 
 namespace BackendFramework.Interfaces

--- a/Backend/Interfaces/IUserEditContext.cs
+++ b/Backend/Interfaces/IUserEditContext.cs
@@ -1,4 +1,4 @@
-﻿using BackendFramework.ValueModels;
+﻿using BackendFramework.Models;
 using MongoDB.Driver;
 
 namespace BackendFramework.Interfaces

--- a/Backend/Interfaces/IUserEditRepository.cs
+++ b/Backend/Interfaces/IUserEditRepository.cs
@@ -9,7 +9,7 @@ namespace BackendFramework.Interfaces
         Task<List<UserEdit>> GetAllUserEdits(string projectId);
         Task<UserEdit> GetUserEdit(string projectId, string userEditId);
         Task<UserEdit> Create(UserEdit userEdit);
-        Task<bool> Delete(string projectId, string uesrEditId);
+        Task<bool> Delete(string projectId, string userEditId);
         Task<bool> DeleteAllUserEdits(string projectId);
         Task<bool> Replace(string projectId, string userEditId, UserEdit userEdit);
     }

--- a/Backend/Interfaces/IUserEditRepository.cs
+++ b/Backend/Interfaces/IUserEditRepository.cs
@@ -1,6 +1,6 @@
-﻿using BackendFramework.ValueModels;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace BackendFramework.Interfaces
 {

--- a/Backend/Interfaces/IUserEditService.cs
+++ b/Backend/Interfaces/IUserEditService.cs
@@ -7,6 +7,6 @@ namespace BackendFramework.Interfaces
     public interface IUserEditService
     {
         Task<bool> AddStepToGoal(string projectId, string userEditId, int goalIndex, string userEdit);
-        Task<Tuple<bool, int>> AddGoalToUserEdit(string projectId, string UserEditId, Edit edit);
+        Task<Tuple<bool, int>> AddGoalToUserEdit(string projectId, string userEditId, Edit edit);
     }
 }

--- a/Backend/Interfaces/IUserEditService.cs
+++ b/Backend/Interfaces/IUserEditService.cs
@@ -1,6 +1,6 @@
-﻿using BackendFramework.ValueModels;
-using System;
+﻿using System;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace BackendFramework.Interfaces
 {

--- a/Backend/Interfaces/IUserRoleContext.cs
+++ b/Backend/Interfaces/IUserRoleContext.cs
@@ -1,4 +1,4 @@
-﻿using BackendFramework.ValueModels;
+﻿using BackendFramework.Models;
 using MongoDB.Driver;
 
 namespace BackendFramework.Interfaces

--- a/Backend/Interfaces/IUserRoleService.cs
+++ b/Backend/Interfaces/IUserRoleService.cs
@@ -1,6 +1,6 @@
-﻿using BackendFramework.ValueModels;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace BackendFramework.Interfaces
 {

--- a/Backend/Interfaces/IUserService.cs
+++ b/Backend/Interfaces/IUserService.cs
@@ -1,6 +1,6 @@
-﻿using BackendFramework.ValueModels;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace BackendFramework.Interfaces
 {

--- a/Backend/Interfaces/IUserService.cs
+++ b/Backend/Interfaces/IUserService.cs
@@ -14,6 +14,6 @@ namespace BackendFramework.Interfaces
         Task<bool> Delete(string userId);
         Task<bool> DeleteAllUsers();
         Task<User> Authenticate(string username, string password);
-        Task<User> MakeJWT(User user);
+        Task<User> MakeJwt(User user);
     }
 }

--- a/Backend/Interfaces/IWordContext.cs
+++ b/Backend/Interfaces/IWordContext.cs
@@ -1,4 +1,4 @@
-﻿using BackendFramework.ValueModels;
+﻿using BackendFramework.Models;
 using MongoDB.Driver;
 
 namespace BackendFramework.Interfaces

--- a/Backend/Interfaces/IWordRepository.cs
+++ b/Backend/Interfaces/IWordRepository.cs
@@ -1,6 +1,6 @@
-using BackendFramework.ValueModels;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace BackendFramework.Interfaces
 {

--- a/Backend/Interfaces/IWordService.cs
+++ b/Backend/Interfaces/IWordService.cs
@@ -1,6 +1,6 @@
-﻿using BackendFramework.ValueModels;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace BackendFramework.Interfaces
 {

--- a/Backend/Models/Project.cs
+++ b/Backend/Models/Project.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using BackendFramework.ValueModels;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using Newtonsoft.Json;
@@ -64,7 +63,7 @@ namespace BackendFramework.Models
 
         public Project Clone()
         {
-            Project clone = new Project
+            var clone = new Project
             {
                 Id = Id.Clone() as string,
                 Name = Name.Clone() as string,
@@ -146,7 +145,7 @@ namespace BackendFramework.Models
             }
             else
             {
-                Project other = obj as Project;
+                var other = obj as Project;
                 return other.Id.Equals(Id) && ContentEquals(other);
             }
         }
@@ -201,7 +200,7 @@ namespace BackendFramework.Models
 
 	public class ProjectWithUser : Project
 	{
-		public User __UpdatedUser;
+		public User UpdatedUser;
 
 		public ProjectWithUser() { }
 

--- a/Backend/Models/Project.cs
+++ b/Backend/Models/Project.cs
@@ -77,31 +77,31 @@ namespace BackendFramework.Models
                 PartsOfSpeech = new List<string>()
             };
 
-            foreach (SemanticDomain sd in SemanticDomains)
+            foreach (var sd in SemanticDomains)
             {
                 clone.SemanticDomains.Add(sd.Clone());
             }
-            foreach (string aws in AnalysisWritingSystems)
+            foreach (var aws in AnalysisWritingSystems)
             {
                 clone.AnalysisWritingSystems.Add(aws.Clone() as string);
             }
-            foreach (string cs in ValidCharacters)
+            foreach (var cs in ValidCharacters)
             {
                 clone.ValidCharacters.Add(cs.Clone() as string);
             }
-            foreach (string cs in RejectedCharacters)
+            foreach (var cs in RejectedCharacters)
             {
                 clone.RejectedCharacters.Add(cs.Clone() as string);
             }
-            foreach (CustomField cf in CustomFields)
+            foreach (var cf in CustomFields)
             {
                 clone.CustomFields.Add(cf.Clone());
             }
-            foreach (string wf in WordFields)
+            foreach (var wf in WordFields)
             {
                 clone.WordFields.Add(wf.Clone() as string);
             }
-            foreach (string pos in PartsOfSpeech)
+            foreach (var pos in PartsOfSpeech)
             {
                 clone.PartsOfSpeech.Add(pos.Clone() as string);
             }

--- a/Backend/Models/Project.cs
+++ b/Backend/Models/Project.cs
@@ -1,12 +1,13 @@
-﻿using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using BackendFramework.ValueModels;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
-namespace BackendFramework.ValueModels
+namespace BackendFramework.Models
 {
     public class Project
     {

--- a/Backend/Models/User.cs
+++ b/Backend/Models/User.cs
@@ -92,12 +92,12 @@ namespace BackendFramework.Models
                 ProjectRoles = new Dictionary<string, string>()
             };
 
-            foreach (string projId in WorkedProjects.Keys)
+            foreach (var projId in WorkedProjects.Keys)
             {
                 clone.WorkedProjects.Add(projId.Clone() as string, WorkedProjects[projId].Clone() as string);
             }
 
-            foreach (string projId in ProjectRoles.Keys)
+            foreach (var projId in ProjectRoles.Keys)
             {
                 clone.ProjectRoles.Add(projId.Clone() as string, ProjectRoles[projId].Clone() as string);
             }

--- a/Backend/Models/User.cs
+++ b/Backend/Models/User.cs
@@ -1,10 +1,10 @@
-﻿using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
 
-namespace BackendFramework.ValueModels
+namespace BackendFramework.Models
 {
     public class User
     {
@@ -75,7 +75,7 @@ namespace BackendFramework.ValueModels
 
         public User Clone()
         {
-            User clone = new User
+            var clone = new User
             {
                 Id = Id.Clone() as string,
                 Avatar = Avatar.Clone() as string,
@@ -135,7 +135,7 @@ namespace BackendFramework.ValueModels
             }
             else
             {
-                User other = obj as User;
+                var other = obj as User;
                 return other.Id.Equals(Id) && ContentEquals(other);
             }
         }
@@ -160,7 +160,7 @@ namespace BackendFramework.ValueModels
         }
     }
 
-    /// <summary> Contains username and password for authenitcation </summary>
+    /// <summary> Contains username and password for authentication. </summary>
     public class Credentials
     {
         public string Username { get; set; }

--- a/Backend/Models/UserEdit.cs
+++ b/Backend/Models/UserEdit.cs
@@ -1,10 +1,10 @@
-﻿using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
 
-namespace BackendFramework.ValueModels
+namespace BackendFramework.Models
 {
     /// <summary> The changes a user has made on a particular project </summary>
     public class UserEdit
@@ -59,7 +59,7 @@ namespace BackendFramework.ValueModels
             }
             else
             {
-                UserEdit other = obj as UserEdit;
+                var other = obj as UserEdit;
                 return other.Id.Equals(Id) && ContentEquals(other);
             }
         }
@@ -92,7 +92,7 @@ namespace BackendFramework.ValueModels
             }
             else
             {
-                UserEditObjectWrapper other = obj as UserEditObjectWrapper;
+                var other = obj as UserEditObjectWrapper;
                 return other.GoalIndex.Equals(GoalIndex) && other.NewEdit.Equals(NewEdit);
             }
         }
@@ -105,7 +105,7 @@ namespace BackendFramework.ValueModels
 
     public class Edit
     {
-        /// <summary> Integer representation of enum <see cref="ValueModels.GoalType"/> </summary>
+        /// <summary> Integer representation of enum <see cref="Models.GoalType"/> </summary>
         [BsonElement("goalType")]
         public int GoalType { get; set; }
 

--- a/Backend/Models/UserEdit.cs
+++ b/Backend/Models/UserEdit.cs
@@ -28,7 +28,7 @@ namespace BackendFramework.Models
 
         public UserEdit Clone()
         {
-            UserEdit clone = new UserEdit
+            var clone = new UserEdit
             {
                 Id = Id.Clone() as string,
                 ProjectId = ProjectId.Clone() as string,
@@ -120,7 +120,7 @@ namespace BackendFramework.Models
 
         public Edit Clone()
         {
-            Edit clone = new Edit
+            var clone = new Edit
             {
                 GoalType = GoalType,
                 StepData = new List<string>()
@@ -142,7 +142,7 @@ namespace BackendFramework.Models
             }
             else
             {
-                Edit other = obj as Edit;
+                var other = obj as Edit;
                 return
                     GoalType.Equals(other.GoalType) &&
 

--- a/Backend/Models/UserEdit.cs
+++ b/Backend/Models/UserEdit.cs
@@ -35,7 +35,7 @@ namespace BackendFramework.Models
                 Edits = new List<Edit>()
             };
 
-            foreach (Edit edit in Edits)
+            foreach (var edit in Edits)
             {
                 clone.Edits.Add(edit.Clone());
             }
@@ -126,7 +126,7 @@ namespace BackendFramework.Models
                 StepData = new List<string>()
             };
 
-            foreach (string stepData in StepData)
+            foreach (var stepData in StepData)
             {
                 clone.StepData.Add(stepData.Clone() as string);
             }

--- a/Backend/Models/UserRole.cs
+++ b/Backend/Models/UserRole.cs
@@ -1,10 +1,10 @@
-﻿using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
 
-namespace BackendFramework.ValueModels
+namespace BackendFramework.Models
 {
     /// <summary> The permissions a user has on a particular project </summary>
     public class UserRole
@@ -29,7 +29,7 @@ namespace BackendFramework.ValueModels
 
         public UserRole Clone()
         {
-            UserRole clone = new UserRole
+            var clone = new UserRole
             {
                 Id = Id.Clone() as string,
                 ProjectId = ProjectId.Clone() as string,
@@ -60,7 +60,7 @@ namespace BackendFramework.ValueModels
             }
             else
             {
-                UserRole other = obj as UserRole;
+                var other = obj as UserRole;
                 return other.Id.Equals(Id) && ContentEquals(other);
             }
         }
@@ -79,17 +79,30 @@ namespace BackendFramework.ValueModels
             Permissions = permissions;
         }
         public string ProjectId { get; set; }
-        public List<int> Permissions { get; set; }  //this is a list of permissions but is represented as ints for ease of catching http requests
+
+        /// This is a list of permissions but is represented as ints for ease of catching HTTP requests.
+        public List<int> Permissions { get; set; }
     }
 
     public enum Permission
     {
-        DatabaseAdmin = 6,          //Database Admin, has no limitations
-        EditSettingsNUsers = 5,     //Project Admin, can edit project settings and add and remove users, change userRoles
-        ImportExport = 4,           //Can import and export lift 
-        MergeNCharSet = 3,          //Can merge words and change the char set
-        Unused = 2,                 //Unused
-        WordEntry = 1               //Can enter words
+        /// <summary> Database Admin, has no limitations </summary>
+        DatabaseAdmin = 6,
+
+        /// <summary> Project Admin, can edit project settings and add and remove users, change userRoles </summary>
+        EditSettingsNUsers = 5,
+
+        /// <summary> Can import and export lift </summary>
+        ImportExport = 4,
+
+        /// <summary> Can merge words and change the char set </summary>
+        MergeNCharSet = 3,
+
+        /// <summary> Unused </summary>
+        Unused = 2,
+
+        /// <summary> Can enter words </summary>
+        WordEntry = 1
     }
 
     /// <summary> Return type of Update functions </summary>

--- a/Backend/Models/UserRole.cs
+++ b/Backend/Models/UserRole.cs
@@ -36,7 +36,7 @@ namespace BackendFramework.Models
                 Permissions = new List<int>()
             };
 
-            foreach (int permission in Permissions)
+            foreach (var permission in Permissions)
             {
                 clone.Permissions.Add(permission);
             }

--- a/Backend/Models/Word.cs
+++ b/Backend/Models/Word.cs
@@ -80,19 +80,19 @@ namespace BackendFramework.Models
                 Senses = new List<Sense>()
             };
 
-            foreach (string file in Audio)
+            foreach (var file in Audio)
             {
                 clone.Audio.Add(file.Clone() as string);
             }
-            foreach (string id in EditedBy)
+            foreach (var id in EditedBy)
             {
                 clone.EditedBy.Add(id.Clone() as string);
             }
-            foreach (string id in History)
+            foreach (var id in History)
             {
                 clone.History.Add(id.Clone() as string);
             }
-            foreach (Sense sense in Senses)
+            foreach (var sense in Senses)
             {
                 clone.Senses.Add(sense.Clone());
             }
@@ -124,7 +124,7 @@ namespace BackendFramework.Models
             }
             else
             {
-                Word other = obj as Word;
+                var other = obj as Word;
                 return
                     other.Id.Equals(Id) &&
                     this.ContentEquals(other) &&
@@ -169,17 +169,17 @@ namespace BackendFramework.Models
 
         public Sense Clone()
         {
-            Sense clone = new Sense
+            var clone = new Sense
             {
                 Glosses = new List<Gloss>(),
                 SemanticDomains = new List<SemanticDomain>()
             };
 
-            foreach (Gloss gloss in Glosses)
+            foreach (var gloss in Glosses)
             {
                 clone.Glosses.Add(gloss.Clone());
             }
-            foreach (SemanticDomain sd in SemanticDomains)
+            foreach (var sd in SemanticDomains)
             {
                 clone.SemanticDomains.Add(sd.Clone());
             }

--- a/Backend/Models/Word.cs
+++ b/Backend/Models/Word.cs
@@ -195,7 +195,7 @@ namespace BackendFramework.Models
             }
             else
             {
-                Sense other = obj as Sense;
+                var other = obj as Sense;
                 return
                     other.Glosses.Count == Glosses.Count &&
                     other.Glosses.All(Glosses.Contains) &&

--- a/Backend/Models/Word.cs
+++ b/Backend/Models/Word.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.AspNetCore.Http;
-using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.AspNetCore.Http;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
 
-namespace BackendFramework.ValueModels
+namespace BackendFramework.Models
 {
     public class Word
     {
@@ -64,7 +64,7 @@ namespace BackendFramework.ValueModels
 
         public Word Clone()
         {
-            Word clone = new Word
+            var clone = new Word
             {
                 Id = Id.Clone() as string,
                 Vernacular = Vernacular.Clone() as string,
@@ -233,7 +233,7 @@ namespace BackendFramework.ValueModels
             }
             else
             {
-                Gloss other = obj as Gloss;
+                var other = obj as Gloss;
                 return Language.Equals(other.Language) && Def.Equals(other.Def);
             }
         }
@@ -275,7 +275,7 @@ namespace BackendFramework.ValueModels
             }
             else
             {
-                SemanticDomain other = obj as SemanticDomain;
+                var other = obj as SemanticDomain;
                 return Name.Equals(other.Name) && Id.Equals(other.Id) && Description.Equals(other.Description);
             }
         }
@@ -294,8 +294,8 @@ namespace BackendFramework.ValueModels
         public string FilePath { get; set; }
     }
 
-    /// <summary> 
-    /// Helper object that contains a parent word and a number of children which will be merged into it 
+    /// <summary>
+    /// Helper object that contains a parent word and a number of children which will be merged into it
     /// along with the userId of who made the merge and at what time
     /// </summary>
     public class MergeWords
@@ -316,10 +316,10 @@ namespace BackendFramework.ValueModels
     /// <summary> Information about the state of the word in that database used for merging </summary>
     public enum State
     {
-        active,
-        deleted,
-        sense,
-        duplicate,
-        separate
+        Active,
+        Deleted,
+        Sense,
+        Duplicate,
+        Separate
     }
 }

--- a/Backend/Services/LiftApiServices.cs
+++ b/Backend/Services/LiftApiServices.cs
@@ -114,7 +114,7 @@ namespace BackendFramework.Services
             var util = new Helper.Utilities();
 
             // Generate the zip dir.
-            string exportDir = util.GenerateFilePath(Helper.Utilities.Filetype.dir, true, "",
+            string exportDir = util.GenerateFilePath(Helper.Utilities.FileType.Dir, true, "",
                 Path.Combine(projectId, "Export"));
             if (Directory.Exists(Path.Combine(exportDir, "LiftExport")))
             {
@@ -295,11 +295,11 @@ namespace BackendFramework.Services
                 var util = new Helper.Utilities();
 
                 string projectPath = Path.Combine(util.GenerateFilePath(
-                    Helper.Utilities.Filetype.dir, true, "", ""), _projectId);
+                    Helper.Utilities.FileType.Dir, true, "", ""), _projectId);
                 projectPath = Path.Combine(projectPath, "Import", "ExtractedLocation");
                 var extractedDir = Directory.GetDirectories(projectPath);
                 projectPath = Path.Combine(projectPath, extractedDir.Single());
-                string src = Path.Combine(util.GenerateFilePath(Helper.Utilities.Filetype.audio, true), Path.Combine(projectPath, "audio", audioFile));
+                string src = Path.Combine(util.GenerateFilePath(Helper.Utilities.FileType.Audio, true), Path.Combine(projectPath, "audio", audioFile));
                 string dest = Path.Combine(path, audioFile);
 
                 if (File.Exists(src))
@@ -475,7 +475,7 @@ namespace BackendFramework.Services
             // Get path to dir containing local lift package ~/{projectId}/Import/ExtractedLocation
             Helper.Utilities util = new Helper.Utilities();
             string importDir = util.GenerateFilePath(
-                Helper.Utilities.Filetype.dir, false, "", Path.Combine(_projectId, "Import"));
+                Helper.Utilities.FileType.Dir, false, "", Path.Combine(_projectId, "Import"));
             string extractedPathToImport = Path.Combine(importDir, "ExtractedLocation");
 
             // Get path to directory with audio files ~/{projectId}/Import/ExtractedLocation/{liftName}/audio

--- a/Backend/Services/LiftApiServices.cs
+++ b/Backend/Services/LiftApiServices.cs
@@ -1,12 +1,3 @@
-using BackendFramework.Interfaces;
-using MongoDB.Driver;
-using SIL.DictionaryServices.Lift;
-using SIL.DictionaryServices.Model;
-using SIL.Lift;
-using SIL.Lift.Options;
-using SIL.Lift.Parsing;
-using SIL.Text;
-using SIL.WritingSystems;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -15,7 +6,15 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Xml;
+using BackendFramework.Interfaces;
 using BackendFramework.Models;
+using SIL.DictionaryServices.Lift;
+using SIL.DictionaryServices.Model;
+using SIL.Lift;
+using SIL.Lift.Options;
+using SIL.Lift.Parsing;
+using SIL.Text;
+using SIL.WritingSystems;
 using static SIL.DictionaryServices.Lift.LiftWriter;
 
 namespace BackendFramework.Services

--- a/Backend/Services/LiftApiServices.cs
+++ b/Backend/Services/LiftApiServices.cs
@@ -1,5 +1,4 @@
 using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using MongoDB.Driver;
 using SIL.DictionaryServices.Lift;
 using SIL.DictionaryServices.Model;
@@ -16,6 +15,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Xml;
+using BackendFramework.Models;
 using static SIL.DictionaryServices.Lift.LiftWriter;
 
 namespace BackendFramework.Services
@@ -148,7 +148,7 @@ namespace BackendFramework.Services
             //write out every word with all of its information
             var allWords = _repo.GetAllWords(projectId).Result;
             var frontier = _repo.GetFrontier(projectId).Result;
-            var activeWords = frontier.Where(x => x.Senses.First().Accessibility == (int)State.active).ToList();
+            var activeWords = frontier.Where(x => x.Senses.First().Accessibility == (int)State.Active).ToList();
             var deletedWords = allWords.Where(x => activeWords.Contains(x)).ToList();//TODO: this is wrong, deleted is a subset of active, are not exclusive
             foreach (Word wordEntry in activeWords)
             {

--- a/Backend/Services/PermissionService.cs
+++ b/Backend/Services/PermissionService.cs
@@ -1,9 +1,10 @@
-﻿using BackendFramework.Interfaces;
+﻿using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using BackendFramework.Interfaces;
+using BackendFramework.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.Tokens;
-using System.Collections.Generic;
-using System.IdentityModel.Tokens.Jwt;
-using BackendFramework.Models;
+using Newtonsoft.Json;
 
 namespace BackendFramework.Services
 {
@@ -45,7 +46,7 @@ namespace BackendFramework.Services
             SecurityToken jsonToken = GetJwt(request);
 
             var userRoleInfo = ((JwtSecurityToken)jsonToken).Payload["UserRoleInfo"].ToString();
-            var permissionsObj = Newtonsoft.Json.JsonConvert.DeserializeObject<List<ProjectPermissions>>(userRoleInfo);
+            var permissionsObj = JsonConvert.DeserializeObject<List<ProjectPermissions>>(userRoleInfo);
             return permissionsObj;
         }
 

--- a/Backend/Services/PermissionService.cs
+++ b/Backend/Services/PermissionService.cs
@@ -1,9 +1,9 @@
 ﻿using BackendFramework.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.Tokens;
-using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
+using BackendFramework.Models;
 
 namespace BackendFramework.Services
 {
@@ -16,64 +16,62 @@ namespace BackendFramework.Services
             _userService = userService;
         }
 
-        const int projIdLength = 24;
+        private const int ProjIdLength = 24;
 
-        private SecurityToken GetJWT(HttpContext request)
+        private static SecurityToken GetJwt(HttpContext request)
         {
-            //get authorization header i.e. JWT token
+            // Get authorization header i.e. JWT token
             var jwtToken = request.Request.Headers["Authorization"].ToString();
 
             // "remove "Bearer" from beginning of token
-            var token = jwtToken.Split(" ")[1];
+            string token = jwtToken.Split(" ")[1];
 
-            //parse JWT for project permissions
+            // Parse JWT for project permissions
             var handler = new JwtSecurityTokenHandler();
-            var jsonToken = handler.ReadToken(token);
+            SecurityToken jsonToken = handler.ReadToken(token);
 
             return jsonToken;
         }
 
         public bool IsUserIdAuthorized(HttpContext request, string userId)
         {
-            var jsonToken = GetJWT(request);
-
-            string foundUserId = ((JwtSecurityToken)jsonToken).Payload["UserId"].ToString();
-
+            SecurityToken jsonToken = GetJwt(request);
+            var foundUserId = ((JwtSecurityToken)jsonToken).Payload["UserId"].ToString();
             return userId == foundUserId;
         }
 
-        public List<ProjectPermissions> GetProjectPermissions(HttpContext request)
+        public static List<ProjectPermissions> GetProjectPermissions(HttpContext request)
         {
-            var jsonToken = GetJWT(request);
+            SecurityToken jsonToken = GetJwt(request);
 
-            string userRoleInfo = ((JwtSecurityToken)jsonToken).Payload["UserRoleInfo"].ToString();
-            List<ProjectPermissions> permissionsObj = Newtonsoft.Json.JsonConvert.DeserializeObject<List<ProjectPermissions>>(userRoleInfo);
+            var userRoleInfo = ((JwtSecurityToken)jsonToken).Payload["UserRoleInfo"].ToString();
+            var permissionsObj = Newtonsoft.Json.JsonConvert.DeserializeObject<List<ProjectPermissions>>(userRoleInfo);
             return permissionsObj;
         }
 
         public bool IsProjectAuthorized(string value, HttpContext request)
         {
-            //retrieve jwt token from http request and convert to object
-            List<ProjectPermissions> permissionsObj = GetProjectPermissions(request);
+            // Retrieve JWT token from http request and convert to object
+            var permissionsObj = GetProjectPermissions(request);
 
-            //retrieve project Id from http request
-            int begOfId = 9;
+            // Retrieve project Id from http request
+            const int begOfId = 9;
             int indexOfProjId = request.Request.Path.ToString().LastIndexOf("projects/") + begOfId;
-            if (indexOfProjId + projIdLength > request.Request.Path.ToString().Length)
+            if (indexOfProjId + ProjIdLength > request.Request.Path.ToString().Length)
             {
-                //check if admin
-                var userId = GetUserId(request);
-                var user = _userService.GetUser(userId).Result;
+                // Check if admin
+                string userId = GetUserId(request);
+                User user = _userService.GetUser(userId).Result;
 
-                //if there is no project Id and they are not admin, do not allow changes
+                // If there is no project Id and they are not admin, do not allow changes
                 return user.IsAdmin;
             }
             else
             {
-                string projId = request.Request.Path.ToString().Substring(indexOfProjId, projIdLength);
+                string projId = request.Request.Path.ToString().Substring(indexOfProjId, ProjIdLength);
 
-                //assert that the user has permission for this function
-                foreach (var projectEntry in permissionsObj)
+                // Assert that the user has permission for this function
+                foreach (ProjectPermissions projectEntry in permissionsObj)
                 {
                     if (projectEntry.ProjectId == projId)
                     {
@@ -90,21 +88,16 @@ namespace BackendFramework.Services
 
         public bool IsViolationEdit(HttpContext request, string userEditId, string projectId)
         {
-            var userId = GetUserId(request);
-            var userObj = _userService.GetUser(userId).Result;
+            string userId = GetUserId(request);
+            User userObj = _userService.GetUser(userId).Result;
 
-            if (userObj.WorkedProjects[projectId] != userEditId)
-            {
-                return true;
-            }
-
-            return false;
+            return userObj.WorkedProjects[projectId] != userEditId;
         }
 
         public string GetUserId(HttpContext request)
         {
-            var jsonToken = GetJWT(request);
-            string permissionsObj = ((JwtSecurityToken)jsonToken).Payload["UserId"].ToString();
+            SecurityToken jsonToken = GetJwt(request);
+            var permissionsObj = ((JwtSecurityToken)jsonToken).Payload["UserId"].ToString();
             return permissionsObj;
         }
     }

--- a/Backend/Services/PermissionService.cs
+++ b/Backend/Services/PermissionService.cs
@@ -24,27 +24,26 @@ namespace BackendFramework.Services
             // Get authorization header i.e. JWT token
             var jwtToken = request.Request.Headers["Authorization"].ToString();
 
-            // "remove "Bearer" from beginning of token
-            string token = jwtToken.Split(" ")[1];
+            // Remove "Bearer" from beginning of token
+            var token = jwtToken.Split(" ")[1];
 
             // Parse JWT for project permissions
             var handler = new JwtSecurityTokenHandler();
-            SecurityToken jsonToken = handler.ReadToken(token);
+            var jsonToken = handler.ReadToken(token);
 
             return jsonToken;
         }
 
         public bool IsUserIdAuthorized(HttpContext request, string userId)
         {
-            SecurityToken jsonToken = GetJwt(request);
+            var jsonToken = GetJwt(request);
             var foundUserId = ((JwtSecurityToken)jsonToken).Payload["UserId"].ToString();
             return userId == foundUserId;
         }
 
         public static List<ProjectPermissions> GetProjectPermissions(HttpContext request)
         {
-            SecurityToken jsonToken = GetJwt(request);
-
+            var jsonToken = GetJwt(request);
             var userRoleInfo = ((JwtSecurityToken)jsonToken).Payload["UserRoleInfo"].ToString();
             var permissionsObj = JsonConvert.DeserializeObject<List<ProjectPermissions>>(userRoleInfo);
             return permissionsObj;
@@ -57,26 +56,26 @@ namespace BackendFramework.Services
 
             // Retrieve project Id from http request
             const int begOfId = 9;
-            int indexOfProjId = request.Request.Path.ToString().LastIndexOf("projects/") + begOfId;
+            var indexOfProjId = request.Request.Path.ToString().LastIndexOf("projects/") + begOfId;
             if (indexOfProjId + ProjIdLength > request.Request.Path.ToString().Length)
             {
                 // Check if admin
-                string userId = GetUserId(request);
-                User user = _userService.GetUser(userId).Result;
+                var userId = GetUserId(request);
+                var user = _userService.GetUser(userId).Result;
 
                 // If there is no project Id and they are not admin, do not allow changes
                 return user.IsAdmin;
             }
             else
             {
-                string projId = request.Request.Path.ToString().Substring(indexOfProjId, ProjIdLength);
+                var projId = request.Request.Path.ToString().Substring(indexOfProjId, ProjIdLength);
 
                 // Assert that the user has permission for this function
-                foreach (ProjectPermissions projectEntry in permissionsObj)
+                foreach (var projectEntry in permissionsObj)
                 {
                     if (projectEntry.ProjectId == projId)
                     {
-                        int.TryParse(value, out int intValue);
+                        int.TryParse(value, out var intValue);
                         if (projectEntry.Permissions.Contains(intValue))
                         {
                             return true;
@@ -89,15 +88,14 @@ namespace BackendFramework.Services
 
         public bool IsViolationEdit(HttpContext request, string userEditId, string projectId)
         {
-            string userId = GetUserId(request);
-            User userObj = _userService.GetUser(userId).Result;
-
+            var userId = GetUserId(request);
+            var userObj = _userService.GetUser(userId).Result;
             return userObj.WorkedProjects[projectId] != userEditId;
         }
 
         public string GetUserId(HttpContext request)
         {
-            SecurityToken jsonToken = GetJwt(request);
+            var jsonToken = GetJwt(request);
             var permissionsObj = ((JwtSecurityToken)jsonToken).Payload["UserId"].ToString();
             return permissionsObj;
         }

--- a/Backend/Services/ProjectApiServices.cs
+++ b/Backend/Services/ProjectApiServices.cs
@@ -28,7 +28,7 @@ namespace BackendFramework.Services
         /// <returns> A bool: success of operation </returns>
         public async Task<bool> DeleteAllProjects()
         {
-            DeleteResult deleted = await _projectDatabase.Projects.DeleteManyAsync(_ => true);
+            var deleted = await _projectDatabase.Projects.DeleteManyAsync(_ => true);
             return deleted.DeletedCount != 0;
         }
 
@@ -55,7 +55,7 @@ namespace BackendFramework.Services
         /// <returns> A bool: success of operation </returns>
         public async Task<bool> Delete(string projectId)
         {
-            DeleteResult deleted = await _projectDatabase.Projects.DeleteOneAsync(x => x.Id == projectId);
+            var deleted = await _projectDatabase.Projects.DeleteOneAsync(x => x.Id == projectId);
             return deleted.DeletedCount > 0;
         }
 
@@ -65,7 +65,7 @@ namespace BackendFramework.Services
         {
             var filter = Builders<Project>.Filter.Eq(x => x.Id, projectId);
 
-            //Note: Nulls out values not in update body
+            // Note: Nulls out values not in update body
             var updateDef = Builders<Project>.Update
                 .Set(x => x.Name, project.Name)
                 .Set(x => x.SemanticDomains, project.SemanticDomains)
@@ -78,7 +78,7 @@ namespace BackendFramework.Services
                 .Set(x => x.PartsOfSpeech, project.PartsOfSpeech)
                 .Set(x => x.AutocompleteSetting, project.AutocompleteSetting);
 
-            UpdateResult updateResult = await _projectDatabase.Projects.UpdateOneAsync(filter, updateDef);
+            var updateResult = await _projectDatabase.Projects.UpdateOneAsync(filter, updateDef);
 
             if (!updateResult.IsAcknowledged)
             {
@@ -97,7 +97,7 @@ namespace BackendFramework.Services
         public bool CanImportLift(string projectId)
         {
             var util = new Utilities();
-            string currentPath = util.GenerateFilePath(
+            var currentPath = util.GenerateFilePath(
                 Utilities.FileType.Dir, true, "", Path.Combine(projectId, "Import"));
             var zips = new List<string>(Directory.GetFiles(currentPath, "*.zip"));
             return zips.Count == 0;

--- a/Backend/Services/ProjectApiServices.cs
+++ b/Backend/Services/ProjectApiServices.cs
@@ -28,12 +28,8 @@ namespace BackendFramework.Services
         /// <returns> A bool: success of operation </returns>
         public async Task<bool> DeleteAllProjects()
         {
-            var deleted = await _projectDatabase.Projects.DeleteManyAsync(_ => true);
-            if (deleted.DeletedCount != 0)
-            {
-                return true;
-            }
-            return false;
+            DeleteResult deleted = await _projectDatabase.Projects.DeleteManyAsync(_ => true);
+            return deleted.DeletedCount != 0;
         }
 
         /// <summary> Finds <see cref="Project"/> with specified projectId </summary>
@@ -59,7 +55,7 @@ namespace BackendFramework.Services
         /// <returns> A bool: success of operation </returns>
         public async Task<bool> Delete(string projectId)
         {
-            var deleted = await _projectDatabase.Projects.DeleteOneAsync(x => x.Id == projectId);
+            DeleteResult deleted = await _projectDatabase.Projects.DeleteOneAsync(x => x.Id == projectId);
             return deleted.DeletedCount > 0;
         }
 
@@ -67,7 +63,7 @@ namespace BackendFramework.Services
         /// <returns> A <see cref="ResultOfUpdate"/> enum: success of operation </returns>
         public async Task<ResultOfUpdate> Update(string projectId, Project project)
         {
-            FilterDefinition<Project> filter = Builders<Project>.Filter.Eq(x => x.Id, projectId);
+            var filter = Builders<Project>.Filter.Eq(x => x.Id, projectId);
 
             //Note: Nulls out values not in update body
             var updateDef = Builders<Project>.Update
@@ -82,7 +78,7 @@ namespace BackendFramework.Services
                 .Set(x => x.PartsOfSpeech, project.PartsOfSpeech)
                 .Set(x => x.AutocompleteSetting, project.AutocompleteSetting);
 
-            var updateResult = await _projectDatabase.Projects.UpdateOneAsync(filter, updateDef);
+            UpdateResult updateResult = await _projectDatabase.Projects.UpdateOneAsync(filter, updateDef);
 
             if (!updateResult.IsAcknowledged)
             {
@@ -100,8 +96,9 @@ namespace BackendFramework.Services
 
         public bool CanImportLift(string projectId)
         {
-            Utilities util = new Utilities();
-            var currentPath = util.GenerateFilePath(Utilities.Filetype.dir, true, "", Path.Combine(projectId, "Import"));
+            var util = new Utilities();
+            string currentPath = util.GenerateFilePath(
+                Utilities.Filetype.dir, true, "", Path.Combine(projectId, "Import"));
             var zips = new List<string>(Directory.GetFiles(currentPath, "*.zip"));
             return zips.Count == 0;
         }

--- a/Backend/Services/ProjectApiServices.cs
+++ b/Backend/Services/ProjectApiServices.cs
@@ -98,7 +98,7 @@ namespace BackendFramework.Services
         {
             var util = new Utilities();
             string currentPath = util.GenerateFilePath(
-                Utilities.Filetype.dir, true, "", Path.Combine(projectId, "Import"));
+                Utilities.FileType.Dir, true, "", Path.Combine(projectId, "Import"));
             var zips = new List<string>(Directory.GetFiles(currentPath, "*.zip"));
             return zips.Count == 0;
         }

--- a/Backend/Services/ProjectApiServices.cs
+++ b/Backend/Services/ProjectApiServices.cs
@@ -5,6 +5,7 @@ using MongoDB.Driver;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace BackendFramework.Services
 {

--- a/Backend/Services/ProjectApiServices.cs
+++ b/Backend/Services/ProjectApiServices.cs
@@ -1,10 +1,10 @@
-using BackendFramework.Helper;
-using BackendFramework.Interfaces;
-using MongoDB.Driver;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using BackendFramework.Helper;
+using BackendFramework.Interfaces;
 using BackendFramework.Models;
+using MongoDB.Driver;
 
 namespace BackendFramework.Services
 {

--- a/Backend/Services/ProjectApiServices.cs
+++ b/Backend/Services/ProjectApiServices.cs
@@ -1,6 +1,5 @@
 using BackendFramework.Helper;
 using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using MongoDB.Driver;
 using System.Collections.Generic;
 using System.IO;

--- a/Backend/Services/SemDomParser.cs
+++ b/Backend/Services/SemDomParser.cs
@@ -1,7 +1,7 @@
-using BackendFramework.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using BackendFramework.Interfaces;
 using BackendFramework.Models;
 
 namespace BackendFramework.Services

--- a/Backend/Services/SemDomParser.cs
+++ b/Backend/Services/SemDomParser.cs
@@ -1,5 +1,4 @@
 using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/Backend/Services/SemDomParser.cs
+++ b/Backend/Services/SemDomParser.cs
@@ -3,6 +3,7 @@ using BackendFramework.ValueModels;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace BackendFramework.Services
 {

--- a/Backend/Services/SemDomParser.cs
+++ b/Backend/Services/SemDomParser.cs
@@ -21,7 +21,7 @@ namespace BackendFramework.Services
         public async Task<List<SemanticDomainWithSubdomains>> ParseSemanticDomains(string projectId)
         {
             // Ensure project exists
-            Project proj = await _projectService.GetProject(projectId);
+            var proj = await _projectService.GetProject(projectId);
             if (proj == null)
             {
                 throw new Exception("Project not found");
@@ -40,9 +40,9 @@ namespace BackendFramework.Services
             var sdOfShortLengthList = new List<SemanticDomainWithSubdomains>();
             var sdOfLongLengthList = new List<SemanticDomainWithSubdomains>();
             var returnList = new List<SemanticDomainWithSubdomains>();
-            int length = sdList[0].Id.Length;
+            var length = sdList[0].Id.Length;
 
-            foreach (SemanticDomain sd in sdList)
+            foreach (var sd in sdList)
             {
                 if (sd.Id.Length != length)
                 {
@@ -68,7 +68,7 @@ namespace BackendFramework.Services
                 // If there are any, find short length semdom with same preceding number and add to children
                 if (sdOfShortLengthList.Count != 0)
                 {
-                    foreach (SemanticDomainWithSubdomains shortSd in sdOfShortLengthList)
+                    foreach (var shortSd in sdOfShortLengthList)
                     {
                         if (sd.Id.StartsWith(shortSd.Id))
                         {
@@ -86,7 +86,7 @@ namespace BackendFramework.Services
         {
             public int Compare(SemanticDomain x, SemanticDomain y)
             {
-                int lengthComparison = x.Id.Length.CompareTo(y.Id.Length);
+                var lengthComparison = x.Id.Length.CompareTo(y.Id.Length);
                 if (lengthComparison == 0)
                 {
                     return x.Id.CompareTo(y.Id);

--- a/Backend/Services/SemDomParser.cs
+++ b/Backend/Services/SemDomParser.cs
@@ -16,24 +16,25 @@ namespace BackendFramework.Services
             _projectService = projectService;
         }
 
-        /// <summary> Return <see cref="SemanticDomainWithSubdomains"/> object from a <see cref="SemanticDomain"/> list of a <see cref="Project"/> </summary>
+        /// <summary> Return <see cref="SemanticDomainWithSubdomains"/> object from a
+        /// <see cref="SemanticDomain"/> list of a <see cref="Project"/> </summary>
         public async Task<List<SemanticDomainWithSubdomains>> ParseSemanticDomains(string projectId)
         {
-            //ensure project exists
-            var proj = await _projectService.GetProject(projectId);
+            // Ensure project exists
+            Project proj = await _projectService.GetProject(projectId);
             if (proj == null)
             {
                 throw new Exception("Project not found");
             }
 
-            //ensure semantic domains exist
+            // Ensure semantic domains exist
             var sdList = proj.SemanticDomains;
             if (sdList.Count == 0)
             {
                 throw new Exception("No semantic domains found");
             }
 
-            //get list in nesting order
+            // Get list in nesting order
             sdList.Sort(new SemDomComparer());
 
             var sdOfShortLengthList = new List<SemanticDomainWithSubdomains>();
@@ -41,33 +42,33 @@ namespace BackendFramework.Services
             var returnList = new List<SemanticDomainWithSubdomains>();
             int length = sdList[0].Id.Length;
 
-            foreach (var sd in sdList)
+            foreach (SemanticDomain sd in sdList)
             {
                 if (sd.Id.Length != length)
                 {
-                    //add base level of semdom once we have hit the first entry of subdomains
+                    // Add base level of semdom once we have hit the first entry of subdomains
                     if (length == 3)
                     {
                         returnList.AddRange(sdOfShortLengthList);
                     }
 
-                    //change tree depth level, eg. 1.1 to 1.1.1
+                    // Change tree depth level, eg. 1.1 to 1.1.1
                     length += 2;
 
-                    //replace short length list with long length
+                    // Replace short length list with long length
                     sdOfShortLengthList.Clear();
                     sdOfShortLengthList.AddRange(sdOfLongLengthList);
                     sdOfLongLengthList.Clear();
                 }
 
-                //transform semdom type and keep track of it
+                // Transform semdom type and keep track of it
                 var sdToAdd = new SemanticDomainWithSubdomains(sd);
                 sdOfLongLengthList.Add(sdToAdd);
 
-                //if there are any, find short length semdom with same preceding number and add to children
+                // If there are any, find short length semdom with same preceding number and add to children
                 if (sdOfShortLengthList.Count != 0)
                 {
-                    foreach (var shortSd in sdOfShortLengthList)
+                    foreach (SemanticDomainWithSubdomains shortSd in sdOfShortLengthList)
                     {
                         if (sd.Id.StartsWith(shortSd.Id))
                         {

--- a/Backend/Services/UserApiServices.cs
+++ b/Backend/Services/UserApiServices.cs
@@ -64,10 +64,10 @@ namespace BackendFramework.Services
             }
 
             // Authentication successful so generate jwt token
-            return await MakeJWT(foundUser);
+            return await MakeJwt(foundUser);
         }
 
-        public async Task<User> MakeJWT(User user)
+        public async Task<User> MakeJwt(User user)
         {
             const int tokenExpirationMinutes = 60 * 4;
             var tokenHandler = new JwtSecurityTokenHandler();

--- a/Backend/Services/UserApiServices.cs
+++ b/Backend/Services/UserApiServices.cs
@@ -1,7 +1,3 @@
-using BackendFramework.Interfaces;
-using Microsoft.IdentityModel.Tokens;
-using MongoDB.Bson;
-using MongoDB.Driver;
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
@@ -10,7 +6,11 @@ using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
+using BackendFramework.Interfaces;
 using BackendFramework.Models;
+using Microsoft.IdentityModel.Tokens;
+using MongoDB.Bson;
+using MongoDB.Driver;
 
 namespace BackendFramework.Services
 {

--- a/Backend/Services/UserApiServices.cs
+++ b/Backend/Services/UserApiServices.cs
@@ -17,6 +17,9 @@ namespace BackendFramework.Services
     /// <summary> All application logic for <see cref="User"/>s </summary>
     public class UserService : IUserService
     {
+        private const int SaltLength = 16;
+        private const int HashLength = 20;
+
         private readonly IUserContext _userDatabase;
         private readonly IUserRoleService _userRole;
 
@@ -30,38 +33,37 @@ namespace BackendFramework.Services
         /// <returns> User when credentials are correct, null otherwise </returns>
         public async Task<User> Authenticate(string username, string password)
         {
-            //fetch the stored user
+            // Fetch the stored user
             var userList = await _userDatabase.Users.FindAsync(x => x.Username == username);
             User foundUser = userList.FirstOrDefault();
 
-            //return null if user wtih specified username not found
+            // Return null if user with specified username not found
             if (foundUser == null)
             {
                 return null;
             }
 
-            int saltLength = 16;
-            int hashLength = 20;
 
-            //extract the bytes from password
-            byte[] hashBytes = Convert.FromBase64String(foundUser.Password);
-            //get the salt from the first part of stored value
-            byte[] salt = new byte[saltLength];
-            Array.Copy(hashBytes, 0, salt, 0, saltLength);
-            //compute the hash on the password the user entered
+
+            // Extract the bytes from password
+            var hashBytes = Convert.FromBase64String(foundUser.Password);
+            // Get the salt from the first part of stored value
+            var salt = new byte[SaltLength];
+            Array.Copy(hashBytes, 0, salt, 0, SaltLength);
+            // Compute the hash on the password the user entered
             var rfc = new Rfc2898DeriveBytes(password, salt, 10000);
-            byte[] hash = rfc.GetBytes(hashLength);
+            var hash = rfc.GetBytes(HashLength);
 
-            //check if the password given to us matches the hash we have stored (after the salt)
-            for (int i = 0; i < hashLength; i++)
+            // Check if the password given to us matches the hash we have stored (after the salt)
+            for (var i = 0; i < HashLength; i++)
             {
-                if (hashBytes[i + saltLength] != hash[i])
+                if (hashBytes[i + SaltLength] != hash[i])
                 {
                     return null;
                 }
             }
 
-            // authentication successful so generate jwt token
+            // Authentication successful so generate jwt token
             return await MakeJWT(foundUser);
         }
 
@@ -69,22 +71,21 @@ namespace BackendFramework.Services
         {
             const int tokenExpirationMinutes = 60 * 4;
             var tokenHandler = new JwtSecurityTokenHandler();
-            var secretKey = Environment.GetEnvironmentVariable("ASPNETCORE_JWT_SECRET_KEY");
+            string secretKey = Environment.GetEnvironmentVariable("ASPNETCORE_JWT_SECRET_KEY");
             var key = Encoding.ASCII.GetBytes(secretKey);
 
-            //fetch the projects Id and the roles for each Id
-            List<ProjectPermissions> projectPermissionMap = new List<ProjectPermissions>();
+            // Fetch the projects Id and the roles for each Id
+            var projectPermissionMap = new List<ProjectPermissions>();
 
             foreach (var projectRolePair in user.ProjectRoles)
             {
-                //convert each userRoleId to its respective role and add to the mapping
+                // Convert each userRoleId to its respective role and add to the mapping
                 var permissions = _userRole.GetUserRole(projectRolePair.Key, projectRolePair.Value).Result.Permissions;
                 var validEntry = new ProjectPermissions(projectRolePair.Key, permissions);
                 projectPermissionMap.Add(validEntry);
             }
 
-            var claimString = projectPermissionMap.ToJson();
-
+            string claimString = projectPermissionMap.ToJson();
             var tokenDescriptor = new SecurityTokenDescriptor
             {
                 Subject = new ClaimsIdentity(new Claim[]
@@ -95,9 +96,10 @@ namespace BackendFramework.Services
 
                 Expires = DateTime.UtcNow.AddMinutes(tokenExpirationMinutes),
 
-                SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
+                SigningCredentials = new SigningCredentials(
+                    new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
             };
-            var token = tokenHandler.CreateToken(tokenDescriptor);
+            SecurityToken token = tokenHandler.CreateToken(tokenDescriptor);
             user.Token = tokenHandler.WriteToken(token);
 
             if (await Update(user.Id, user) != ResultOfUpdate.Updated)
@@ -105,7 +107,7 @@ namespace BackendFramework.Services
                 return null;
             }
 
-            // remove password and avatar filepath before returning
+            // Remove password and avatar filepath before returning
             user.Password = "";
             user.Avatar = "";
 
@@ -123,12 +125,8 @@ namespace BackendFramework.Services
         /// <returns> A bool: success of operation </returns>
         public async Task<bool> DeleteAllUsers()
         {
-            var deleted = await _userDatabase.Users.DeleteManyAsync(_ => true);
-            if (deleted.DeletedCount != 0)
-            {
-                return true;
-            }
-            return false;
+            DeleteResult deleted = await _userDatabase.Users.DeleteManyAsync(_ => true);
+            return deleted.DeletedCount != 0;
         }
 
         /// <summary> Finds <see cref="User"/> with specified userId </summary>
@@ -154,7 +152,7 @@ namespace BackendFramework.Services
 
             var userList = await _userDatabase.Users.FindAsync(filter);
 
-            var user = userList.FirstOrDefault();
+            User user = userList.FirstOrDefault();
             return string.IsNullOrEmpty(user?.Avatar) ? null : user.Avatar;
         }
 
@@ -166,28 +164,26 @@ namespace BackendFramework.Services
             var users = await GetAllUsers();
 
             //check to see if username or email address is taken
-            if (users.Count != 0 && _userDatabase.Users.Find(x => (x.Username == user.Username || x.Email == user.Email)).ToList().Count > 0)
+            if (users.Count != 0 && _userDatabase.Users.Find(
+                x => (x.Username == user.Username || x.Email == user.Email)).ToList().Count > 0)
             {
                 return null;
             }
 
-            int saltLength = 16;
-            int hashLength = 20;
-
-            //create cryptographically-secure randomized salt 
+            // Create cryptographically-secure randomized salt
             byte[] salt;
-            new RNGCryptoServiceProvider().GetBytes(salt = new byte[saltLength]);
+            new RNGCryptoServiceProvider().GetBytes(salt = new byte[SaltLength]);
 
-            //hash the password along with the salt
+            // Hash the password along with the salt
             var pbkdf2 = new Rfc2898DeriveBytes(user.Password, salt, 10000);
-            byte[] hash = pbkdf2.GetBytes(20);
+            var hash = pbkdf2.GetBytes(20);
 
-            //combine salt and hashed password for storage
-            byte[] hashBytes = new byte[saltLength + hashLength];
-            Array.Copy(salt, 0, hashBytes, 0, saltLength);
-            Array.Copy(hash, 0, hashBytes, saltLength, hashLength);
+            // Combine salt and hashed password for storage
+            var hashBytes = new byte[SaltLength + HashLength];
+            Array.Copy(salt, 0, hashBytes, 0, SaltLength);
+            Array.Copy(hash, 0, hashBytes, SaltLength, HashLength);
 
-            //replace pasword with hashed password
+            // Replace password with hashed password
             user.Password = Convert.ToBase64String(hashBytes);
             await _userDatabase.Users.InsertOneAsync(user);
             user.Password = "";
@@ -200,7 +196,7 @@ namespace BackendFramework.Services
         /// <returns> A bool: success of operation </returns>
         public async Task<bool> Delete(string userId)
         {
-            var deleted = await _userDatabase.Users.DeleteOneAsync(x => x.Id == userId);
+            DeleteResult deleted = await _userDatabase.Users.DeleteOneAsync(x => x.Id == userId);
             return deleted.DeletedCount > 0;
         }
 
@@ -208,9 +204,9 @@ namespace BackendFramework.Services
         /// <returns> A <see cref="ResultOfUpdate"/> enum: success of operation </returns>
         public async Task<ResultOfUpdate> Update(string userId, User user)
         {
-            FilterDefinition<User> filter = Builders<User>.Filter.Eq(x => x.Id, userId);
+            var filter = Builders<User>.Filter.Eq(x => x.Id, userId);
 
-            //Note: Nulls out values not in update body
+            // Note: Nulls out values not in update body
             var updateDef = Builders<User>.Update
                 .Set(x => x.Name, user.Name)
                 .Set(x => x.Email, user.Email)

--- a/Backend/Services/UserApiServices.cs
+++ b/Backend/Services/UserApiServices.cs
@@ -43,8 +43,6 @@ namespace BackendFramework.Services
                 return null;
             }
 
-
-
             // Extract the bytes from password
             var hashBytes = Convert.FromBase64String(foundUser.Password);
             // Get the salt from the first part of stored value

--- a/Backend/Services/UserApiServices.cs
+++ b/Backend/Services/UserApiServices.cs
@@ -1,5 +1,4 @@
 using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using Microsoft.IdentityModel.Tokens;
 using MongoDB.Bson;
 using MongoDB.Driver;
@@ -11,6 +10,7 @@ using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace BackendFramework.Services
 {

--- a/Backend/Services/UserApiServices.cs
+++ b/Backend/Services/UserApiServices.cs
@@ -35,7 +35,7 @@ namespace BackendFramework.Services
         {
             // Fetch the stored user
             var userList = await _userDatabase.Users.FindAsync(x => x.Username == username);
-            User foundUser = userList.FirstOrDefault();
+            var foundUser = userList.FirstOrDefault();
 
             // Return null if user with specified username not found
             if (foundUser == null)
@@ -69,7 +69,7 @@ namespace BackendFramework.Services
         {
             const int tokenExpirationMinutes = 60 * 4;
             var tokenHandler = new JwtSecurityTokenHandler();
-            string secretKey = Environment.GetEnvironmentVariable("ASPNETCORE_JWT_SECRET_KEY");
+            var secretKey = Environment.GetEnvironmentVariable("ASPNETCORE_JWT_SECRET_KEY");
             var key = Encoding.ASCII.GetBytes(secretKey);
 
             // Fetch the projects Id and the roles for each Id
@@ -83,7 +83,7 @@ namespace BackendFramework.Services
                 projectPermissionMap.Add(validEntry);
             }
 
-            string claimString = projectPermissionMap.ToJson();
+            var claimString = projectPermissionMap.ToJson();
             var tokenDescriptor = new SecurityTokenDescriptor
             {
                 Subject = new ClaimsIdentity(new Claim[]
@@ -97,7 +97,7 @@ namespace BackendFramework.Services
                 SigningCredentials = new SigningCredentials(
                     new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
             };
-            SecurityToken token = tokenHandler.CreateToken(tokenDescriptor);
+            var token = tokenHandler.CreateToken(tokenDescriptor);
             user.Token = tokenHandler.WriteToken(token);
 
             if (await Update(user.Id, user) != ResultOfUpdate.Updated)
@@ -123,7 +123,7 @@ namespace BackendFramework.Services
         /// <returns> A bool: success of operation </returns>
         public async Task<bool> DeleteAllUsers()
         {
-            DeleteResult deleted = await _userDatabase.Users.DeleteManyAsync(_ => true);
+            var deleted = await _userDatabase.Users.DeleteManyAsync(_ => true);
             return deleted.DeletedCount != 0;
         }
 
@@ -149,8 +149,7 @@ namespace BackendFramework.Services
             var filter = filterDef.Eq(x => x.Id, userId);
 
             var userList = await _userDatabase.Users.FindAsync(filter);
-
-            User user = userList.FirstOrDefault();
+            var user = userList.FirstOrDefault();
             return string.IsNullOrEmpty(user?.Avatar) ? null : user.Avatar;
         }
 
@@ -158,10 +157,10 @@ namespace BackendFramework.Services
         /// <returns> The user created </returns>
         public async Task<User> Create(User user)
         {
-            //check if collection is not empty
+            // Check if collection is not empty
             var users = await GetAllUsers();
 
-            //check to see if username or email address is taken
+            // Check to see if username or email address is taken
             if (users.Count != 0 && _userDatabase.Users.Find(
                 x => (x.Username == user.Username || x.Email == user.Email)).ToList().Count > 0)
             {
@@ -194,7 +193,7 @@ namespace BackendFramework.Services
         /// <returns> A bool: success of operation </returns>
         public async Task<bool> Delete(string userId)
         {
-            DeleteResult deleted = await _userDatabase.Users.DeleteOneAsync(x => x.Id == userId);
+            var deleted = await _userDatabase.Users.DeleteOneAsync(x => x.Id == userId);
             return deleted.DeletedCount > 0;
         }
 

--- a/Backend/Services/UserEditApiServices.cs
+++ b/Backend/Services/UserEditApiServices.cs
@@ -19,21 +19,21 @@ namespace BackendFramework.Services
         /// <returns> Tuple of a bool: success of operation and int: index at which the new edit was placed </returns>
         public async Task<Tuple<bool, int>> AddGoalToUserEdit(string projectId, string userEditId, Edit edit)
         {
-            //get userEdit to change
-            var userEntry = await _repo.GetUserEdit(projectId, userEditId);
+            // Get userEdit to change
+            UserEdit userEntry = await _repo.GetUserEdit(projectId, userEditId);
             UserEdit newUserEdit = userEntry.Clone();
 
-            //add the new goal index to Edits list
+            // Add the new goal index to Edits list
             newUserEdit.Edits.Add(edit);
 
-            //replace the old UserEdit object with the new one that contains the new list entry
+            // Replace the old UserEdit object with the new one that contains the new list entry
             bool replaceSucceeded = _repo.Replace(projectId, userEditId, newUserEdit).Result;
 
             int indexOfNewestEdit = -1;
 
             if (replaceSucceeded)
             {
-                var newestEdit = _repo.GetUserEdit(projectId, userEditId).Result;
+                UserEdit newestEdit = _repo.GetUserEdit(projectId, userEditId).Result;
                 indexOfNewestEdit = newestEdit.Edits.Count - 1;
             }
 

--- a/Backend/Services/UserEditApiServices.cs
+++ b/Backend/Services/UserEditApiServices.cs
@@ -20,20 +20,18 @@ namespace BackendFramework.Services
         public async Task<Tuple<bool, int>> AddGoalToUserEdit(string projectId, string userEditId, Edit edit)
         {
             // Get userEdit to change
-            UserEdit userEntry = await _repo.GetUserEdit(projectId, userEditId);
-            UserEdit newUserEdit = userEntry.Clone();
+            var userEntry = await _repo.GetUserEdit(projectId, userEditId);
+            var newUserEdit = userEntry.Clone();
 
             // Add the new goal index to Edits list
             newUserEdit.Edits.Add(edit);
 
             // Replace the old UserEdit object with the new one that contains the new list entry
-            bool replaceSucceeded = _repo.Replace(projectId, userEditId, newUserEdit).Result;
-
-            int indexOfNewestEdit = -1;
-
+            var replaceSucceeded = _repo.Replace(projectId, userEditId, newUserEdit).Result;
+            var indexOfNewestEdit = -1;
             if (replaceSucceeded)
             {
-                UserEdit newestEdit = _repo.GetUserEdit(projectId, userEditId).Result;
+                var newestEdit = _repo.GetUserEdit(projectId, userEditId).Result;
                 indexOfNewestEdit = newestEdit.Edits.Count - 1;
             }
 
@@ -44,13 +42,10 @@ namespace BackendFramework.Services
         /// <returns> A bool: success of operation </returns>
         public async Task<bool> AddStepToGoal(string projectId, string userEditId, int goalIndex, string userEdit)
         {
-            UserEdit addUserEdit = await _repo.GetUserEdit(projectId, userEditId);
-            UserEdit newUserEdit = addUserEdit.Clone();
-
+            var addUserEdit = await _repo.GetUserEdit(projectId, userEditId);
+            var newUserEdit = addUserEdit.Clone();
             newUserEdit.Edits[goalIndex].StepData.Add(userEdit);
-
-            bool updateResult = _repo.Replace(projectId, userEditId, newUserEdit).Result;
-
+            var updateResult = _repo.Replace(projectId, userEditId, newUserEdit).Result;
             return updateResult;
         }
     }

--- a/Backend/Services/UserEditApiServices.cs
+++ b/Backend/Services/UserEditApiServices.cs
@@ -1,7 +1,7 @@
 using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using System;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace BackendFramework.Services
 {

--- a/Backend/Services/UserEditApiServices.cs
+++ b/Backend/Services/UserEditApiServices.cs
@@ -52,7 +52,6 @@ namespace BackendFramework.Services
             bool updateResult = _repo.Replace(projectId, userEditId, newUserEdit).Result;
 
             return updateResult;
-
         }
     }
 }

--- a/Backend/Services/UserEditApiServices.cs
+++ b/Backend/Services/UserEditApiServices.cs
@@ -1,6 +1,6 @@
-using BackendFramework.Interfaces;
 using System;
 using System.Threading.Tasks;
+using BackendFramework.Interfaces;
 using BackendFramework.Models;
 
 namespace BackendFramework.Services

--- a/Backend/Services/UserEditRepository.cs
+++ b/Backend/Services/UserEditRepository.cs
@@ -1,5 +1,4 @@
 using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using MongoDB.Driver;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/Backend/Services/UserEditRepository.cs
+++ b/Backend/Services/UserEditRepository.cs
@@ -26,19 +26,16 @@ namespace BackendFramework.Services
         /// <returns> A bool: success of operation </returns>
         public async Task<bool> DeleteAllUserEdits(string projectId)
         {
-            var deleted = await _userEditDatabase.UserEdits.DeleteManyAsync(u => u.ProjectId == projectId);
-            if (deleted.DeletedCount != 0)
-            {
-                return true;
-            }
-            return false;
+            DeleteResult deleted = await _userEditDatabase.UserEdits.DeleteManyAsync(u => u.ProjectId == projectId);
+            return deleted.DeletedCount != 0;
         }
 
         /// <summary> Finds <see cref="UserEdit"/> with specified userRoleId and projectId </summary>
         public async Task<UserEdit> GetUserEdit(string projectId, string userEditId)
         {
             var filterDef = new FilterDefinitionBuilder<UserEdit>();
-            var filter = filterDef.And(filterDef.Eq(x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, userEditId));
+            var filter = filterDef.And(filterDef.Eq(
+                x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, userEditId));
 
             var userEditList = await _userEditDatabase.UserEdits.FindAsync(filter);
 
@@ -58,7 +55,8 @@ namespace BackendFramework.Services
         public async Task<bool> Delete(string projectId, string userEditId)
         {
             var filterDef = new FilterDefinitionBuilder<UserEdit>();
-            var filter = filterDef.And(filterDef.Eq(x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, userEditId));
+            var filter = filterDef.And(filterDef.Eq(
+                x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, userEditId));
 
             var deleted = await _userEditDatabase.UserEdits.DeleteOneAsync(filter);
             return deleted.DeletedCount > 0;
@@ -69,7 +67,8 @@ namespace BackendFramework.Services
         public async Task<bool> Replace(string projectId, string userEditId, UserEdit userEdit)
         {
             var filterDef = new FilterDefinitionBuilder<UserEdit>();
-            var filter = filterDef.And(filterDef.Eq(x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, userEditId));
+            var filter = filterDef.And(filterDef.Eq(
+                x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, userEditId));
 
             var result = await _userEditDatabase.UserEdits.ReplaceOneAsync(filter, userEdit);
             return result.IsAcknowledged && result.ModifiedCount == 1;

--- a/Backend/Services/UserEditRepository.cs
+++ b/Backend/Services/UserEditRepository.cs
@@ -26,7 +26,7 @@ namespace BackendFramework.Services
         /// <returns> A bool: success of operation </returns>
         public async Task<bool> DeleteAllUserEdits(string projectId)
         {
-            DeleteResult deleted = await _userEditDatabase.UserEdits.DeleteManyAsync(u => u.ProjectId == projectId);
+            var deleted = await _userEditDatabase.UserEdits.DeleteManyAsync(u => u.ProjectId == projectId);
             return deleted.DeletedCount != 0;
         }
 
@@ -70,7 +70,7 @@ namespace BackendFramework.Services
             var filter = filterDef.And(filterDef.Eq(
                 x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, userEditId));
 
-            ReplaceOneResult result = await _userEditDatabase.UserEdits.ReplaceOneAsync(filter, userEdit);
+            var result = await _userEditDatabase.UserEdits.ReplaceOneAsync(filter, userEdit);
             return result.IsAcknowledged && result.ModifiedCount == 1;
         }
     }

--- a/Backend/Services/UserEditRepository.cs
+++ b/Backend/Services/UserEditRepository.cs
@@ -1,8 +1,8 @@
-using BackendFramework.Interfaces;
-using MongoDB.Driver;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using BackendFramework.Interfaces;
 using BackendFramework.Models;
+using MongoDB.Driver;
 
 namespace BackendFramework.Services
 {

--- a/Backend/Services/UserEditRepository.cs
+++ b/Backend/Services/UserEditRepository.cs
@@ -51,7 +51,7 @@ namespace BackendFramework.Services
         }
 
         /// <summary> Removes <see cref="UserEdit"/> with specified userRoleId and projectId </summary>
-        /// <returns> A bool: sucess of operation </returns>
+        /// <returns> A bool: success of operation </returns>
         public async Task<bool> Delete(string projectId, string userEditId)
         {
             var filterDef = new FilterDefinitionBuilder<UserEdit>();
@@ -70,7 +70,7 @@ namespace BackendFramework.Services
             var filter = filterDef.And(filterDef.Eq(
                 x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, userEditId));
 
-            var result = await _userEditDatabase.UserEdits.ReplaceOneAsync(filter, userEdit);
+            ReplaceOneResult result = await _userEditDatabase.UserEdits.ReplaceOneAsync(filter, userEdit);
             return result.IsAcknowledged && result.ModifiedCount == 1;
         }
     }

--- a/Backend/Services/UserEditRepository.cs
+++ b/Backend/Services/UserEditRepository.cs
@@ -3,6 +3,7 @@ using BackendFramework.ValueModels;
 using MongoDB.Driver;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace BackendFramework.Services
 {

--- a/Backend/Services/UserRoleApiServices.cs
+++ b/Backend/Services/UserRoleApiServices.cs
@@ -1,5 +1,4 @@
 using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using MongoDB.Driver;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/Backend/Services/UserRoleApiServices.cs
+++ b/Backend/Services/UserRoleApiServices.cs
@@ -26,12 +26,8 @@ namespace BackendFramework.Services
         /// <returns> A bool: success of operation </returns>
         public async Task<bool> DeleteAllUserRoles(string projectId)
         {
-            var deleted = await _userRoleDatabase.UserRoles.DeleteManyAsync(u => u.ProjectId == projectId);
-            if (deleted.DeletedCount != 0)
-            {
-                return true;
-            }
-            return false;
+            DeleteResult deleted = await _userRoleDatabase.UserRoles.DeleteManyAsync(u => u.ProjectId == projectId);
+            return deleted.DeletedCount != 0;
         }
 
         /// <summary> Finds <see cref="UserRole"/> with specified userRoleId and projectId </summary>
@@ -58,9 +54,10 @@ namespace BackendFramework.Services
         public async Task<bool> Delete(string projectId, string userRoleId)
         {
             var filterDef = new FilterDefinitionBuilder<UserRole>();
-            var filter = filterDef.And(filterDef.Eq(x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, userRoleId));
+            var filter = filterDef.And(filterDef.Eq(
+                x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, userRoleId));
 
-            var deleted = await _userRoleDatabase.UserRoles.DeleteOneAsync(filter);
+            DeleteResult deleted = await _userRoleDatabase.UserRoles.DeleteOneAsync(filter);
             return deleted.DeletedCount > 0;
         }
 
@@ -68,11 +65,10 @@ namespace BackendFramework.Services
         /// <returns> A <see cref="ResultOfUpdate"/> enum: success of operation </returns>
         public async Task<ResultOfUpdate> Update(string userRoleId, UserRole userRole)
         {
-            FilterDefinition<UserRole> filter = Builders<UserRole>.Filter.Eq(x => x.Id, userRoleId);
-
-            var updateDef = Builders<UserRole>.Update.Set(x => x.Permissions, userRole.Permissions);
-
-            var updateResult = await _userRoleDatabase.UserRoles.UpdateOneAsync(filter, updateDef);
+            var filter = Builders<UserRole>.Filter.Eq(x => x.Id, userRoleId);
+            var updateDef = Builders<UserRole>.Update.Set(
+                x => x.Permissions, userRole.Permissions);
+            UpdateResult updateResult = await _userRoleDatabase.UserRoles.UpdateOneAsync(filter, updateDef);
 
             if (!updateResult.IsAcknowledged)
             {

--- a/Backend/Services/UserRoleApiServices.cs
+++ b/Backend/Services/UserRoleApiServices.cs
@@ -1,8 +1,8 @@
-using BackendFramework.Interfaces;
-using MongoDB.Driver;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using BackendFramework.Interfaces;
 using BackendFramework.Models;
+using MongoDB.Driver;
 
 namespace BackendFramework.Services
 {

--- a/Backend/Services/UserRoleApiServices.cs
+++ b/Backend/Services/UserRoleApiServices.cs
@@ -26,7 +26,7 @@ namespace BackendFramework.Services
         /// <returns> A bool: success of operation </returns>
         public async Task<bool> DeleteAllUserRoles(string projectId)
         {
-            DeleteResult deleted = await _userRoleDatabase.UserRoles.DeleteManyAsync(u => u.ProjectId == projectId);
+            var deleted = await _userRoleDatabase.UserRoles.DeleteManyAsync(u => u.ProjectId == projectId);
             return deleted.DeletedCount != 0;
         }
 
@@ -34,7 +34,8 @@ namespace BackendFramework.Services
         public async Task<UserRole> GetUserRole(string projectId, string userRoleId)
         {
             var filterDef = new FilterDefinitionBuilder<UserRole>();
-            var filter = filterDef.And(filterDef.Eq(x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, userRoleId));
+            var filter = filterDef.And(filterDef.Eq(
+                x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, userRoleId));
 
             var userRoleList = await _userRoleDatabase.UserRoles.FindAsync(filter);
 
@@ -57,7 +58,7 @@ namespace BackendFramework.Services
             var filter = filterDef.And(filterDef.Eq(
                 x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, userRoleId));
 
-            DeleteResult deleted = await _userRoleDatabase.UserRoles.DeleteOneAsync(filter);
+            var deleted = await _userRoleDatabase.UserRoles.DeleteOneAsync(filter);
             return deleted.DeletedCount > 0;
         }
 
@@ -68,7 +69,7 @@ namespace BackendFramework.Services
             var filter = Builders<UserRole>.Filter.Eq(x => x.Id, userRoleId);
             var updateDef = Builders<UserRole>.Update.Set(
                 x => x.Permissions, userRole.Permissions);
-            UpdateResult updateResult = await _userRoleDatabase.UserRoles.UpdateOneAsync(filter, updateDef);
+            var updateResult = await _userRoleDatabase.UserRoles.UpdateOneAsync(filter, updateDef);
 
             if (!updateResult.IsAcknowledged)
             {

--- a/Backend/Services/UserRoleApiServices.cs
+++ b/Backend/Services/UserRoleApiServices.cs
@@ -3,6 +3,7 @@ using BackendFramework.ValueModels;
 using MongoDB.Driver;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace BackendFramework.Services
 {

--- a/Backend/Services/WordApiServices.cs
+++ b/Backend/Services/WordApiServices.cs
@@ -1,9 +1,9 @@
-using BackendFramework.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using BackendFramework.Interfaces;
 using BackendFramework.Models;
 
 namespace BackendFramework.Services

--- a/Backend/Services/WordApiServices.cs
+++ b/Backend/Services/WordApiServices.cs
@@ -22,12 +22,12 @@ namespace BackendFramework.Services
         /// <returns> A bool: success of operation </returns>
         public async Task<bool> Delete(string projectId, string wordId)
         {
-            bool wordIsInFrontier = _repo.DeleteFrontier(projectId, wordId).Result;
+            var wordIsInFrontier = _repo.DeleteFrontier(projectId, wordId).Result;
 
             // We only want to add the deleted word if the word started in the frontier
             if (wordIsInFrontier)
             {
-                Word wordToDelete = _repo.GetWord(projectId, wordId).Result;
+                var wordToDelete = _repo.GetWord(projectId, wordId).Result;
                 wordToDelete.Id = "";
                 wordToDelete.History = new List<string>() { wordId };
 
@@ -46,7 +46,7 @@ namespace BackendFramework.Services
         /// <returns> A bool: success of operation </returns>
         public async Task<bool> Update(string projectId, string wordId, Word word)
         {
-            bool wordIsInFrontier = _repo.DeleteFrontier(projectId, wordId).Result;
+            var wordIsInFrontier = _repo.DeleteFrontier(projectId, wordId).Result;
 
             // We only want to update words that are in the frontier
             if (wordIsInFrontier)
@@ -77,14 +77,14 @@ namespace BackendFramework.Services
         {
             var newWordsList = new List<Word>();
 
-            Word addParent = mergeWords.Parent.Clone();
+            var addParent = mergeWords.Parent.Clone();
             addParent.History = new List<string>();
 
             // Generate new child words form child word field
-            foreach (MergeSourceWord newChildWordState in mergeWords.ChildrenWords)
+            foreach (var newChildWordState in mergeWords.ChildrenWords)
             {
                 // Get child word
-                Word currentChildWord = await _repo.GetWord(projectId, newChildWordState.SrcWordId);
+                var currentChildWord = await _repo.GetWord(projectId, newChildWordState.SrcWordId);
                 // Remove child from frontier
                 await _repo.DeleteFrontier(projectId, currentChildWord.Id);
 
@@ -103,10 +103,10 @@ namespace BackendFramework.Services
 
                 // Add child word to the database
                 currentChildWord.Id = "";
-                Word newChildWord = await _repo.Add(currentChildWord);
+                var newChildWord = await _repo.Add(currentChildWord);
 
                 // Handle different states
-                Word separateWord = currentChildWord.Clone();
+                var separateWord = currentChildWord.Clone();
                 separateWord.Senses = new List<Sense>();
                 separateWord.Id = "";
                 for (var i = 0; i < currentChildWord.Senses.Count; i++)
@@ -139,16 +139,15 @@ namespace BackendFramework.Services
                 if (separateWord.Senses.Count != 0)
                 {
                     separateWord.ProjectId = projectId;
-                    Word newSeparate = await _repo.Create(separateWord);
+                    var newSeparate = await _repo.Create(separateWord);
                     newWordsList.Add(newSeparate);
                 }
             }
 
             // Add parent with child history to the database
             addParent.ProjectId = projectId;
-            Word newParent = await _repo.Create(addParent);
+            var newParent = await _repo.Create(addParent);
             newWordsList.Insert(0, newParent);
-
             return newWordsList;
         }
 
@@ -165,16 +164,16 @@ namespace BackendFramework.Services
             var isUniqueWord = true;
 
             // Iterate over words with the same vernacular
-            foreach (Word matchingVern in allVernaculars)
+            foreach (var matchingVern in allVernaculars)
             {
                 // Iterate over senses of those words
-                foreach (Sense newSense in word.Senses)
+                foreach (var newSense in word.Senses)
                 {
                     var newSenseIndex = 0;
                     foundDuplicateSense = false;
 
                     // Iterate over the senses of the new word
-                    foreach (Sense oldSense in matchingVern.Senses)
+                    foreach (var oldSense in matchingVern.Senses)
                     {
                         var oldSenseIndex = 0;
 
@@ -219,7 +218,7 @@ namespace BackendFramework.Services
         public string GetAudioFilePath(string projectId, string wordId, string fileName)
         {
             // Generate path to home on linux
-            string pathToHome = Environment.GetEnvironmentVariable("HOME");
+            var pathToHome = Environment.GetEnvironmentVariable("HOME");
 
             // Generate home on windows
             if (pathToHome == null)
@@ -227,7 +226,7 @@ namespace BackendFramework.Services
                 pathToHome = Environment.GetEnvironmentVariable("UserProfile");
             }
 
-            string filepath = Path.Combine(pathToHome, ".CombineFiles", projectId,
+            var filepath = Path.Combine(pathToHome, ".CombineFiles", projectId,
                 "Import", "ExtractedLocation", "Lift", "Audio", fileName);
             Console.WriteLine($"filePath: {filepath}");
             return filepath;

--- a/Backend/Services/WordApiServices.cs
+++ b/Backend/Services/WordApiServices.cs
@@ -1,10 +1,10 @@
 using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace BackendFramework.Services
 {
@@ -33,7 +33,7 @@ namespace BackendFramework.Services
 
                 foreach (var senseAcc in wordToDelete.Senses)
                 {
-                    senseAcc.Accessibility = (int)State.deleted;
+                    senseAcc.Accessibility = (int)State.Deleted;
                 }
 
                 await _repo.Create(wordToDelete);
@@ -112,16 +112,16 @@ namespace BackendFramework.Services
                     switch (newChildWordState.SenseStates[i])
                     {
                         //add the word to the parent's history
-                        case State.sense:
-                        case State.duplicate:
+                        case State.Sense:
+                        case State.Duplicate:
                             if (!addParent.History.Contains(currentChildWord.Id))
                             {
                                 addParent.History.Add(currentChildWord.Id);
                             }
                             break;
                         //add the sense to a separate word and the word to its history
-                        case State.separate:
-                            currentChildWord.Senses[i].Accessibility = (int)State.active;
+                        case State.Separate:
+                            currentChildWord.Senses[i].Accessibility = (int)State.Active;
                             separateWord.Senses.Add(currentChildWord.Senses[i]);
                             if (!separateWord.History.Contains(currentChildWord.Id))
                             {

--- a/Backend/Services/WordApiServices.cs
+++ b/Backend/Services/WordApiServices.cs
@@ -22,9 +22,9 @@ namespace BackendFramework.Services
         /// <returns> A bool: success of operation </returns>
         public async Task<bool> Delete(string projectId, string wordId)
         {
-            var wordIsInFrontier = _repo.DeleteFrontier(projectId, wordId).Result;
+            bool wordIsInFrontier = _repo.DeleteFrontier(projectId, wordId).Result;
 
-            //we only want to add the deleted word if the word started in the frontier
+            // We only want to add the deleted word if the word started in the frontier
             if (wordIsInFrontier)
             {
                 Word wordToDelete = _repo.GetWord(projectId, wordId).Result;
@@ -46,19 +46,21 @@ namespace BackendFramework.Services
         /// <returns> A bool: success of operation </returns>
         public async Task<bool> Update(string projectId, string wordId, Word word)
         {
-            var wordIsInFrontier = _repo.DeleteFrontier(projectId, wordId).Result;
+            bool wordIsInFrontier = _repo.DeleteFrontier(projectId, wordId).Result;
 
-            //we only want to update words that are in the frontier
+            // We only want to update words that are in the frontier
             if (wordIsInFrontier)
             {
                 word.Id = "";
                 word.ProjectId = projectId;
 
-                if (word.History == null) //keep track of the old word
+                // Keep track of the old word
+                if (word.History == null)
                 {
                     word.History = new List<string> { wordId };
                 }
-                else //if we are updating the history, don't overwrite it, just add to the history
+                // If we are updating the history, don't overwrite it, just add to the history
+                else
                 {
                     word.History.Add(wordId);
                 }
@@ -75,43 +77,43 @@ namespace BackendFramework.Services
         {
             var newWordsList = new List<Word>();
 
-            var addParent = mergeWords.Parent.Clone();
+            Word addParent = mergeWords.Parent.Clone();
             addParent.History = new List<string>();
 
-            //generate new child words form child word field
-            foreach (var newChildWordState in mergeWords.ChildrenWords)
+            // Generate new child words form child word field
+            foreach (MergeSourceWord newChildWordState in mergeWords.ChildrenWords)
             {
-                //get child word
-                var currentChildWord = await _repo.GetWord(projectId, newChildWordState.SrcWordId);
-                //remove child from frontier
+                // Get child word
+                Word currentChildWord = await _repo.GetWord(projectId, newChildWordState.SrcWordId);
+                // Remove child from frontier
                 await _repo.DeleteFrontier(projectId, currentChildWord.Id);
 
-                //iterate through senses of that word and change to corresponding state in mergewords
+                // Iterate through senses of that word and change to corresponding state in mergewords
                 if (currentChildWord.Senses.Count != newChildWordState.SenseStates.Count)
                 {
                     throw new FormatException("Sense counts don't match");
                 }
-                for (int i = 0; i < currentChildWord.Senses.Count; i++)
+                for (var i = 0; i < currentChildWord.Senses.Count; i++)
                 {
                     currentChildWord.Senses[i].Accessibility = (int)newChildWordState.SenseStates[i];
                 }
 
-                //change the child word's history to its previous self
+                // Change the child word's history to its previous self
                 currentChildWord.History = new List<string>() { newChildWordState.SrcWordId };
 
-                //add child word to the database
+                // Add child word to the database
                 currentChildWord.Id = "";
-                var newChildWord = await _repo.Add(currentChildWord);
+                Word newChildWord = await _repo.Add(currentChildWord);
 
-                //handle different states
-                var separateWord = currentChildWord.Clone();
+                // Handle different states
+                Word separateWord = currentChildWord.Clone();
                 separateWord.Senses = new List<Sense>();
                 separateWord.Id = "";
-                for (int i = 0; i < currentChildWord.Senses.Count; i++)
+                for (var i = 0; i < currentChildWord.Senses.Count; i++)
                 {
                     switch (newChildWordState.SenseStates[i])
                     {
-                        //add the word to the parent's history
+                        // Add the word to the parent's history
                         case State.Sense:
                         case State.Duplicate:
                             if (!addParent.History.Contains(currentChildWord.Id))
@@ -119,7 +121,7 @@ namespace BackendFramework.Services
                                 addParent.History.Add(currentChildWord.Id);
                             }
                             break;
-                        //add the sense to a separate word and the word to its history
+                        // Add the sense to a separate word and the word to its history
                         case State.Separate:
                             currentChildWord.Senses[i].Accessibility = (int)State.Active;
                             separateWord.Senses.Add(currentChildWord.Senses[i]);
@@ -133,18 +135,18 @@ namespace BackendFramework.Services
                     }
                 }
 
-                //add a new word to the database with all of the senses with separate tags from this word
+                // Add a new word to the database with all of the senses with separate tags from this word
                 if (separateWord.Senses.Count != 0)
                 {
                     separateWord.ProjectId = projectId;
-                    var newSeparate = await _repo.Create(separateWord);
+                    Word newSeparate = await _repo.Create(separateWord);
                     newWordsList.Add(newSeparate);
                 }
             }
 
-            //add parent with child history to the datbase
+            // Add parent with child history to the database
             addParent.ProjectId = projectId;
-            var newParent = await _repo.Create(addParent);
+            Word newParent = await _repo.Create(addParent);
             newWordsList.Insert(0, newParent);
 
             return newWordsList;
@@ -153,47 +155,49 @@ namespace BackendFramework.Services
         /// <summary> Checks if a word being added is an exact duplicate of a preexisting word </summary>
         public async Task<bool> WordIsUnique(Word word)
         {
-            //get all words from frontier
+            // Get all words from frontier
             var allWords = await _repo.GetFrontier(word.ProjectId);
 
-            //find all words with matching vernacular
+            // Find all words with matching vernacular
             var allVernaculars = allWords.FindAll(x => x.Vernacular == word.Vernacular);
 
             var foundDuplicateSense = false;
             var isUniqueWord = true;
 
-            //iterate over words with the same vernacular
-            foreach (var matchingVern in allVernaculars)
+            // Iterate over words with the same vernacular
+            foreach (Word matchingVern in allVernaculars)
             {
-                //iterate over senses of those words
-                foreach (var newSense in word.Senses)
+                // Iterate over senses of those words
+                foreach (Sense newSense in word.Senses)
                 {
-                    int newSenseIndex = 0;
+                    var newSenseIndex = 0;
                     foundDuplicateSense = false;
 
-                    //iterate over the senses of the new word
-                    foreach (var oldSense in matchingVern.Senses)
+                    // Iterate over the senses of the new word
+                    foreach (Sense oldSense in matchingVern.Senses)
                     {
-                        int oldSenseIndex = 0;
+                        var oldSenseIndex = 0;
 
-                        //if the new sense is a strict subset of the old one, then merge it in
+                        // If the new sense is a strict subset of the old one, then merge it in
                         if (newSense.Glosses.All(s => oldSense.Glosses.Contains(s)))
                         {
                             foundDuplicateSense = true;
 
-                            //add edited by and remove duplicates
+                            // Add edited by and remove duplicates
                             matchingVern.EditedBy.AddRange(word.EditedBy);
                             matchingVern.EditedBy = matchingVern.EditedBy.Distinct().ToList();
 
-                            //add semantic domains and remove duplicates
-                            matchingVern.Senses[oldSenseIndex].SemanticDomains.AddRange(word.Senses[newSenseIndex].SemanticDomains);
-                            matchingVern.Senses[oldSenseIndex].SemanticDomains = matchingVern.Senses[newSenseIndex].SemanticDomains.Distinct().ToList();
+                            // Add semantic domains and remove duplicates
+                            matchingVern.Senses[oldSenseIndex].SemanticDomains.AddRange(
+                                word.Senses[newSenseIndex].SemanticDomains);
+                            matchingVern.Senses[oldSenseIndex].SemanticDomains = matchingVern.
+                                Senses[newSenseIndex].SemanticDomains.Distinct().ToList();
                         }
 
                         oldSenseIndex++;
                     }
 
-                    //if we never found a matching sense in the old word, the words are different
+                    // If we never found a matching sense in the old word, the words are different
                     if (!foundDuplicateSense)
                     {
                         break;
@@ -202,7 +206,7 @@ namespace BackendFramework.Services
                     newSenseIndex++;
                 }
 
-                //update the word only if all the senses were duplicates
+                // Update the word only if all the senses were duplicates
                 if (foundDuplicateSense)
                 {
                     isUniqueWord = false;
@@ -214,16 +218,17 @@ namespace BackendFramework.Services
 
         public string GetAudioFilePath(string projectId, string wordId, string fileName)
         {
-            //generate path to home on linux
-            var pathToHome = Environment.GetEnvironmentVariable("HOME");
+            // Generate path to home on linux
+            string pathToHome = Environment.GetEnvironmentVariable("HOME");
 
-            //generate home on windows
+            // Generate home on windows
             if (pathToHome == null)
             {
                 pathToHome = Environment.GetEnvironmentVariable("UserProfile");
             }
 
-            var filepath = Path.Combine(pathToHome, ".CombineFiles", projectId, "Import", "ExtractedLocation", "Lift", "Audio", fileName);
+            string filepath = Path.Combine(pathToHome, ".CombineFiles", projectId,
+                "Import", "ExtractedLocation", "Lift", "Audio", fileName);
             Console.WriteLine($"filePath: {filepath}");
             return filepath;
         }

--- a/Backend/Services/WordRepository.cs
+++ b/Backend/Services/WordRepository.cs
@@ -1,5 +1,4 @@
 using BackendFramework.Interfaces;
-using BackendFramework.ValueModels;
 using MongoDB.Driver;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/Backend/Services/WordRepository.cs
+++ b/Backend/Services/WordRepository.cs
@@ -1,8 +1,8 @@
-using BackendFramework.Interfaces;
-using MongoDB.Driver;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using BackendFramework.Interfaces;
 using BackendFramework.Models;
+using MongoDB.Driver;
 
 namespace BackendFramework.Services
 {

--- a/Backend/Services/WordRepository.cs
+++ b/Backend/Services/WordRepository.cs
@@ -42,7 +42,7 @@ namespace BackendFramework.Services
             var filterDef = new FilterDefinitionBuilder<Word>();
             var filter = filterDef.Eq(x => x.ProjectId, projectId);
 
-            DeleteResult deleted = await _wordDatabase.Words.DeleteManyAsync(filter);
+            var deleted = await _wordDatabase.Words.DeleteManyAsync(filter);
             await _wordDatabase.Frontier.DeleteManyAsync(filter);
             if (deleted.DeletedCount != 0)
             {
@@ -90,7 +90,7 @@ namespace BackendFramework.Services
             var filter = filterDef.And(filterDef.Eq(
                 x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, wordId));
 
-            DeleteResult deleted = await _wordDatabase.Frontier.DeleteOneAsync(filter);
+            var deleted = await _wordDatabase.Frontier.DeleteOneAsync(filter);
             return deleted.DeletedCount > 0;
         }
     }

--- a/Backend/Services/WordRepository.cs
+++ b/Backend/Services/WordRepository.cs
@@ -26,21 +26,23 @@ namespace BackendFramework.Services
         public async Task<Word> GetWord(string projectId, string wordId)
         {
             var filterDef = new FilterDefinitionBuilder<Word>();
-            var filter = filterDef.And(filterDef.Eq(x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, wordId));
+            var filter = filterDef.And(filterDef.Eq(
+                x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, wordId));
 
             var wordList = await _wordDatabase.Words.FindAsync(filter);
 
             return wordList.FirstOrDefault();
         }
 
-        /// <summary> Removes all <see cref="Word"/>s from the WordsCollection and Frontier for specified <see cref="Project"/> </summary>
+        /// <summary> Removes all <see cref="Word"/>s from the WordsCollection and Frontier for specified
+        /// <see cref="Project"/> </summary>
         /// <returns> A bool: success of operation </returns>
         public async Task<bool> DeleteAllWords(string projectId)
         {
             var filterDef = new FilterDefinitionBuilder<Word>();
             var filter = filterDef.Eq(x => x.ProjectId, projectId);
 
-            var deleted = await _wordDatabase.Words.DeleteManyAsync(filter);
+            DeleteResult deleted = await _wordDatabase.Words.DeleteManyAsync(filter);
             await _wordDatabase.Frontier.DeleteManyAsync(filter);
             if (deleted.DeletedCount != 0)
             {
@@ -85,9 +87,10 @@ namespace BackendFramework.Services
         public async Task<bool> DeleteFrontier(string projectId, string wordId)
         {
             var filterDef = new FilterDefinitionBuilder<Word>();
-            var filter = filterDef.And(filterDef.Eq(x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, wordId));
+            var filter = filterDef.And(filterDef.Eq(
+                x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, wordId));
 
-            var deleted = await _wordDatabase.Frontier.DeleteOneAsync(filter);
+            DeleteResult deleted = await _wordDatabase.Frontier.DeleteOneAsync(filter);
             return deleted.DeletedCount > 0;
         }
     }

--- a/Backend/Services/WordRepository.cs
+++ b/Backend/Services/WordRepository.cs
@@ -3,6 +3,7 @@ using BackendFramework.ValueModels;
 using MongoDB.Driver;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using BackendFramework.Models;
 
 namespace BackendFramework.Services
 {

--- a/Backend/Startup.cs
+++ b/Backend/Startup.cs
@@ -1,4 +1,7 @@
-﻿using BackendFramework.Interfaces;
+﻿using System;
+using System.Text;
+using BackendFramework.Contexts;
+using BackendFramework.Interfaces;
 using BackendFramework.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
@@ -10,9 +13,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
 using SIL.Lift.Parsing;
-using System;
-using System.Text;
-using BackendFramework.Contexts;
 
 namespace BackendFramework
 {

--- a/Backend/Startup.cs
+++ b/Backend/Startup.cs
@@ -55,7 +55,7 @@ namespace BackendFramework
 
             // Configure JWT Authentication
             const string secretKeyEnvName = "ASPNETCORE_JWT_SECRET_KEY";
-            string secretKey = Environment.GetEnvironmentVariable(secretKeyEnvName);
+            var secretKey = Environment.GetEnvironmentVariable(secretKeyEnvName);
 
             // The JWT key size must be at least 128 bits long.
             const int minKeyLength = 128 / 8;

--- a/Backend/Startup.cs
+++ b/Backend/Startup.cs
@@ -1,5 +1,4 @@
-﻿using BackendFramework.Context;
-using BackendFramework.Interfaces;
+﻿using BackendFramework.Interfaces;
 using BackendFramework.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
@@ -13,6 +12,7 @@ using Microsoft.IdentityModel.Tokens;
 using SIL.Lift.Parsing;
 using System;
 using System.Text;
+using BackendFramework.Contexts;
 
 namespace BackendFramework
 {

--- a/Backend/Startup.cs
+++ b/Backend/Startup.cs
@@ -19,9 +19,9 @@ namespace BackendFramework
     public class Startup
     {
         private const string AllowedOrigins = "AllowAll";
-        
+
         private readonly ILogger<Startup> _logger;
-        
+
         public IConfiguration Configuration { get; }
 
         public Startup(ILogger<Startup> logger, IConfiguration configuration)
@@ -55,7 +55,7 @@ namespace BackendFramework
 
             // Configure JWT Authentication
             const string secretKeyEnvName = "ASPNETCORE_JWT_SECRET_KEY";
-            var secretKey = Environment.GetEnvironmentVariable(secretKeyEnvName);
+            string secretKey = Environment.GetEnvironmentVariable(secretKeyEnvName);
 
             // The JWT key size must be at least 128 bits long.
             const int minKeyLength = 128 / 8;

--- a/Backend/Startup.cs
+++ b/Backend/Startup.cs
@@ -18,15 +18,17 @@ namespace BackendFramework
 {
     public class Startup
     {
+        private const string AllowedOrigins = "AllowAll";
+        
+        private readonly ILogger<Startup> _logger;
+        
+        public IConfiguration Configuration { get; }
+
         public Startup(ILogger<Startup> logger, IConfiguration configuration)
         {
             _logger = logger;
             Configuration = configuration;
         }
-
-        private readonly ILogger<Startup> _logger;
-        
-        public IConfiguration Configuration { get; }
 
         public class Settings
         {
@@ -34,16 +36,14 @@ namespace BackendFramework
             public string CombineDatabase { get; set; }
         }
 
-        private const string AllowedOrigins = "AllowAll";
-
         private class EnvironmentNotConfiguredException : Exception
         {
         }
 
-		/// <summary> This method gets called by the runtime. Use this method to add services for dependency injection. </summary>
+		/// <summary> This method gets called by the runtime. Use this method to add services for dependency injection.
+		/// </summary>
 		public void ConfigureServices(IServiceCollection services)
         {
-
             services.AddCors(options =>
             {
                 options.AddPolicy(AllowedOrigins,
@@ -125,7 +125,8 @@ namespace BackendFramework
             services.AddTransient<IPermissionService, PermissionService>();
         }
 
-        /// <summary> This method gets called by the runtime. Use this method to configure the HTTP request pipeline. </summary>
+        /// <summary> This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        /// </summary>
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             if (env.IsDevelopment())
@@ -134,7 +135,8 @@ namespace BackendFramework
             }
             else
             {
-                // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+                // The default HSTS value is 30 days. You may want to change this for production scenarios,
+                // see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
             }
 

--- a/docs/c_sharp_style_guide.md
+++ b/docs/c_sharp_style_guide.md
@@ -1,0 +1,17 @@
+﻿# C# Style Guide and Coding Conventions
+
+## Overview
+
+In general, follow the Microsoft C# Coding Guidelines described in the following links:
+
+- https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/naming-guidelines
+- https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/identifier-names
+- https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions
+
+# Exceptions
+
+The following guidelines supersede the Microsoft C# Coding Guidelines, an should be used.
+
+## Type Inference
+
+Use type inference (`var`) wherever possible. This can improve readability and ease of refactoring.


### PR DESCRIPTION
Style guide followed taken from the official MS C# style guide:

- https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/naming-guidelines
- https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/identifier-names
- https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions

Summary of changes:

- No functionality is changed
- Fix issues that do not conform to MS C# conventions (essentially get the project to all be following the same style guide, in this case the standard C# style guide)
- Rename `BackendFramework.ValueModels` namespace to match C# guidelines
- Rename `BackendFramework.Contexts` namespace to match C# guidelines
- Fix spelling mistakes
- Make variables `const` where possible
- Make methods `static` where possible
- Sort `using` directives
______

When merging, squash commits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/293)
<!-- Reviewable:end -->
