### PR TITLE
[DataEntryTable] Remove "en" assumption

### DIFF
--- a/src/components/DataEntry/DataEntryTable/DataEntryTable.tsx
+++ b/src/components/DataEntry/DataEntryTable/DataEntryTable.tsx
@@ -8,6 +8,8 @@ import {
 } from "react-localize-redux";
 
 import * as Backend from "../../../backend";
+import { getProjectId } from "../../../backend/localStorage";
+import { Project } from "../../../types/project";
 import DomainTree from "../../../types/SemanticDomain";
 import theme from "../../../types/theme";
 import {
@@ -43,6 +45,7 @@ interface DataEntryTableState {
   existingWords: Word[];
   recentlyAddedWords: WordAccess[];
   isReady: boolean;
+  analysisLang: string;
 }
 
 async function addAudiosToBackend(
@@ -91,22 +94,17 @@ export function addSemanticDomainToSense(
 export function addSenseToWord(
   semanticDomain: SemanticDomain,
   existingWord: Word,
-  gloss: string
+  gloss: string,
+  language: string
 ): Word {
-  let updatedWord: Word = { ...existingWord };
-
-  let newGloss: Gloss = {
-    language: "en",
-    def: gloss,
-  };
-
-  let newSense: Sense = {
+  const updatedWord: Word = { ...existingWord };
+  const newGloss: Gloss = { language, def: gloss };
+  const newSense: Sense = {
     glosses: [newGloss],
     semanticDomains: [semanticDomain],
     accessibility: State.Active,
   };
-
-  updatedWord.senses.push(newSense); // Fix which sense we are adding to
+  updatedWord.senses.push(newSense);
   return updatedWord;
 }
 
@@ -124,6 +122,7 @@ export class DataEntryTable extends React.Component<
       existingWords: [],
       recentlyAddedWords: [],
       isReady: false,
+      analysisLang: "en",
     };
     this.refNewEntry = React.createRef<NewEntry>();
     this.recorder = new Recorder();
@@ -133,6 +132,15 @@ export class DataEntryTable extends React.Component<
 
   async componentDidMount() {
     await this.updateExisting();
+    await this.getProjectSettings();
+  }
+
+  async getProjectSettings() {
+    const proj: Project = await Backend.getProject(getProjectId());
+    let analysisLang: string = "en";
+    if (proj.analysisWritingSystems.length > 0)
+      analysisLang = proj.analysisWritingSystems[0].bcp47;
+    this.setState({ analysisLang });
   }
 
   /** Finished with this page of words, select new semantic domain */
@@ -157,9 +165,7 @@ export class DataEntryTable extends React.Component<
     } else {
       recentlyAddedWords.push(newWordAccess);
     }
-    this.setState({
-      recentlyAddedWords,
-    });
+    this.setState({ recentlyAddedWords });
   }
 
   /** Update the word in the backend and the frontend */
@@ -247,7 +253,8 @@ export class DataEntryTable extends React.Component<
     const updatedWord = addSenseToWord(
       this.props.semanticDomain,
       existingWord,
-      gloss
+      gloss,
+      this.state.analysisLang
     );
     await this.updateWordForNewEntry(
       updatedWord,
@@ -514,6 +521,7 @@ export class DataEntryTable extends React.Component<
                   if (this.refNewEntry.current)
                     this.refNewEntry.current.focusVernInput();
                 }}
+                analysisLang={this.state.analysisLang}
               />
             </Grid>
           ))}
@@ -536,6 +544,7 @@ export class DataEntryTable extends React.Component<
                 this.setState({ isReady: isReady })
               }
               recorder={this.recorder}
+              analysisLang={this.state.analysisLang}
             />
           </Grid>
         </Grid>

