### PR TITLE
Correct directory used for Backend software

### DIFF
--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -19,9 +19,12 @@
 set -euf -o pipefail
 
 cd ..
-echo "Building app"
+echo "Building frontend"
 npm install
 npm run build
 cd Backend
+echo "Removing previous build results"
+rm -rf bin/Release/*
+echo "Building backend"
 dotnet publish -c Release
 cd ../deploy

--- a/deploy/playbook_publish.yml
+++ b/deploy/playbook_publish.yml
@@ -1,16 +1,18 @@
 ---
-
 ################################
 # Playbook to test the role for deploying the application
 #
 
-- name:  Deploy TheCombine application
+- name: Deploy TheCombine application
   hosts: all
   become: yes
 
   vars_files:
     - "vars/config_common.yml"
     - "vars/vault_config.yml"
+
+  vars:
+    - backend_dotnet_version: "{{ lookup('pipe', 'grep TargetFramework ../Backend/BackendFramework.csproj') | regex_replace('.*<TargetFramework>netcoreapp([\\d\\.]+).*', '\\1') }}"
 
   tasks:
     - name: print .NET version

--- a/deploy/playbook_publish.yml
+++ b/deploy/playbook_publish.yml
@@ -13,6 +13,10 @@
     - "vars/vault_config.yml"
 
   tasks:
+    - name: print .NET version
+      debug:
+        var: backend_dotnet_version
+
     - name: create user for backend process
       user:
         name: "{{ combine_user }}"

--- a/deploy/playbook_publish.yml
+++ b/deploy/playbook_publish.yml
@@ -12,12 +12,12 @@
     - "vars/vault_config.yml"
 
   vars:
-    - backend_dotnet_version: "{{ lookup('pipe', 'grep TargetFramework ../Backend/BackendFramework.csproj') | regex_replace('.*<TargetFramework>netcoreapp([\\d\\.]+).*', '\\1') }}"
+    - combine_build_dir: "../Backend/bin/Release/{{ lookup('pipe', 'grep TargetFramework ../Backend/BackendFramework.csproj') | regex_replace('.*<TargetFramework>([^<]+).*', '\\1') }}"
 
   tasks:
-    - name: print .NET version
+    - name: print backend software location
       debug:
-        var: backend_dotnet_version
+        var: combine_build_dir
 
     - name: create user for backend process
       user:

--- a/deploy/roles/dotnet_core/defaults/main.yml
+++ b/deploy/roles/dotnet_core/defaults/main.yml
@@ -1,16 +1,14 @@
 ---
-
 # Specify the .NET package to install:
 #   Runtime: aspnetcore-runtime-2.1
 #   SDK: dotnet-sdk-2.1
 
 dotnet_pkg:
-  - "aspnetcore-runtime-{{ backend_dotnet_version | default('3.1') }}"
+  - aspnetcore-runtime-3.1
 
 deprecated_pkgs:
   - aspnetcore-runtime-2.1
   - dotnet-runtime-2.1
   - dotnet-hostfxr-2.1
   - dotnet-runtime-deps-2.1
-
 #dotnet_pkg: dotnet-sdk-2.1

--- a/deploy/roles/dotnet_core/defaults/main.yml
+++ b/deploy/roles/dotnet_core/defaults/main.yml
@@ -5,7 +5,7 @@
 #   SDK: dotnet-sdk-2.1
 
 dotnet_pkg:
-  - aspnetcore-runtime-3.1
+  - "aspnetcore-runtime-{{ backend_dotnet_version | default('3.1') }}"
 
 deprecated_pkgs:
   - aspnetcore-runtime-2.1

--- a/deploy/roles/the_combine_app/defaults/main.yml
+++ b/deploy/roles/the_combine_app/defaults/main.yml
@@ -12,7 +12,6 @@ www_app_owner: www-data
 www_app_group: www-data
 
 combine_backend_dir: /home/combine/Backend
-combine_build_dir: "../Backend/bin/Release/netcoreapp{{ backend_dotnet_version | default('3.1') }}/"
 
 #############################
 # setup logging

--- a/deploy/roles/the_combine_app/defaults/main.yml
+++ b/deploy/roles/the_combine_app/defaults/main.yml
@@ -12,6 +12,7 @@ www_app_owner: www-data
 www_app_group: www-data
 
 combine_backend_dir: /home/combine/Backend
+combine_build_dir: "../Backend/bin/Release/netcoreapp{{ backend_dotnet_version | default('3.1') }}/"
 
 #############################
 # setup logging

--- a/deploy/roles/the_combine_app/tasks/backend_cert.yml
+++ b/deploy/roles/the_combine_app/tasks/backend_cert.yml
@@ -12,18 +12,6 @@
   import_role:
     name: ssl_config
 
-# - name: add the combine user to ACL for certificate files
-#   acl:
-#     name: "{{ item }}"
-#     state: present
-#     permissions: rw
-#     entity: "{{ combine_user }}"
-#     etype:  user
-#     recursive: no
-#     default: yes
-#   with_items:
-#     - "{{ ssl_path }}/localhost.key"
-
 - name: export PKCS12 certificate
   openssl_pkcs12:
     action: export

--- a/deploy/roles/the_combine_app/tasks/install.yml
+++ b/deploy/roles/the_combine_app/tasks/install.yml
@@ -15,10 +15,6 @@
     owner: "{{ www_app_owner }}"
     group: "{{ www_app_group }}"
 
-- name: print build directory
-  debug:
-    var: combine_build_dir
-
 - name: install backend framework
   copy:
     src: "{{ combine_build_dir }}"

--- a/deploy/roles/the_combine_app/tasks/install.yml
+++ b/deploy/roles/the_combine_app/tasks/install.yml
@@ -15,9 +15,13 @@
     owner: "{{ www_app_owner }}"
     group: "{{ www_app_group }}"
 
+- name: print build directory
+  debug:
+    var: combine_build_dir
+
 - name: install backend framework
   copy:
-    src: ../Backend/bin/Release/netcoreapp2.1/
+    src: "{{ combine_build_dir }}"
     dest: "{{ combine_backend_dir }}"
     owner: "{{ combine_user }}"
     group: "{{ combine_group }}"

--- a/deploy/roles/the_combine_app/tasks/main.yml
+++ b/deploy/roles/the_combine_app/tasks/main.yml
@@ -4,4 +4,7 @@
 - { include: install.yml, tags: [ install ] }
 - { include: backend_cert.yml, tags: [ install ] }
 - { include: backend_service.yml, tags: [ install ] }
+# flush handlers so that we can properly test if backend
+# service is up
+- meta: flush_handlers
 - { include: test.yml, tags: [ test ] }

--- a/deploy/roles/the_combine_app/tasks/test.yml
+++ b/deploy/roles/the_combine_app/tasks/test.yml
@@ -8,6 +8,5 @@
   assert:
     success_msg: Combine Backend is running
     fail_msg: "Combine Backend is {{ ansible_facts.services['combine_backend.service'].state }}"
-    quiet: yes
     that:
       - ansible_facts.services['combine_backend.service'].state == 'running'

--- a/deploy/roles/the_combine_app/tasks/test.yml
+++ b/deploy/roles/the_combine_app/tasks/test.yml
@@ -6,5 +6,8 @@
 
 - name: Verify backend is running
   assert:
+    success_msg: Combine Backend is running
+    fail_msg: "Combine Backend is {{ ansible_facts.services['combine_backend.service'].state }}"
+    quiet: yes
     that:
       - ansible_facts.services['combine_backend.service'].state == 'running'

--- a/deploy/roles/the_combine_app/tasks/test.yml
+++ b/deploy/roles/the_combine_app/tasks/test.yml
@@ -1,6 +1,10 @@
 ---
 
 
-- name: Test TheCombine application installation
-  debug:
-    msg: "TO DO: TheCombine application installation tests"
+- name: get service facts
+  service_facts:
+
+- name: Verify backend is running
+  assert:
+    that:
+      - ansible_facts.services['combine_backend.service'].state == 'running'

--- a/deploy/vars/config_common.yml
+++ b/deploy/vars/config_common.yml
@@ -1,11 +1,9 @@
 ---
-
 # Configuration variable that are common to production and development
 
 # configure URL to access the application
 url_domain: "{{ lookup('env', 'TOPLEVELDOMAIN') | default('languagetechnology.org', true) }}"
 url_hostname: "thecombine"
-
 
 www_app_dir: "/var/www/{{ url_hostname }}.org/htdocs"
 www_app_owner: www-data
@@ -16,7 +14,6 @@ www_uploads_dir: /var/thecombine/uploads
 www_uploads_owner: www-data
 www_uploads_group: www-data
 
-
 combine_backend_dir: /home/{{ combine_user }}/Backend
 
 ###############################################
@@ -24,7 +21,7 @@ combine_backend_dir: /home/{{ combine_user }}/Backend
 # the certificate server,
 #(thecombine.languagetechnology.org)
 ###############################################
-cert_server_user:  cert-user
+cert_server_user: cert-user
 cert_server_login_key_path: site_files/root_keys
 
 # mongo_path: /hddlinux/mongodb
@@ -49,21 +46,20 @@ combine_group: combine
 backend_loglevel_default: "{{ app_loglevel | default('Information') }}"
 backend_loglevel_system: "{{ sys_loglevel | default('Information') }}"
 backend_loglevel_microsoft: "{{ ms_loglevel | default('Information') }}"
-backend_dotnet_version:  "{{ lookup('pipe', 'grep TargetFramework ../Backend/BackendFramework.csproj') | regex_replace('.*<TargetFramework>netcoreapp([\\d\\.]+).*', '\\1') }}"
 
 ###############################################
 # SSL config for certificate for Backend Web Server (Kestrel)
 ###############################################
 backend_cert_name: "localhost.pem"
-backend_key_name:  "localhost.key"
-backend_csr_name:  "localhost.csr"
+backend_key_name: "localhost.key"
+backend_csr_name: "localhost.csr"
 
-backend_pfx_cert_name:    "localhost.pfx"
-backend_cert_email:    jimgrady.jg@gmail.com
-backend_cert_country:  US
-backend_cert_state:    Texas
+backend_pfx_cert_name: "localhost.pfx"
+backend_cert_email: jimgrady.jg@gmail.com
+backend_cert_country: US
+backend_cert_state: Texas
 backend_cert_locality: Dallas
-backend_cert_org:      SIL International
+backend_cert_org: SIL International
 
 ssl_path: "/home/{{ combine_user }}/.ssl"
 ssl_path_owner: "{{ combine_user }}"
@@ -72,18 +68,18 @@ ssl_path_group: "{{ combine_user }}"
 ssl_letsencrypt_install: false
 
 ssl_items:
-  - name:  "localhost"
+  - name: "localhost"
     state: selfsign
     request:
-        country_code: "{{ backend_cert_country }}"
-        state: "{{ backend_cert_state }}"
-        locality: "{{ backend_cert_locality }}"
-        organization: "{{ backend_cert_org }}"
-        organization_unit: "Language Technology"
-        common_name: "{{ url_hostname }}"
-        alt_names:
-          - key: DNS.1
-            value: "localhost"
+      country_code: "{{ backend_cert_country }}"
+      state: "{{ backend_cert_state }}"
+      locality: "{{ backend_cert_locality }}"
+      organization: "{{ backend_cert_org }}"
+      organization_unit: "Language Technology"
+      common_name: "{{ url_hostname }}"
+      alt_names:
+        - key: DNS.1
+          value: "localhost"
     sign:
 
 # Apache configuration
@@ -126,13 +122,13 @@ apache_vhosts:
         ssl_path: "/etc/letsencrypt/live/{{ apache_server_name }}"
         certificate_file: "cert.pem"
         key_file: "privkey.pem"
-#        chain_file: "fullchain.pem"
+        #        chain_file: "fullchain.pem"
         extra:
-        - '<ifModule mod_headers.c>'
-        - '    <Files "service-worker.js">'
-        - '        Header Set Service-Worker-allowed "/"'
-        - '    </Files>'
-        - '</IfModule>'
+          - "<ifModule mod_headers.c>"
+          - '    <Files "service-worker.js">'
+          - '        Header Set Service-Worker-allowed "/"'
+          - "    </Files>"
+          - "</IfModule>"
         reverse_proxy: true
         proxy:
-          - '/v1/ https://127.0.0.1:5001/v1/'
+          - "/v1/ https://127.0.0.1:5001/v1/"

--- a/deploy/vars/config_common.yml
+++ b/deploy/vars/config_common.yml
@@ -124,11 +124,11 @@ apache_vhosts:
         key_file: "privkey.pem"
         #        chain_file: "fullchain.pem"
         extra:
-          - "<ifModule mod_headers.c>"
+          - '<ifModule mod_headers.c>'
           - '    <Files "service-worker.js">'
           - '        Header Set Service-Worker-allowed "/"'
-          - "    </Files>"
-          - "</IfModule>"
+          - '    </Files>'
+          - '</IfModule>'
         reverse_proxy: true
         proxy:
-          - "/v1/ https://127.0.0.1:5001/v1/"
+          - '/v1/ https://127.0.0.1:5001/v1/'

--- a/deploy/vars/config_common.yml
+++ b/deploy/vars/config_common.yml
@@ -49,7 +49,7 @@ combine_group: combine
 backend_loglevel_default: "{{ app_loglevel | default('Information') }}"
 backend_loglevel_system: "{{ sys_loglevel | default('Information') }}"
 backend_loglevel_microsoft: "{{ ms_loglevel | default('Information') }}"
-
+backend_dotnet_version:  "{{ lookup('pipe', 'grep TargetFramework ../Backend/BackendFramework.csproj') | regex_replace('.*<TargetFramework>netcoreapp([\\d\\.]+).*', '\\1') }}"
 
 ###############################################
 # SSL config for certificate for Backend Web Server (Kestrel)


### PR DESCRIPTION
Closes #371.

Issue #371 states that the role for the_combine_app installs the Backend software from a hardcoded directory.  This PR makes the following changes to address this issue:
 - Use .NET version specified in BackendFramework.csproj to select directory for Backend software to install
 - Add a test to verify that the backend service is running at the end of the installation process
 - Update build script to remove old builds before building the backend

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/372)
<!-- Reviewable:end -->
