### PR TITLE
Suppress backend warnings triggered in release mode

### DIFF
--- a/Backend/Controllers/FrontierController.cs
+++ b/Backend/Controllers/FrontierController.cs
@@ -48,7 +48,10 @@ namespace BackendFramework.Controllers
         /// <remarks> POST: v1/projects/{projectId}/words/frontier </remarks>
         /// <returns> Id of word created </returns>
         [HttpPost]
+        // TODO: Remove this warning suppression when the function is implemented for release mode.
+#pragma warning disable 1998
         public async Task<IActionResult> PostFrontier(string projectId, [FromBody]Word word)
+#pragma warning restore 1998
         {
 #if DEBUG
             if (!_permissionService.HasProjectPermission(Permission.WordEntry, HttpContext))
@@ -74,7 +77,10 @@ namespace BackendFramework.Controllers
         /// <summary> Deletes all words in a project's frontier </summary>
         /// <remarks> DELETE: v1/projects/{projectId}/words/frontier/{wordId} </remarks>
         [HttpDelete("{wordId}")]
+        // TODO: Remove this warning suppression when the function is implemented for release mode.
+#pragma warning disable 1998
         public async Task<IActionResult> DeleteFrontier(string projectId, string wordId)
+#pragma warning restore 1998
         {
 #if DEBUG
             if (!_permissionService.HasProjectPermission(Permission.WordEntry, HttpContext))

--- a/Backend/Controllers/UserEditController.cs
+++ b/Backend/Controllers/UserEditController.cs
@@ -53,7 +53,10 @@ namespace BackendFramework.Controllers
         /// <remarks> DELETE: v1/projects/{projectId}/useredits </remarks>
         /// <returns> true: if success, false: if there were no projects </returns>
         [HttpDelete]
+        // TODO: Remove this warning suppression when the function is implemented for release mode.
+#pragma warning disable 1998
         public async Task<IActionResult> Delete(string projectId)
+#pragma warning restore 1998
         {
 #if DEBUG
             if (!_permissionService.HasProjectPermission(Permission.DatabaseAdmin, HttpContext))


### PR DESCRIPTION
Closes #369

Also:

- [x] Enable `dotnet publish -c Release` test on CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/370)
<!-- Reviewable:end -->
