### PR TITLE
Create a single module from which to interact with local storage

### DIFF
--- a/src/backend/localStorage.tsx
+++ b/src/backend/localStorage.tsx
@@ -1,0 +1,20 @@
+﻿import { User } from "../types/user";
+
+/**
+ * Gets the current user from local storage.
+ */
+export function getUser(): User | null {
+  const user: string | null = localStorage.getItem("user");
+  if (user != null) {
+    return JSON.parse(user);
+  }
+  return null;
+}
+
+export function setProjectID(id: string) {
+  localStorage.setItem("projectId", id);
+}
+
+export function getProjectId(): string {
+  return localStorage.getItem("projectId") || "";
+}

--- a/src/backend/localStorage.tsx
+++ b/src/backend/localStorage.tsx
@@ -5,10 +5,7 @@
  */
 export function getUser(): User | null {
   const user: string | null = localStorage.getItem("user");
-  if (user != null) {
-    return JSON.parse(user);
-  }
-  return null;
+  return user ? JSON.parse(user) : null;
 }
 
 export function setProjectID(id: string) {

--- a/src/backend/localStorage.tsx
+++ b/src/backend/localStorage.tsx
@@ -3,8 +3,8 @@
 /**
  * Gets the current user from local storage.
  */
-export function getUser(): User | null {
-  const user: string | null = localStorage.getItem("user");
+export function getCurrentUser(): User | null {
+  const user = localStorage.getItem("user");
   return user ? JSON.parse(user) : null;
 }
 

--- a/src/components/AppBar/UserMenu.tsx
+++ b/src/components/AppBar/UserMenu.tsx
@@ -1,11 +1,12 @@
-import history from "../../history";
 import React from "react";
-import { Button, Menu, MenuItem, Avatar } from "@material-ui/core";
+import { Avatar, Button, Menu, MenuItem } from "@material-ui/core";
 import { Translate } from "react-localize-redux";
-import { Settings, ExitToApp, Person } from "@material-ui/icons";
+import { ExitToApp, Person, Settings } from "@material-ui/icons";
+
+import history from "../../history";
 import theme from "../../types/theme";
 import { avatarSrc } from "../../backend";
-import { getCurrentUser } from "../UserSettings/UserSettings";
+import { getCurrentUser } from "../../backend/localStorage";
 
 /**
  * Avatar in appbar with dropdown (Project settings, user settings, log out)
@@ -25,7 +26,7 @@ export default function UserMenu() {
   }
 
   async function getAvatar() {
-    const user = getCurrentUser();
+    const user = getCurrentUser()!;
     const a = await avatarSrc(user);
     setAvatar(a);
   }

--- a/src/components/DataEntry/DataEntryTable/DataEntryTable.tsx
+++ b/src/components/DataEntry/DataEntryTable/DataEntryTable.tsx
@@ -1,13 +1,15 @@
 import React from "react";
 import { Typography, Grid, Button } from "@material-ui/core";
-import theme from "../../../types/theme";
 import {
   Translate,
   LocalizeContextProps,
   withLocalize,
 } from "react-localize-redux";
+
+import theme from "../../../types/theme";
 import { Word, SemanticDomain, State } from "../../../types/word";
 import * as Backend from "../../../backend";
+import * as LocalStorage from "../../../backend/localStorage";
 import DomainTree from "../../TreeView/SemanticDomain";
 import SpellChecker from "../spellChecker";
 import { ExistingEntry } from "./ExistingEntry/ExistingEntry";
@@ -42,7 +44,7 @@ async function getWordsFromBackend(): Promise<Word[]> {
   return words;
 }
 async function getProjectAutocompleteSetting(): Promise<AutoComplete> {
-  let proj = await Backend.getProject(Backend.getProjectId());
+  let proj = await Backend.getProject(LocalStorage.getProjectId());
   return proj.autocompleteSetting;
 }
 

--- a/src/components/GoalTimeline/GoalsActions.tsx
+++ b/src/components/GoalTimeline/GoalsActions.tsx
@@ -81,7 +81,7 @@ function asyncCreateNewUserEditsObject(projectId: string) {
 
 export function asyncGetUserEdits() {
   return async (dispatch: ThunkDispatch<StoreState, any, GoalAction>) => {
-    const user = LocalStorage.getUser();
+    const user = LocalStorage.getCurrentUser();
     if (user) {
       const projectId: string = LocalStorage.getProjectId();
       const userEditId: string | undefined = getUserEditIdFromProjectId(

--- a/src/components/GoalTimeline/GoalsActions.tsx
+++ b/src/components/GoalTimeline/GoalsActions.tsx
@@ -1,6 +1,8 @@
-import { Goal } from "../../types/goals";
-import { ActionWithPayload } from "../../types/mockAction";
 import { Dispatch } from "redux";
+import { ThunkDispatch } from "redux-thunk";
+
+import { Goal, GoalType } from "../../types/goals";
+import { ActionWithPayload } from "../../types/mockAction";
 import * as Backend from "../../backend";
 import * as LocalStorage from "../../backend/localStorage";
 import history from "../../history";
@@ -9,19 +11,17 @@ import { CreateCharInv } from "../../goals/CreateCharInv/CreateCharInv";
 import { ValidateChars } from "../../goals/ValidateChars/ValidateChars";
 import { CreateStrWordInv } from "../../goals/CreateStrWordInv/CreateStrWordInv";
 import { ValidateStrWords } from "../../goals/ValidateStrWords/ValidateStrWords";
-import { MergeDups, MergeDupData } from "../../goals/MergeDupGoal/MergeDups";
+import { MergeDupData, MergeDups } from "../../goals/MergeDupGoal/MergeDups";
 import { SpellCheckGloss } from "../../goals/SpellCheckGloss/SpellCheckGloss";
 import { ReviewEntries } from "../../goals/ReviewEntries/ReviewEntries";
 import { HandleFlags } from "../../goals/HandleFlags/HandleFlags";
 import { Edit } from "../../types/userEdit";
-import { GoalType } from "../../types/goals";
 import DupFinder from "../../goals/MergeDupGoal/DuplicateFinder/DuplicateFinder";
-import { ThunkDispatch } from "redux-thunk";
 import { StoreState } from "../../types";
 import { Hash } from "../../goals/MergeDupGoal/MergeDupStep/MergeDupsTree";
 import {
-  refreshWords,
   MergeTreeAction,
+  refreshWords,
 } from "../../goals/MergeDupGoal/MergeDupStep/MergeDupStepActions";
 
 export enum GoalsActions {
@@ -100,8 +100,8 @@ export function asyncGetUserEdits() {
 
 export function asyncAddGoalToHistory(goal: Goal) {
   return async (dispatch: ThunkDispatch<StoreState, any, GoalAction>) => {
-    let user: User | undefined = getUser();
-    if (user !== undefined) {
+    const user = LocalStorage.getCurrentUser();
+    if (user) {
       let userEditId: string | undefined = getUserEditId(user);
       if (userEditId !== undefined) {
         dispatch(loadGoalData(goal)).then(

--- a/src/components/GoalTimeline/GoalsActions.tsx
+++ b/src/components/GoalTimeline/GoalsActions.tsx
@@ -197,8 +197,8 @@ export function updateStepData(goal: Goal): Goal {
 }
 
 export function getUserEditId(user: User): string | undefined {
-  let projectId = LocalStorage.getProjectId();
-  let userEditId: string | undefined = getUserEditIdFromProjectId(
+  const projectId = LocalStorage.getProjectId();
+  const userEditId: string | undefined = getUserEditIdFromProjectId(
     user.workedProjects,
     projectId
   );

--- a/src/components/GoalTimeline/GoalsActions.tsx
+++ b/src/components/GoalTimeline/GoalsActions.tsx
@@ -120,15 +120,6 @@ export function asyncAddGoalToHistory(goal: Goal) {
   };
 }
 
-export function getUser(): User | undefined {
-  let userString: string | null = localStorage.getItem("user");
-  let user: User | undefined;
-  if (userString) {
-    user = JSON.parse(userString);
-  }
-  return user;
-}
-
 export function loadGoalData(goal: Goal) {
   return async (dispatch: ThunkDispatch<any, any, MergeTreeAction>) => {
     switch (goal.goalType) {

--- a/src/components/GoalTimeline/tests/GoalTimelineActions.test.tsx
+++ b/src/components/GoalTimeline/tests/GoalTimelineActions.test.tsx
@@ -1,9 +1,10 @@
+import configureMockStore, { MockStoreEnhanced } from "redux-mock-store";
+import thunk from "redux-thunk";
+
 import * as actions from "../GoalsActions";
 import { Goal } from "../../../types/goals";
 import { CreateCharInv } from "../../../goals/CreateCharInv/CreateCharInv";
 import { MergeDups, MergeDupData } from "../../../goals/MergeDupGoal/MergeDups";
-import configureMockStore, { MockStoreEnhanced } from "redux-mock-store";
-import thunk from "redux-thunk";
 import { HandleFlags } from "../../../goals/HandleFlags/HandleFlags";
 import { goalDataMock } from "../../../goals/MergeDupGoal/MergeDupStep/tests/MockMergeDupData";
 import { ReviewEntries } from "../../../goals/ReviewEntries/ReviewEntries";
@@ -13,6 +14,7 @@ import {
   MergeTreeAction,
 } from "../../../goals/MergeDupGoal/MergeDupStep/MergeDupStepActions";
 import { defaultState as goalsDefaultState } from "../DefaultState";
+import * as LocalStorage from "../../../backend/localStorage";
 
 jest.mock(
   ".././../../goals/MergeDupGoal/DuplicateFinder/DuplicateFinder",
@@ -165,11 +167,11 @@ describe("Test GoalsActions", () => {
 
   it("should return a user", () => {
     localStorage.setItem("user", JSON.stringify(mockUser));
-    expect(actions.getUser()).toEqual(mockUser);
+    expect(LocalStorage.getCurrentUser()).toEqual(mockUser);
   });
 
   it("should return undefined when there is no user", () => {
-    expect(actions.getUser()).toEqual(undefined);
+    expect(LocalStorage.getCurrentUser()).toEqual(null);
   });
 
   it("should dispatch UPDATE_GOAL and SET_DATA", async () => {

--- a/src/components/Login/AuthHeaders.tsx
+++ b/src/components/Login/AuthHeaders.tsx
@@ -1,4 +1,4 @@
-import { getUser } from "../../backend/localStorage";
+import { getCurrentUser } from "../../backend/localStorage";
 
 /**
  * Returns authorization header with JWT token.
@@ -9,7 +9,7 @@ import { getUser } from "../../backend/localStorage";
  * example: `axios.post("localhost:5001", data, { headers: authHeader() })`
  */
 export function authHeader() {
-  let user = getUser();
+  let user = getCurrentUser();
   if (user && user.token) {
     return { Authorization: "Bearer " + user.token };
   } else {

--- a/src/components/Login/AuthHeaders.tsx
+++ b/src/components/Login/AuthHeaders.tsx
@@ -9,7 +9,7 @@ import { getCurrentUser } from "../../backend/localStorage";
  * example: `axios.post("localhost:5001", data, { headers: authHeader() })`
  */
 export function authHeader() {
-  let user = getCurrentUser();
+  const user = getCurrentUser();
   if (user && user.token) {
     return { Authorization: "Bearer " + user.token };
   } else {

--- a/src/components/Login/AuthHeaders.tsx
+++ b/src/components/Login/AuthHeaders.tsx
@@ -1,14 +1,15 @@
+import { getUser } from "../../backend/localStorage";
+
 /**
- * Returns authorization header with jwt token
+ * Returns authorization header with JWT token.
  *
- * When making an axios request on a protected endpoint, include `{headers:authHeader()}`
+ * When making an axios request on a protected endpoint, include
+ * `{ headers:authHeader() }`
  *
- * example: `axios.post("localhost:5001", data, { headers: authHeader()})`
+ * example: `axios.post("localhost:5001", data, { headers: authHeader() })`
  */
 export function authHeader() {
-  let userString = localStorage.getItem("user");
-  let user = userString ? JSON.parse(userString) : null;
-
+  let user = getUser();
   if (user && user.token) {
     return { Authorization: "Bearer " + user.token };
   } else {

--- a/src/components/PrivateRoute/index.tsx
+++ b/src/components/PrivateRoute/index.tsx
@@ -1,5 +1,7 @@
 import React from "react";
-import { Route, Redirect } from "react-router-dom";
+import { Redirect, Route } from "react-router-dom";
+
+import { getUser } from "../../backend/localStorage";
 
 /**
  * Redirects to /login if there is no `user` in localStorage
@@ -8,7 +10,7 @@ export const PrivateRoute = ({ component: Component, ...rest }: any) => (
   <Route
     {...rest}
     render={(props) =>
-      localStorage.getItem("user") ? (
+      getUser() ? (
         <Component {...props} />
       ) : (
         <Redirect

--- a/src/components/PrivateRoute/index.tsx
+++ b/src/components/PrivateRoute/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Redirect, Route } from "react-router-dom";
 
-import { getUser } from "../../backend/localStorage";
+import { getCurrentUser } from "../../backend/localStorage";
 
 /**
  * Redirects to /login if there is no `user` in localStorage
@@ -10,7 +10,7 @@ export const PrivateRoute = ({ component: Component, ...rest }: any) => (
   <Route
     {...rest}
     render={(props) =>
-      getUser() ? (
+      getCurrentUser() ? (
         <Component {...props} />
       ) : (
         <Redirect

--- a/src/components/Project/ProjectReducer.tsx
+++ b/src/components/Project/ProjectReducer.tsx
@@ -1,6 +1,6 @@
 import { ProjectAction, SET_CURRENT_PROJECT } from "./ProjectActions";
 import { Project, defaultProject } from "../../types/project";
-import { setProjectID } from "../../backend";
+import { setProjectID } from "../../backend/localStorage";
 import { StoreActions, StoreAction } from "../../rootActions";
 
 export const projectReducer = (

--- a/src/components/ProjectScreen/ChooseProject/ChooseProjectComponent.tsx
+++ b/src/components/ProjectScreen/ChooseProject/ChooseProjectComponent.tsx
@@ -15,7 +15,7 @@ import {
 import { Project } from "../../../types/project";
 import { getAllProjectsByUser } from "../../../backend";
 import history from "../../../history";
-import { getUserFromLocalStorage } from "../../../localStorage";
+import { getUser } from "../../../backend/localStorage";
 
 export interface ChooseProjectProps {
   setCurrentProject: (project: Project) => void;
@@ -32,7 +32,7 @@ class ChooseProject extends React.Component<
   constructor(props: ChooseProjectProps & LocalizeContextProps) {
     super(props);
     this.state = { projectList: [] };
-    const user = getUserFromLocalStorage();
+    const user = getUser();
     if (user) {
       getAllProjectsByUser(user).then((projects) => {
         this.setState({ ...this.state, projectList: projects });

--- a/src/components/ProjectScreen/ChooseProject/ChooseProjectComponent.tsx
+++ b/src/components/ProjectScreen/ChooseProject/ChooseProjectComponent.tsx
@@ -15,7 +15,7 @@ import {
 import { Project } from "../../../types/project";
 import { getAllProjectsByUser } from "../../../backend";
 import history from "../../../history";
-import { getUser } from "../../../backend/localStorage";
+import { getCurrentUser } from "../../../backend/localStorage";
 
 export interface ChooseProjectProps {
   setCurrentProject: (project: Project) => void;
@@ -32,7 +32,7 @@ class ChooseProject extends React.Component<
   constructor(props: ChooseProjectProps & LocalizeContextProps) {
     super(props);
     this.state = { projectList: [] };
-    const user = getUser();
+    const user = getCurrentUser();
     if (user) {
       getAllProjectsByUser(user).then((projects) => {
         this.setState({ ...this.state, projectList: projects });

--- a/src/components/ProjectScreen/ChooseProject/ChooseProjectComponent.tsx
+++ b/src/components/ProjectScreen/ChooseProject/ChooseProjectComponent.tsx
@@ -1,20 +1,21 @@
 import React from "react";
 import {
-  Translate,
   LocalizeContextProps,
+  Translate,
   withLocalize,
 } from "react-localize-redux";
 import {
-  Typography,
-  CardContent,
   Card,
+  CardContent,
   List,
   ListItem,
+  Typography,
 } from "@material-ui/core";
+
 import { Project } from "../../../types/project";
 import { getAllProjectsByUser } from "../../../backend";
 import history from "../../../history";
-import { User } from "../../../types/user";
+import { getUserFromLocalStorage } from "../../../localStorage";
 
 export interface ChooseProjectProps {
   setCurrentProject: (project: Project) => void;
@@ -31,10 +32,9 @@ class ChooseProject extends React.Component<
   constructor(props: ChooseProjectProps & LocalizeContextProps) {
     super(props);
     this.state = { projectList: [] };
-    let user: string | null = localStorage.getItem("user");
+    const user = getUserFromLocalStorage();
     if (user) {
-      let userObject: User = JSON.parse(user);
-      getAllProjectsByUser(userObject).then((projects) => {
+      getAllProjectsByUser(user).then((projects) => {
         this.setState({ ...this.state, projectList: projects });
       });
     }

--- a/src/components/ProjectSettings/ProjectUsers/ProjectUsers.tsx
+++ b/src/components/ProjectSettings/ProjectUsers/ProjectUsers.tsx
@@ -16,7 +16,7 @@ import {
   getAllUsersInCurrentProject,
 } from "../../../backend";
 import theme from "../../../types/theme";
-import { getUser } from "../../../backend/localStorage";
+import { getCurrentUser } from "../../../backend/localStorage";
 
 interface UserProps {}
 
@@ -73,7 +73,7 @@ class ProjectUsers extends React.Component<UserProps, UserState> {
   }
 
   addToProject(user: User) {
-    const currentUser = getUser();
+    const currentUser = getCurrentUser();
     if (currentUser && user.id !== currentUser.id) {
       addUserRole([1, 2, 3], user).then(() => this.populateUsers());
     }

--- a/src/components/ProjectSettings/ProjectUsers/ProjectUsers.tsx
+++ b/src/components/ProjectSettings/ProjectUsers/ProjectUsers.tsx
@@ -1,20 +1,22 @@
 import React from "react";
 import {
+  Avatar,
   List,
   ListItem,
-  ListItemText,
   ListItemIcon,
-  Avatar,
+  ListItemText,
 } from "@material-ui/core";
 import Done from "@material-ui/icons/Done";
+
 import { User } from "../../../types/user";
 import {
-  getAllUsers,
-  getAllUsersInCurrentProject,
   addUserRole,
   avatarSrc,
+  getAllUsers,
+  getAllUsersInCurrentProject,
 } from "../../../backend";
 import theme from "../../../types/theme";
+import { getUser } from "../../../backend/localStorage";
 
 interface UserProps {}
 
@@ -71,15 +73,10 @@ class ProjectUsers extends React.Component<UserProps, UserState> {
   }
 
   addToProject(user: User) {
-    if (user.id !== this.getCurrentUser().id) {
+    const currentUser = getUser();
+    if (currentUser && user.id !== currentUser.id) {
       addUserRole([1, 2, 3], user).then(() => this.populateUsers());
     }
-  }
-
-  /** Get user from localstorage */
-  getCurrentUser(): User {
-    const userString = localStorage.getItem("user");
-    return userString ? JSON.parse(userString) : null;
   }
 
   render() {

--- a/src/components/UserSettings/AvatarUpload.tsx
+++ b/src/components/UserSettings/AvatarUpload.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from "react";
-import { Typography, Grid } from "@material-ui/core";
+import { Grid, Typography } from "@material-ui/core";
 import { Translate } from "react-localize-redux";
+
 import { uploadAvatar } from "../../backend";
 import FileInputButton from "../Buttons/FileInputButton";
 import LoadingDoneButton from "../Buttons/LoadingDoneButton";
-import { getCurrentUser } from "./UserSettings";
+import { getCurrentUser } from "../../backend/localStorage";
 
 /**
  * Allows the current user to select an image and upload as their avatar
@@ -27,8 +28,7 @@ export default function AvatarUpload(props: { doneCallback?: () => void }) {
     e.preventDefault();
     const avatar = file;
 
-    const user = getCurrentUser();
-
+    const user = getCurrentUser()!;
     if (avatar) {
       setLoading(true);
       uploadAvatar(user, avatar)

--- a/src/components/UserSettings/UserSettings.tsx
+++ b/src/components/UserSettings/UserSettings.tsx
@@ -1,28 +1,30 @@
 import React from "react";
 import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  Typography,
-  Grid,
+  LocalizeContextProps,
+  Translate,
+  withLocalize,
+} from "react-localize-redux";
+import {
   Avatar,
-  TextField,
   Button,
   Card,
   CardContent,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Grid,
   makeStyles,
+  TextField,
+  Typography,
 } from "@material-ui/core";
+import { CameraAlt, Email, Phone } from "@material-ui/icons";
+
 import { User } from "../../types/user";
 import AvatarUpload from "./AvatarUpload";
 import AppBarComponent from "../AppBar/AppBarComponent";
-import { avatarSrc, getUser, updateUser } from "../../backend";
-import { Phone, Email, CameraAlt } from "@material-ui/icons";
+import {avatarSrc, getUser, updateUser} from "../../backend";
 import theme from "../../types/theme";
-import {
-  LocalizeContextProps,
-  withLocalize,
-  Translate,
-} from "react-localize-redux";
+import { getCurrentUser } from "../../backend/localStorage";
 
 function AvatarDialog(props: { open: boolean; onClose?: () => void }) {
   return (
@@ -84,7 +86,7 @@ class UserSettings extends React.Component<
 > {
   constructor(props: LocalizeContextProps) {
     super(props);
-    const user = getCurrentUser();
+    const user = getCurrentUser()!;
     this.state = {
       user,
       name: user.name,
@@ -96,7 +98,7 @@ class UserSettings extends React.Component<
   }
 
   async getAvatar() {
-    const user = getCurrentUser();
+    const user = getCurrentUser()!;
     const a = await avatarSrc(user);
     this.setState({ avatar: a });
   }
@@ -223,12 +225,6 @@ class UserSettings extends React.Component<
 }
 
 export default withLocalize(UserSettings);
-
-/** Get user from localstorage */
-export function getCurrentUser(): User {
-  const userString = localStorage.getItem("user");
-  return userString ? JSON.parse(userString) : null;
-}
 
 /** Update user in localstorage with user from backend */
 export async function updateCurrentUser() {

--- a/src/goals/CharInventoryCreation/CharacterInventoryActions.tsx
+++ b/src/goals/CharInventoryCreation/CharacterInventoryActions.tsx
@@ -1,25 +1,25 @@
 import { Dispatch } from "react";
+
 import { StoreState } from "../../types";
 import {
-  setCurrentProject,
   ProjectAction,
+  setCurrentProject,
 } from "../../components/Project/ProjectActions";
 import {
-  updateGoal,
-  getUserEditId,
   getIndexInHistory,
+  getUserEditId,
   GoalAction,
-  getUser,
+  updateGoal,
 } from "../../components/GoalTimeline/GoalsActions";
 import { CreateCharInv } from "../CreateCharInv/CreateCharInv";
-import * as backend from "../../backend";
 import { Goal } from "../../types/goals";
 import { Project } from "../../types/project";
-import { User } from "../../types/user";
 import {
   CharacterSetEntry,
   characterStatus,
 } from "./CharacterInventoryReducer";
+import * as backend from "../../backend";
+import * as LocalStorage from "../../backend/localStorage";
 
 export enum CharacterInventoryType {
   SET_VALID_CHARACTERS = "SET_VALID_CHARACTERS",
@@ -214,8 +214,8 @@ async function saveChangesToGoal(
   history: Goal[],
   dispatch: Dispatch<CharacterInventoryAction | ProjectAction | GoalAction>
 ) {
-  let user: User | undefined = getUser();
-  if (user !== undefined) {
+  const user = LocalStorage.getCurrentUser();
+  if (user) {
     let userEditId: string | undefined = getUserEditId(user);
     if (userEditId !== undefined) {
       let indexInHistory: number = getIndexInHistory(history, updatedGoal);

--- a/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepActions.tsx
+++ b/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepActions.tsx
@@ -1,21 +1,21 @@
-import { StoreState } from "../../../types";
+import { Dispatch } from "redux";
 import { ThunkDispatch } from "redux-thunk";
-import { MergeTreeReference, Hash, TreeDataSense } from "./MergeDupsTree";
-import { Word, State } from "../../../types/word";
-import * as backend from "../../../backend";
+
+import { StoreState } from "../../../types";
+import { Hash, MergeTreeReference, TreeDataSense } from "./MergeDupsTree";
+import { State, Word } from "../../../types/word";
 import {
-  getUserEditId,
   getIndexInHistory,
-  getUser,
+  getUserEditId,
   updateGoal,
   UpdateGoalAction,
   updateStepData,
 } from "../../../components/GoalTimeline/GoalsActions";
 import { Goal, GoalHistoryState } from "../../../types/goals";
-import { Dispatch } from "redux";
 import { MergeDups, MergeStepData } from "../MergeDups";
 import navigationHistory from "../../../history";
-import { User } from "../../../types/user";
+import * as backend from "../../../backend";
+import * as LocalStorage from "../../../backend/localStorage";
 
 export enum MergeTreeActions {
   SET_VERNACULAR = "SET_VERNACULAR",
@@ -160,8 +160,8 @@ export function mergeSense() {
 }
 
 async function addStepToGoal(goal: Goal, indexInHistory: number) {
-  let user: User | undefined = getUser();
-  if (user !== undefined) {
+  const user = LocalStorage.getCurrentUser();
+  if (user) {
     let userEditId: string | undefined = getUserEditId(user);
     if (userEditId !== undefined) {
       await backend.addStepToGoal(userEditId, indexInHistory, goal);

--- a/src/localStorage/index.tsx
+++ b/src/localStorage/index.tsx
@@ -1,9 +1,0 @@
-﻿import { User } from "../types/user";
-
-export function getUserFromLocalStorage(): User | null {
-  const user: string | null = localStorage.getItem("user");
-  if (user != null) {
-    return JSON.parse(user);
-  }
-  return null;
-}

--- a/src/localStorage/index.tsx
+++ b/src/localStorage/index.tsx
@@ -1,0 +1,9 @@
+﻿import { User } from "../types/user";
+
+export function getUserFromLocalStorage(): User | null {
+  const user: string | null = localStorage.getItem("user");
+  if (user != null) {
+    return JSON.parse(user);
+  }
+  return null;
+}


### PR DESCRIPTION
Closes #314

This is a somewhat conservative first step to collapse 7-8 duplicated redefinitions of the `getCurrentUser()` function. There are more accesses to `localStorage` that could be grouped here, but this is a helpful step towards allowing #310 to continue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/317)
<!-- Reviewable:end -->
