### PR TITLE
Add trailing '/' to combine_build_dir variable.

### DIFF
--- a/deploy/playbook_publish.yml
+++ b/deploy/playbook_publish.yml
@@ -12,7 +12,7 @@
     - "vars/vault_config.yml"
 
   vars:
-    - combine_build_dir: "../Backend/bin/Release/{{ lookup('pipe', 'grep TargetFramework ../Backend/BackendFramework.csproj') | regex_replace('.*<TargetFramework>([^<]+).*', '\\1') }}"
+    - combine_build_dir: "../Backend/bin/Release/{{ lookup('pipe', 'grep TargetFramework ../Backend/BackendFramework.csproj') | regex_replace('.*<TargetFramework>([^<]+).*', '\\1') }}/"
 
   tasks:
     - name: print backend software location


### PR DESCRIPTION
The trailing '/' is required so that .../netcore3.1/* is copied to {{ 
dest_dir}} instead of {{ dest_dir }}/netcore3.1.

*Assertion:* The problem is limited to how TheCombine backend software is installed on the target.  Verification can be performed on a NUC or the demo server.

*Verification Method*
1. Verify installation on clean target
   1. Reinstall OS on NUC from restore image (OS, users & ssh keys setup) & upgrade packages
   1. Install app using .NET 3.1 on NUC
      1. `playbook_nuc.yml` to install .NET 3.1
      1. Run `./build.sh`
      1. Run `playbook_publish.yml` to install TheCombine on the NUC
   1. *Verify* operation of TheCombine
      1. *Verify* combine_backend service is running on NUC
      1. Connect to *TheCombine* via WiFi access point
      1. *Verify* frontend can connect to backend, e.g. register a new user.
1. Verify installation on target that had .NET 2.1 version of *TheCombine* installed
   1. Reinstall OS on NUC from restore image (OS, users & ssh keys setup) & upgrade packages
   1. Checkout commit 0152bf13 ('master' before backend was ported to .NET 3.1)
   1. Install app using .NET 2.1 on NUC
   1. *Verify* that 2.1 is only .NET runtime installed
   1. *Verify* operation of TheCombine
   1. Checkout branch `fix_backend_install_dir` (current change)
   1. Install app using .NET 3.1 on NUC
   1. *Verify* that 3.1 is only .NET runtime installed
   1. *Verify* operation of TheCombine

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/381)
<!-- Reviewable:end -->
