### PR TITLE
Run backend on a non-privileged port within Docker container

### DIFF
--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -13,6 +13,7 @@ RUN dotnet publish -c Release -o build
 # Build runtime image.
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
 
+ENV ASPNETCORE_URLS=http://+:5000
 ENV COMBINE_IS_IN_CONTAINER=1
 
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     volumes:
       - backend_data:/root/.CombineFiles
     expose:
-      - 80
+      - 5000
     depends_on:
       - database
     env_file:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -13,7 +13,7 @@ server {
   charset             utf-8;
 
   location /v1 {
-        proxy_pass         http://backend;
+        proxy_pass         http://backend:5000;
         proxy_http_version 1.1;
         proxy_set_header   Upgrade $http_upgrade;
         proxy_set_header   Connection keep-alive;


### PR DESCRIPTION
When running inside of Docker, the backend now runs on port 5000 rather than port 80. This is an important first step towards #514, as now running the backend itself inside the container no longer requires root priveledges.

This change is completed isolated within the Docker Compose project and does not affect any external deployment configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/523)
<!-- Reviewable:end -->
