### PR TITLE
Remove '/v1' from baseUrl configuration files

### DIFF
--- a/deploy/group_vars/nuc/main.yml
+++ b/deploy/group_vars/nuc/main.yml
@@ -5,7 +5,7 @@
 # Group: nuc
 #################################################
 
-config_base_url: "https://thecombine.languagetechnology.org/v1"
+config_base_url: "https://thecombine.languagetechnology.org"
 config_captcha_required: "false"
 config_captcha_sitekey: ""
 

--- a/deploy/group_vars/server/main.yml
+++ b/deploy/group_vars/server/main.yml
@@ -5,7 +5,7 @@
 # Group: server
 #################################################
 
-config_base_url: "https://thecombine.languagetechnology.org/v1"
+config_base_url: "https://thecombine.languagetechnology.org"
 config_captcha_required: "true"
 config_captcha_sitekey: "6LemQNgUAAAAAAwJ6dps-Uncg5xsNuDdMxehfW8d"
 


### PR DESCRIPTION
Update server configurations to match changes made in PR #447.

PR#447 updates RuntimeConfig.baseUrl() so that it returns the URL of the server, not the URL of the Backend service.  This requires that the config.js files that are generated to deploy the application must not have the '/v1' in any configuration items.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/462)
<!-- Reviewable:end -->