--- a/src/components/DataEntry/DataEntryTable/NewEntry/NewEntry.tsx
+++ b/src/components/DataEntry/DataEntryTable/NewEntry/NewEntry.tsx
@@ -21,6 +21,7 @@ interface NewEntryProps {
   semanticDomain: SemanticDomain;
   setIsReadyState: (isReady: boolean) => void;
   recorder?: Recorder;
+  analysisLang: string;
 }
 
 interface NewEntryState {
@@ -82,7 +83,7 @@ export default class NewEntry extends React.Component<
         ...this.state.newEntry,
         senses: [
           {
-            glosses: [{ language: "en", def: newValue }],
+            glosses: [{ language: this.props.analysisLang, def: newValue }],
             semanticDomains: [this.props.semanticDomain],
           },
         ],

--- a/src/components/DataEntry/DataEntryTable/NewEntry/NewEntry.tsx
+++ b/src/components/DataEntry/DataEntryTable/NewEntry/NewEntry.tsx
@@ -216,6 +216,7 @@ export default class NewEntry extends React.Component<
                 setActiveGloss={(newGloss: string) =>
                   this.setState({ activeGloss: newGloss })
                 }
+                analysisLang={this.props.analysisLang}
               />
             </Grid>
             <Grid item xs={12}>

--- a/src/components/DataEntry/DataEntryTable/NewEntry/tests/NewEntry.test.tsx
+++ b/src/components/DataEntry/DataEntryTable/NewEntry/tests/NewEntry.test.tsx
@@ -21,10 +21,10 @@ describe("Tests NewEntry", () => {
           <NewEntry
             allVerns={[]}
             allWords={[]}
-            updateWordWithNewGloss={() => new Promise(() => {})}
-            addNewWord={() => new Promise(() => {})}
+            updateWordWithNewGloss={jest.fn()}
+            addNewWord={jest.fn()}
             semanticDomain={{ name: "", id: "" }}
-            setIsReadyState={() => null}
+            setIsReadyState={jest.fn()}
             analysisLang={""}
           />
         </Provider>

--- a/src/components/DataEntry/DataEntryTable/NewEntry/tests/NewEntry.test.tsx
+++ b/src/components/DataEntry/DataEntryTable/NewEntry/tests/NewEntry.test.tsx
@@ -21,10 +21,11 @@ describe("Tests NewEntry", () => {
           <NewEntry
             allVerns={[]}
             allWords={[]}
-            updateWord={() => null}
-            addNewWord={() => null}
+            updateWordWithNewGloss={() => new Promise(() => {})}
+            addNewWord={() => new Promise(() => {})}
             semanticDomain={{ name: "", id: "" }}
             setIsReadyState={() => null}
+            analysisLang={""}
           />
         </Provider>
       );

--- a/src/components/DataEntry/DataEntryTable/RecentEntry/RecentEntry.tsx
+++ b/src/components/DataEntry/DataEntryTable/RecentEntry/RecentEntry.tsx
@@ -134,6 +134,7 @@ export default class RecentEntry extends React.Component<
                 if (this.state.vernacular) this.focusOnNewEntry();
               }}
               setActiveGloss={() => {}}
+              analysisLang={""}
             />
           </Grid>
           <Grid

--- a/src/components/DataEntry/DataEntryTable/RecentEntry/RecentEntry.tsx
+++ b/src/components/DataEntry/DataEntryTable/RecentEntry/RecentEntry.tsx
@@ -134,7 +134,7 @@ export default class RecentEntry extends React.Component<
                 if (this.state.vernacular) this.focusOnNewEntry();
               }}
               setActiveGloss={() => {}}
-              analysisLang={""}
+              analysisLang={this.props.analysisLang}
             />
           </Grid>
           <Grid

