### PR TITLE
Allow deleting all senses from a word

### DIFF
--- a/src/goals/ReviewEntries/ReviewEntriesComponent/ReviewEntriesActions.tsx
+++ b/src/goals/ReviewEntries/ReviewEntriesComponent/ReviewEntriesActions.tsx
@@ -106,10 +106,6 @@ function cleanSenses(
     if (senseBuffer) cleanSenses.push(senseBuffer);
   }
 
-  // Check to see if the user is attempting to delete all senses and correct accordingly
-  if (cleanSenses.filter((value) => !value.deleted).length === 0)
-    cleanSenses = oldSenses;
-
   return cleanSenses;
 }
 

--- a/src/goals/ReviewEntries/ReviewEntriesComponent/tests/ReviewEntriesActions.test.tsx
+++ b/src/goals/ReviewEntries/ReviewEntriesComponent/tests/ReviewEntriesActions.test.tsx
@@ -274,17 +274,6 @@ describe("Test ReviewEntriesActions", () => {
     checkResultantData(oldFrontierWord);
   });
 
-  it("Reverts senses when all senses of an old word removed", async () => {
-    await makeDispatch(
-      {
-        ...oldWord,
-        senses: [],
-      },
-      oldWord
-    );
-    checkResultantData(oldFrontierWord);
-  });
-
   // Tests rejection of bad data
   it("Rejects a vernacular which is empty and cannot be restored", async () => {
     mockBackendReturn({ ...oldFrontierWord, vernacular: "" });


### PR DESCRIPTION
closes #312 

The review entries page purposefully prevented you from removing all senses from a word. This has been removed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/387)
<!-- Reviewable:end -->
