### PR TITLE
Make TAB skip things that don't play well with ENTER.

### DIFF
--- a/src/components/DataEntry/DataEntryHeader/DataEntryHeader.tsx
+++ b/src/components/DataEntry/DataEntryHeader/DataEntryHeader.tsx
@@ -46,6 +46,11 @@ export class DataEntryHeader extends React.Component<
           color="primary"
           style={{ paddingTop: "8px" }}
           disabled={!hasQuestions}
+          onKeyPress={(e) => {
+            if (e.key === "Enter") {
+              this.props.setQuestionVisibility(!this.props.questionsVisible);
+            }
+          }}
         />
         {getQuestions(this.props.questionsVisible, this.props.domain.questions)}
       </Typography>

--- a/src/components/DataEntry/DataEntryTable/DataEntryTable.tsx
+++ b/src/components/DataEntry/DataEntryTable/DataEntryTable.tsx
@@ -405,6 +405,7 @@ export class DataEntryTable extends React.Component<
               variant="contained"
               color={this.state.isReady ? "primary" : "secondary"}
               style={{ marginTop: theme.spacing(2) }}
+              tabIndex="-1"
               onClick={() => {
                 // Check if there is a new word, but the user clicked complete instead of pressing enter
                 if (this.refNewEntry.current) {

--- a/src/components/DataEntry/DataEntryTable/DataEntryTable.tsx
+++ b/src/components/DataEntry/DataEntryTable/DataEntryTable.tsx
@@ -405,7 +405,7 @@ export class DataEntryTable extends React.Component<
               variant="contained"
               color={this.state.isReady ? "primary" : "secondary"}
               style={{ marginTop: theme.spacing(2) }}
-              tabIndex="-1"
+              tabIndex={-1}
               onClick={() => {
                 // Check if there is a new word, but the user clicked complete instead of pressing enter
                 if (this.refNewEntry.current) {

--- a/src/components/DataEntry/DataEntryTable/ExistingEntry/DeleteEntry/DeleteEntry.tsx
+++ b/src/components/DataEntry/DataEntryTable/ExistingEntry/DeleteEntry/DeleteEntry.tsx
@@ -21,7 +21,11 @@ export class DeleteEntry extends React.Component<
     return (
       <React.Fragment>
         <Tooltip title={<Translate id="addWords.deleteRow" />} placement="top">
-          <IconButton size="small" onClick={() => this.props.removeEntry()}>
+          <IconButton
+            tabIndex="-1"
+            size="small"
+            onClick={() => this.props.removeEntry()}
+          >
             <Delete />
           </IconButton>
         </Tooltip>

--- a/src/components/DataEntry/DataEntryTable/ExistingEntry/DeleteEntry/DeleteEntry.tsx
+++ b/src/components/DataEntry/DataEntryTable/ExistingEntry/DeleteEntry/DeleteEntry.tsx
@@ -22,7 +22,7 @@ export class DeleteEntry extends React.Component<
       <React.Fragment>
         <Tooltip title={<Translate id="addWords.deleteRow" />} placement="top">
           <IconButton
-            tabIndex="-1"
+            tabIndex={-1}
             size="small"
             onClick={() => this.props.removeEntry()}
           >

--- a/src/components/Pronunciations/AudioPlayer.tsx
+++ b/src/components/Pronunciations/AudioPlayer.tsx
@@ -59,7 +59,7 @@ export default function AudioPlayer(props: PlayerProps) {
   return (
     <Tooltip title={<Translate id="pronunciations.playTooltip" />}>
       <IconButton
-        tabIndex="-1"
+        tabIndex={-1}
         onClick={deleteOrTogglePlay}
         className={classes.button}
         aria-label="play"

--- a/src/components/Pronunciations/AudioPlayer.tsx
+++ b/src/components/Pronunciations/AudioPlayer.tsx
@@ -59,6 +59,7 @@ export default function AudioPlayer(props: PlayerProps) {
   return (
     <Tooltip title={<Translate id="pronunciations.playTooltip" />}>
       <IconButton
+        tabIndex="-1"
         onClick={deleteOrTogglePlay}
         className={classes.button}
         aria-label="play"

--- a/src/components/Pronunciations/RecorderIcon.tsx
+++ b/src/components/Pronunciations/RecorderIcon.tsx
@@ -49,7 +49,7 @@ export default function RecorderIcon(props: RecorderIconProps) {
 
   return (
     <IconButton
-      tabIndex="-1"
+      tabIndex={-1}
       onMouseDown={toggleIsRecordingToTrue}
       onTouchStart={toggleIsRecordingToTrue}
       onMouseUp={toggleIsRecordingToFalse}

--- a/src/components/Pronunciations/RecorderIcon.tsx
+++ b/src/components/Pronunciations/RecorderIcon.tsx
@@ -49,6 +49,7 @@ export default function RecorderIcon(props: RecorderIconProps) {
 
   return (
     <IconButton
+      tabIndex="-1"
       onMouseDown={toggleIsRecordingToTrue}
       onTouchStart={toggleIsRecordingToTrue}
       onMouseUp={toggleIsRecordingToFalse}

--- a/src/components/Pronunciations/tests/__snapshots__/Pronunciations.test.tsx.snap
+++ b/src/components/Pronunciations/tests/__snapshots__/Pronunciations.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`pronunciation tests displays buttons 1`] = `
     onTouchEnd={[Function]}
     onTouchMove={[Function]}
     onTouchStart={[Function]}
-    tabIndex={0}
+    tabIndex="-1"
     type="button"
   >
     <span
@@ -62,7 +62,7 @@ exports[`pronunciation tests displays buttons 1`] = `
     onTouchEnd={[Function]}
     onTouchMove={[Function]}
     onTouchStart={[Function]}
-    tabIndex={0}
+    tabIndex="-1"
     title={null}
     type="button"
   >
@@ -102,7 +102,7 @@ exports[`pronunciation tests displays buttons 1`] = `
     onTouchEnd={[Function]}
     onTouchMove={[Function]}
     onTouchStart={[Function]}
-    tabIndex={0}
+    tabIndex="-1"
     title={null}
     type="button"
   >

--- a/src/components/Pronunciations/tests/__snapshots__/Pronunciations.test.tsx.snap
+++ b/src/components/Pronunciations/tests/__snapshots__/Pronunciations.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`pronunciation tests displays buttons 1`] = `
     onTouchEnd={[Function]}
     onTouchMove={[Function]}
     onTouchStart={[Function]}
-    tabIndex="-1"
+    tabIndex={-1}
     type="button"
   >
     <span
@@ -62,7 +62,7 @@ exports[`pronunciation tests displays buttons 1`] = `
     onTouchEnd={[Function]}
     onTouchMove={[Function]}
     onTouchStart={[Function]}
-    tabIndex="-1"
+    tabIndex={-1}
     title={null}
     type="button"
   >
@@ -102,7 +102,7 @@ exports[`pronunciation tests displays buttons 1`] = `
     onTouchEnd={[Function]}
     onTouchMove={[Function]}
     onTouchStart={[Function]}
-    tabIndex="-1"
+    tabIndex={-1}
     title={null}
     type="button"
   >


### PR DESCRIPTION
For the sake of vision-impaired users, we will eventually want a more thorough refactor of how everything behaves with keyboard-and-voice-only operation.

For now, this resolves #479

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/579)
<!-- Reviewable:end -->
