### PR TITLE
Fix README getting started link to point to .NET Core 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,4 +138,4 @@ TODO
 - [React-Redux](https://redux.js.org/basics/usage-with-react)
 - [React-Localize-Redux](https://ryandrewjohnson.github.io/react-localize-redux/)
   (Language Localization)
-- [ASP.NET](https://docs.microsoft.com/en-us/aspnet/core/getting-started/?view=aspnetcore-2.2)
+- [ASP.NET](https://docs.microsoft.com/en-us/aspnet/core/getting-started/?view=aspnetcore-3.1)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/405)
<!-- Reviewable:end -->
