### PR TITLE
Fix baseURL

### DIFF
--- a/src/backend/index.tsx
+++ b/src/backend/index.tsx
@@ -12,7 +12,7 @@ import { UserRole } from "../types/userRole";
 import { RuntimeConfig } from "../types/runtimeConfig";
 import * as LocalStorage from "./localStorage";
 
-const baseURL = RuntimeConfig.getInstance().baseUrl();
+const baseURL = `${RuntimeConfig.getInstance().baseUrl()}/v1`;
 
 const backendServer = axios.create({
   baseURL,

--- a/src/types/runtimeConfig.tsx
+++ b/src/types/runtimeConfig.tsx
@@ -48,7 +48,7 @@ export class RuntimeConfig {
     } else {
       baseUrl = defaultConfig.baseUrl;
     }
-    return `${baseUrl}/v1`;
+    return baseUrl;
   }
 
   public captchaSiteKey(): string {


### PR DESCRIPTION
#446 Introduced an error causing all backend wrappers to drop the `/v1` prefix from their routes. I have changed appending the `/v1` prefix to be handled by the backend wrapper rather than the runtimeConfig.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/447)
<!-- Reviewable:end -->
