### PR TITLE
Fix goal suggestions

### DIFF
--- a/src/components/GoalTimeline/GoalTimelineVertical/GoalTimelineVertical.tsx
+++ b/src/components/GoalTimeline/GoalTimelineVertical/GoalTimelineVertical.tsx
@@ -109,7 +109,7 @@ export class GoalTimelineVertical extends React.Component<
     let data: Goal[] = this.props.suggestions.slice(1);
     let hasGoal: boolean;
 
-    if (data.length) {
+    if (this.props.suggestions.length) {
       for (let goal of this.props.allPossibleGoals) {
         hasGoal = false;
         for (let i = 0; i < data.length && !hasGoal; i++) {

--- a/src/components/GoalTimeline/GoalTimelineVertical/GoalTimelineVertical.tsx
+++ b/src/components/GoalTimeline/GoalTimelineVertical/GoalTimelineVertical.tsx
@@ -109,18 +109,21 @@ export class GoalTimelineVertical extends React.Component<
     let data: Goal[] = this.props.suggestions.slice(1);
     let hasGoal: boolean;
 
-    for (let goal of this.props.allPossibleGoals) {
-      hasGoal = false;
-      for (let i = 0; i < data.length && !hasGoal; i++) {
-        if (goal.name === data[i].name) {
-          hasGoal = true;
+    if (data.length) {
+      for (let goal of this.props.allPossibleGoals) {
+        hasGoal = false;
+        for (let i = 0; i < data.length && !hasGoal; i++) {
+          if (goal.name === data[i].name) {
+            hasGoal = true;
+          }
+        }
+        if (!hasGoal && goal.name !== this.props.suggestions[0].name) {
+          data.push(goal);
         }
       }
-      if (!hasGoal && goal.name !== this.props.suggestions[0].name) {
-        data.push(goal);
-      }
+    } else {
+      return this.props.allPossibleGoals;
     }
-
     return data;
   }
 

--- a/src/components/GoalTimeline/GoalTimelineVertical/tests/GoalTimelineVertical.test.tsx
+++ b/src/components/GoalTimeline/GoalTimelineVertical/tests/GoalTimelineVertical.test.tsx
@@ -96,6 +96,11 @@ describe("Test GoalTimelineVertical", () => {
     // Cleanup
     createTimeMaster();
   });
+
+  it("Generates proper suggestion data: empty suggestion data", () => {
+    createTimeMaster([], []);
+    expect(timeHandle.createSuggestionData()).toEqual(goals);
+  });
 });
 
 function createTimeMaster(history?: Goal[], suggestions?: Goal[]): void {


### PR DESCRIPTION
My pull request for removing duplicate goal suggestions in Data Cleanup > Other Options contains a bug for when the goalSuggestions redux state is empty. To reproduce the issue, select Data Cleanup > Our Recommendation 3 times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/567)
<!-- Reviewable:end -->
