### PR TITLE
Add Ubuntu 18.04 development instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ Backend.Tests/bin/Audio/*.mp3
 /**/*.~un
 /**/*.swp
 Backend.Tests/bin/Avatars/*
+mongo_database
 
 # Vagrant instances
 .vagrant/

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A rapid word collection tool.
      /bin to PATH Environment Variable
      - On Windows, if using [Chocolatey][chocolatey]: `choco install mongodb`
      - On Ubuntu 18.04:
-        ```
+        ```bash
         $ sudo apt install mongodb
 
         # Disable Mongo from starting system-wide.

--- a/README.md
+++ b/README.md
@@ -27,17 +27,9 @@ A rapid word collection tool.
    - [.NET Core SDK 3.1 (LTS)](https://dotnet.microsoft.com/download/dotnet-core/3.1)
      - On Ubuntu 18.04, follow these 
        [instructions](https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-ubuntu-1804).
-   - [MongoDB Server](https://www.mongodb.com/download-center/community) and add
+   - [MongoDB Server](https://docs.mongodb.com/manual/administration/install-community/) and add
      /bin to PATH Environment Variable
      - On Windows, if using [Chocolatey][chocolatey]: `choco install mongodb`
-     - On Ubuntu 18.04:
-        ```bash
-        $ sudo apt install mongodb
-
-        # Disable Mongo from starting system-wide.
-        $ sudo systemctl disable mongodb
-        $ sudo systemctl stop mongodb
-        ```
    - [VS Code](https://code.visualstudio.com/download) and Prettier code
      formatting extension
    - [dotnet-format](https://github.com/dotnet/format):

--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ A rapid word collection tool.
 5. (VS Code Users Only) Enable automatic formatting on save.
    - **File** | **Preferences** | **Settings** | Search for **formatOnSave** and
      check the box.
-6. Run `npm run predatabase` to create the local database folder.
-7. Run `npm start` from the project directory to install dependencies and start
+6. Run `npm start` from the project directory to install dependencies and start
    the project
 
 [chocolatey]: https://chocolatey.org/

--- a/README.md
+++ b/README.md
@@ -21,12 +21,9 @@ A rapid word collection tool.
 2. Install:
    - [Node.js 12 (LTS)](https://nodejs.org/en/)
      - On Windows, if using [Chocolatey][chocolatey]: `choco install nodejs-lts`
-     - On Ubuntu 18.04:
-        ```bash
-        $ sudo apt install curl
-        $ curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
-        $ sudo apt install nodejs
-        ```
+     - On Ubuntu, follow
+       [this guide](https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions)
+       using the appropriate Node.js version.
    - [.NET Core SDK 3.1 (LTS)](https://dotnet.microsoft.com/download/dotnet-core/3.1)
      - On Ubuntu 18.04, follow these 
        [instructions](https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-ubuntu-1804).

--- a/README.md
+++ b/README.md
@@ -21,15 +21,31 @@ A rapid word collection tool.
 2. Install:
    - [Node.js 12 (LTS)](https://nodejs.org/en/)
      - On Windows, if using [Chocolatey][chocolatey]: `choco install nodejs-lts`
+     - On Ubuntu 18.04:
+        ```bash
+        $ sudo apt install curl
+        $ curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+        $ sudo apt install nodejs
+        ```
    - [.NET Core SDK 3.1 (LTS)](https://dotnet.microsoft.com/download/dotnet-core/3.1)
+     - On Ubuntu 18.04, follow these 
+       [instructions](https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-ubuntu-1804).
    - [MongoDB Server](https://www.mongodb.com/download-center/community) and add
      /bin to PATH Environment Variable
      - On Windows, if using [Chocolatey][chocolatey]: `choco install mongodb`
+     - On Ubuntu 18.04:
+        ```
+        $ sudo apt install mongodb
+
+        # Disable Mongo from starting system-wide.
+        $ sudo systemctl disable mongodb
+        $ sudo systemctl stop mongodb
+        ```
    - [VS Code](https://code.visualstudio.com/download) and Prettier code
      formatting extension
    - [dotnet-format](https://github.com/dotnet/format):
      `dotnet tool install -g dotnet-format --version 3.3.111304`
-3. Run `dotnet dev-certs https` and `dotnet dev-certs https --trust` to
+3. (Windows Only) Run `dotnet dev-certs https` and `dotnet dev-certs https --trust` to
    generate and trust an SSL certificate
 4. Set the environment variable `ASPNETCORE_JWT_SECRET_KEY` to a string
    **containing at least 16 characters**, such as _This is a secret key_. Set
@@ -37,7 +53,8 @@ A rapid word collection tool.
 5. (VS Code Users Only) Enable automatic formatting on save.
    - **File** | **Preferences** | **Settings** | Search for **formatOnSave** and
      check the box.
-6. Run `npm start` from the project directory to install dependencies and start
+6. Run `npm run predatabase` to create the local database folder.
+7. Run `npm start` from the project directory to install dependencies and start
    the project
 
 [chocolatey]: https://chocolatey.org/

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A rapid word collection tool.
    ```
 
 2. Install:
-   - [Node.js 12 (LTS)](https://nodejs.org/en/)
+   - [Node.js 12 (LTS)](https://nodejs.org/en/download/)
      - On Windows, if using [Chocolatey][chocolatey]: `choco install nodejs-lts`
      - On Ubuntu, follow
        [this guide](https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions)

--- a/mongo_database/.gitignore
+++ b/mongo_database/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/setupMongo.ts
+++ b/setupMongo.ts
@@ -1,6 +1,6 @@
 import * as makeDir from "make-dir";
 
-const directory = "../mongo_database";
+const directory = "./mongo_database";
 
 const makeMongoDirectory = async () => {
   await makeDir(directory);


### PR DESCRIPTION
Closes #400 

- Add development instructions for Ubuntu 18.04
- Fix `npm run predatabase` script

These instructions were tested on a clean, up-to-date Ubuntu 18.04 VM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/401)
<!-- Reviewable:end -->
