### PR TITLE
Revert getProjectsByUser to use projectRoles

### DIFF
--- a/src/backend/index.tsx
+++ b/src/backend/index.tsx
@@ -197,7 +197,7 @@ export async function getAllProjects(): Promise<Project[]> {
 }
 
 export async function getAllProjectsByUser(user: User): Promise<Project[]> {
-  let projectIds: string[] = Object.keys(user.workedProjects);
+  let projectIds: string[] = Object.keys(user.projectRoles);
   let projects: Project[] = [];
   for (let projectId of projectIds) {
     await getProject(projectId).then((project) => {


### PR DESCRIPTION
projectRoles is the field used to specify a users relation to a project while workedProjects is used to store a list of the things a user has done on a project. If a user makes no changes to a project, invited but hasn't done anything, then it would be entirely acceptable for that project not to show up in the users workedProjects, however projectRoles will have to mention the relationship.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/403)
<!-- Reviewable:end -->
