### PR TITLE
Don't open a browser tab every time the backend relaunches

### DIFF
--- a/Backend/Properties/launchSettings.json
+++ b/Backend/Properties/launchSettings.json
@@ -19,7 +19,7 @@
     },
     "BackendFramework": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "launchUrl": "v1/",
       "environmentVariables": {
         "Key": "Value",


### PR DESCRIPTION
Currently during development relaunching the backend keeps opening new browser tabs. This is an annoyance, especially since the developer generally doesn't need to browse to the backend.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/348)
<!-- Reviewable:end -->