--- a/src/components/DataEntry/DataEntryTable/RecentEntry/RecentEntry.tsx
+++ b/src/components/DataEntry/DataEntryTable/RecentEntry/RecentEntry.tsx
@@ -22,6 +22,7 @@ interface RecentEntryProps {
   semanticDomain: SemanticDomain;
   recorder: Recorder;
   focusNewEntry: () => void;
+  analysisLang: string;
 }
 
 interface RecentEntryState {
@@ -33,7 +34,7 @@ interface RecentEntryState {
 }
 
 /**
- * Displays a word a user can still make edits to
+ * Displays a recently entered word that a user can still edit
  */
 export default class RecentEntry extends React.Component<
   RecentEntryProps,
@@ -43,7 +44,8 @@ export default class RecentEntry extends React.Component<
     super(props);
 
     let sense: Sense = { ...props.entry.senses[props.senseIndex] };
-    if (sense.glosses.length < 1) sense.glosses.push({ def: "", language: "" });
+    if (sense.glosses.length < 1)
+      sense.glosses.push({ def: "", language: this.props.analysisLang });
 
     this.state = {
       vernacular: props.entry.vernacular,

--- a/src/components/DataEntry/DataEntryTable/RecentEntry/tests/RecentEntry.test.tsx
+++ b/src/components/DataEntry/DataEntryTable/RecentEntry/tests/RecentEntry.test.tsx
@@ -32,14 +32,14 @@ function renderWithWord(word: Word) {
           allWords={[]}
           entry={word}
           senseIndex={0}
-          updateGloss={() => null}
-          updateVern={() => null}
-          removeEntry={() => null}
-          addAudioToWord={() => null}
-          deleteAudioFromWord={() => null}
+          updateGloss={jest.fn()}
+          updateVern={jest.fn()}
+          removeEntry={jest.fn()}
+          addAudioToWord={jest.fn()}
+          deleteAudioFromWord={jest.fn()}
           semanticDomain={{ name: "", id: "" }}
           recorder={new Recorder()}
-          focusNewEntry={() => null}
+          focusNewEntry={jest.fn()}
           analysisLang={"en"}
         />
       </Provider>

--- a/src/components/DataEntry/DataEntryTable/RecentEntry/tests/RecentEntry.test.tsx
+++ b/src/components/DataEntry/DataEntryTable/RecentEntry/tests/RecentEntry.test.tsx
@@ -40,7 +40,7 @@ function renderWithWord(word: Word) {
           semanticDomain={{ name: "", id: "" }}
           recorder={new Recorder()}
           focusNewEntry={() => null}
-          analysisLang={""}
+          analysisLang={"en"}
         />
       </Provider>
     );

--- a/src/components/DataEntry/DataEntryTable/RecentEntry/tests/RecentEntry.test.tsx
+++ b/src/components/DataEntry/DataEntryTable/RecentEntry/tests/RecentEntry.test.tsx
@@ -40,6 +40,7 @@ function renderWithWord(word: Word) {
           semanticDomain={{ name: "", id: "" }}
           recorder={new Recorder()}
           focusNewEntry={() => null}
+          analysisLang={""}
         />
       </Provider>
     );

--- a/src/components/DataEntry/DataEntryTable/VernWithSuggestions/SenseDialog/SenseDialog.tsx
+++ b/src/components/DataEntry/DataEntryTable/VernWithSuggestions/SenseDialog/SenseDialog.tsx
@@ -23,6 +23,7 @@ function SenseDialog(
     selectedWord: Word;
     open: boolean;
     handleClose: (senseIndex: number) => void;
+    analysisLang: string;
   } & LocalizeContextProps
 ) {
   return (
@@ -31,6 +32,7 @@ function SenseDialog(
         <SenseList
           selectedWord={props.selectedWord}
           closeDialog={props.handleClose}
+          analysisLang={props.analysisLang}
         />
       </DialogContent>
     </Dialog>
@@ -40,6 +42,7 @@ function SenseDialog(
 interface SenseListProps {
   selectedWord: Word;
   closeDialog: (senseIndex: number) => void;
+  analysisLang: string;
 }
 
 // Copied from customized menus at https://material-ui.com/components/menus/
@@ -75,10 +78,13 @@ export function SenseList(props: SenseListProps) {
                 </div>
                 <div style={{ margin: theme.spacing(4) }}>
                   <DomainCell
-                    rowData={parseWord({
-                      ...props.selectedWord,
-                      senses: [sense],
-                    } as Word)}
+                    rowData={parseWord(
+                      {
+                        ...props.selectedWord,
+                        senses: [sense],
+                      } as Word,
+                      props.analysisLang
+                    )}
                     sortingByDomains={false}
                   />
                 </div>

--- a/src/components/DataEntry/DataEntryTable/VernWithSuggestions/SenseDialog/SenseDialog.tsx
+++ b/src/components/DataEntry/DataEntryTable/VernWithSuggestions/SenseDialog/SenseDialog.tsx
@@ -65,10 +65,10 @@ export function SenseList(props: SenseListProps) {
             </div>
             <div style={{ margin: theme.spacing(4) }}>
               <DomainCell
-                rowData={parseWord(
-                  { ...props.selectedWord, senses: [sense] } as Word,
-                  "en"
-                )}
+                rowData={parseWord({
+                  ...props.selectedWord,
+                  senses: [sense],
+                } as Word)}
                 sortingByDomains={false}
               />
             </div>

--- a/src/components/DataEntry/DataEntryTable/VernWithSuggestions/VernDialog/VernDialog.tsx
+++ b/src/components/DataEntry/DataEntryTable/VernWithSuggestions/VernDialog/VernDialog.tsx
@@ -24,6 +24,7 @@ export function VernDialog(
     vernacularWords: Word[];
     open: boolean;
     handleClose: (selectedWordId?: string) => void;
+    analysisLang: string;
   } & LocalizeContextProps
 ) {
   return (
@@ -37,6 +38,7 @@ export function VernDialog(
         <VernList
           vernacularWords={props.vernacularWords}
           closeDialog={props.handleClose}
+          analysisLang={props.analysisLang}
         />
       </DialogContent>
     </Dialog>
@@ -46,6 +48,7 @@ export function VernDialog(
 interface VernListProps {
   vernacularWords: Word[];
   closeDialog: (selectedWordId: string) => void;
+  analysisLang: string;
 }
 
 // Copied from customized menus at https://material-ui.com/components/menus/
@@ -91,13 +94,13 @@ export function VernList(props: VernListProps) {
                 <SenseCell
                   editable={false}
                   sortingByGloss={false}
-                  value={parseWord(word).senses}
-                  rowData={parseWord(word)}
+                  value={parseWord(word, props.analysisLang).senses}
+                  rowData={parseWord(word, props.analysisLang)}
                 />
               </div>
               <div style={{ margin: theme.spacing(4) }}>
                 <DomainCell
-                  rowData={parseWord(word)}
+                  rowData={parseWord(word, props.analysisLang)}
                   sortingByDomains={false}
                 />
               </div>

--- a/src/components/DataEntry/DataEntryTable/VernWithSuggestions/VernDialog/VernDialog.tsx
+++ b/src/components/DataEntry/DataEntryTable/VernWithSuggestions/VernDialog/VernDialog.tsx
@@ -71,15 +71,12 @@ export function VernList(props: VernListProps) {
               <SenseCell
                 editable={false}
                 sortingByGloss={false}
-                value={parseWord(word, "en").senses}
-                rowData={parseWord(word, "en")}
+                value={parseWord(word).senses}
+                rowData={parseWord(word)}
               />
             </div>
             <div style={{ margin: theme.spacing(4) }}>
-              <DomainCell
-                rowData={parseWord(word, "en")}
-                sortingByDomains={false}
-              />
+              <DomainCell rowData={parseWord(word)} sortingByDomains={false} />
             </div>
           </StyledMenuItem>
         ))}

--- a/src/components/DataEntry/DataEntryTable/VernWithSuggestions/VernDialog/tests/VernDialog.test.tsx
+++ b/src/components/DataEntry/DataEntryTable/VernWithSuggestions/VernDialog/tests/VernDialog.test.tsx
@@ -21,7 +21,7 @@ describe("Tests VernList ", () => {
       renderer.create(
         <VernList
           vernacularWords={[simpleWord("", "")]}
-          closeDialog={() => null}
+          closeDialog={jest.fn()}
           analysisLang={"en"}
         />
       );

--- a/src/components/DataEntry/DataEntryTable/VernWithSuggestions/VernDialog/tests/VernDialog.test.tsx
+++ b/src/components/DataEntry/DataEntryTable/VernWithSuggestions/VernDialog/tests/VernDialog.test.tsx
@@ -22,6 +22,7 @@ describe("Tests VernList ", () => {
         <VernList
           vernacularWords={[simpleWord("", "")]}
           closeDialog={() => null}
+          analysisLang={"en"}
         />
       );
     });
@@ -54,6 +55,7 @@ function createVernListInstance(
       <VernList
         vernacularWords={_vernacularWords}
         closeDialog={_mockCallback}
+        analysisLang={"en"}
       />
     </Provider>
   ).root;

--- a/src/components/DataEntry/DataEntryTable/VernWithSuggestions/VernWithSuggestions.tsx
+++ b/src/components/DataEntry/DataEntryTable/VernWithSuggestions/VernWithSuggestions.tsx
@@ -26,6 +26,7 @@ interface VernWithSuggestionsProps {
   updateWordId: (wordId?: string) => void;
   selectedWordId?: string;
   onBlur?: () => void;
+  analysisLang: string;
 }
 
 interface VernWithSuggestionsState {
@@ -187,6 +188,7 @@ export class VernWithSuggestions extends React.Component<
               }
             }}
             vernacularWords={this.state.dupVernWords}
+            analysisLang={this.props.analysisLang}
           />
         )}
         {this.props.isNew && (
@@ -201,6 +203,7 @@ export class VernWithSuggestions extends React.Component<
               }
               this.setState({ senseOpen: false });
             }}
+            analysisLang={this.props.analysisLang}
           />
         )}
       </React.Fragment>

--- a/src/components/DataEntry/DataEntryTable/VernWithSuggestions/tests/VernWithSuggestions.test.tsx
+++ b/src/components/DataEntry/DataEntryTable/VernWithSuggestions/tests/VernWithSuggestions.test.tsx
@@ -10,11 +10,11 @@ describe("Tests VernWithSuggestions", () => {
         <LocalizedVernWithSuggestions
           vernacular={""}
           vernInput={React.createRef<HTMLDivElement>()}
-          updateVernField={() => []}
-          setActiveGloss={() => null}
-          updateWordId={() => null}
+          updateVernField={jest.fn()}
+          setActiveGloss={jest.fn()}
+          updateWordId={jest.fn()}
           allVerns={[]}
-          handleEnterAndTab={() => null}
+          handleEnterAndTab={jest.fn()}
           analysisLang={"en"}
         />
       );

--- a/src/components/DataEntry/DataEntryTable/VernWithSuggestions/tests/VernWithSuggestions.test.tsx
+++ b/src/components/DataEntry/DataEntryTable/VernWithSuggestions/tests/VernWithSuggestions.test.tsx
@@ -11,9 +11,11 @@ describe("Tests VernWithSuggestions", () => {
           vernacular={""}
           vernInput={React.createRef<HTMLDivElement>()}
           updateVernField={() => []}
+          setActiveGloss={() => null}
           updateWordId={() => null}
           allVerns={[]}
-          handleEnter={() => null}
+          handleEnterAndTab={() => null}
+          analysisLang={"en"}
         />
       );
     });

--- a/src/components/DataEntry/DataEntryTable/tests/DataEntryTable.test.tsx
+++ b/src/components/DataEntry/DataEntryTable/tests/DataEntryTable.test.tsx
@@ -131,7 +131,9 @@ describe("Tests DataEntryTable", () => {
       ...word,
       senses: [...word.senses, newSense],
     };
-    expect(addSenseToWord(semanticDomain, word, gloss)).toEqual(expectedWord);
+    expect(addSenseToWord(semanticDomain, word, gloss, "en")).toEqual(
+      expectedWord
+    );
   });
 
   it("adds a sense to a word that already has a sense", () => {
@@ -154,7 +156,9 @@ describe("Tests DataEntryTable", () => {
       ...word,
       senses: [...word.senses, expectedSense],
     };
-    expect(addSenseToWord(semanticDomain, word, gloss)).toEqual(expectedWord);
+    expect(addSenseToWord(semanticDomain, word, gloss, "en")).toEqual(
+      expectedWord
+    );
   });
 
   it("adds a semantic domain to an existing sense", () => {

--- a/src/components/DataEntry/DataEntryTable/tests/DataEntryTable.test.tsx
+++ b/src/components/DataEntry/DataEntryTable/tests/DataEntryTable.test.tsx
@@ -58,13 +58,11 @@ beforeEach(() => {
         <DataEntryTable
           domain={baseDomain}
           semanticDomain={mockSemanticDomain}
-          displaySemanticDomainView={(_isGettingSemanticDomain: boolean) => {}}
+          displaySemanticDomainView={jest.fn()}
           isSmallScreen={false}
           hideQuestions={hideQuestionsMock}
-          getWordsFromBackend={() => {
-            return new Promise(() => []);
-          }}
-          showExistingData={() => {}}
+          getWordsFromBackend={jest.fn()}
+          showExistingData={jest.fn()}
         />
       </Provider>
     );

--- a/src/goals/ReviewEntries/ReviewEntriesComponent/ReviewEntriesTypes.ts
+++ b/src/goals/ReviewEntries/ReviewEntriesComponent/ReviewEntriesTypes.ts
@@ -22,7 +22,7 @@ export interface ReviewEntriesSense {
 
 export function parseWord(
   word: Word,
-  analysisLang: string,
+  analysisLang?: string,
   commonRecorder?: Recorder
 ) {
   let currentWord: ReviewEntriesWord = {
@@ -39,7 +39,7 @@ export function parseWord(
   return currentWord;
 }
 // Convert a Sense into a ReviewEntriesSense
-function parseSense(sense: Sense, analysisLang: string) {
+function parseSense(sense: Sense, analysisLang?: string) {
   let hasGloss: boolean;
   let currentSense: ReviewEntriesSense = {
     glosses: "",
@@ -61,7 +61,7 @@ function parseSense(sense: Sense, analysisLang: string) {
   hasGloss = false;
   if (sense.glosses)
     for (let gloss of sense.glosses)
-      if (gloss.language === analysisLang) {
+      if (analysisLang === undefined || gloss.language === analysisLang) {
         hasGloss = true;
         currentSense.glosses += gloss.def + SEPARATOR;
       }

--- a/src/goals/ReviewEntries/ReviewEntriesComponent/ReviewEntriesTypes.ts
+++ b/src/goals/ReviewEntries/ReviewEntriesComponent/ReviewEntriesTypes.ts
@@ -22,7 +22,7 @@ export interface ReviewEntriesSense {
 
 export function parseWord(
   word: Word,
-  analysisLang?: string,
+  analysisLang: string, // bcp47 code
   commonRecorder?: Recorder
 ) {
   let currentWord: ReviewEntriesWord = {
@@ -39,7 +39,7 @@ export function parseWord(
   return currentWord;
 }
 // Convert a Sense into a ReviewEntriesSense
-function parseSense(sense: Sense, analysisLang?: string) {
+function parseSense(sense: Sense, analysisLang: string) {
   let hasGloss: boolean;
   let currentSense: ReviewEntriesSense = {
     glosses: "",
@@ -61,7 +61,7 @@ function parseSense(sense: Sense, analysisLang?: string) {
   hasGloss = false;
   if (sense.glosses)
     for (let gloss of sense.glosses)
-      if (analysisLang === undefined || gloss.language === analysisLang) {
+      if (gloss.language === analysisLang) {
         hasGloss = true;
         currentSense.glosses += gloss.def + SEPARATOR;
       }


### PR DESCRIPTION
**Priority:** Without this change, senses without "en" never show up in the NewEntry dialogs.

* Use project's first analysis language in new entries instead of 'en'
* Allow non-'en' senses to show up in the dialogs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/615)
<!-- Reviewable:end -->
