### PR TITLE
Fix bug in parseWord

### DIFF
--- a/src/goals/ReviewEntries/ReviewEntriesComponent/ReviewEntriesActions.tsx
+++ b/src/goals/ReviewEntries/ReviewEntriesComponent/ReviewEntriesActions.tsx
@@ -239,12 +239,13 @@ function refreshWord(
   ) => {
     const newWordId = await action(oldWordId);
     const newWord = await backend.getWord(newWordId);
+
     const analysisLang = getState().currentProject.analysisWritingSystems[0]
       ? getState().currentProject.analysisWritingSystems[0]
       : { name: "English", bcp47: "en", font: "" };
 
     dispatch(
-      updateWord(oldWordId, newWordId, parseWord(newWord, analysisLang.name))
+      updateWord(oldWordId, newWordId, parseWord(newWord, analysisLang.bcp47))
     );
   };
 }


### PR DESCRIPTION
parseWord was comparing the Analysis Language name instead of the bcp47
This caused recording to make the glosses empty until the page refreshed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/622)
<!-- Reviewable:end -->
