### PR TITLE
Patch refreshWord to return 'en' for analysisLang if none is stored.

### DIFF
--- a/src/goals/ReviewEntries/ReviewEntriesComponent/ReviewEntriesActions.tsx
+++ b/src/goals/ReviewEntries/ReviewEntriesComponent/ReviewEntriesActions.tsx
@@ -206,7 +206,9 @@ export function refreshWord(oldWordId: string, newWordId: string) {
     getState: () => StoreState
   ) => {
     const newWord = await backend.getWord(newWordId);
-    const analysisLang = getState().currentProject.analysisWritingSystems[0];
+    const analysisLang = getState().currentProject.analysisWritingSystems[0]
+      ? getState().currentProject.analysisWritingSystems[0]
+      : "en";
 
     dispatch(
       updateWord(oldWordId, newWordId, parseWord(newWord, analysisLang))


### PR DESCRIPTION
Resolves #328

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/435)
<!-- Reviewable:end -->
