### PR TITLE
Add clarification about the SMTP variable values

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ A rapid word collection tool.
 4. Set the environment variable `ASPNETCORE_JWT_SECRET_KEY` to a string
    **containing at least 16 characters**, such as _This is a secret key_. Set
    it in your `.profile` (Linux) or the _System_ app (Windows).
-6. If you want the email services to work you will need to set the following environment variables:
+6. If you want the email services to work you will need to set the following environment variables.
+   These values must be kept secret, so ask your email administrator to supply them.
    - `ASPNETCORE_SMTP_SERVER`
    - `ASPNETCORE_SMTP_PORT`
    - `ASPNETCORE_SMTP_USERNAME`


### PR DESCRIPTION
Explain that `STMP` environment values must be kept secret, which is why they are not provided in the README.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/513)
<!-- Reviewable:end -->
