### PR TITLE
[ProjectSettings] Make project languages editable

### DIFF
--- a/src/components/ProjectSettings/ProjectLanguages/EditableWritingSystem.tsx
+++ b/src/components/ProjectSettings/ProjectLanguages/EditableWritingSystem.tsx
@@ -1,0 +1,113 @@
+import { Grid, Button } from "@material-ui/core";
+import { Check, Clear, Edit } from "@material-ui/icons";
+import { LanguagePicker, languagePickerStrings_en } from "mui-language-picker";
+import React from "react";
+import {
+  LocalizeContextProps,
+  Translate,
+  withLocalize,
+} from "react-localize-redux";
+
+import { WritingSystem } from "../../../types/project";
+
+interface EditableWritingSystemProps {
+  ws: WritingSystem;
+  index?: number;
+  update: (ws: WritingSystem, index?: number) => void;
+}
+
+interface EditableWritingSystemState {
+  name: string;
+  bcp47: string;
+  font: string;
+  edit: boolean;
+}
+
+class EditableWritingSystem extends React.Component<
+  EditableWritingSystemProps & LocalizeContextProps,
+  EditableWritingSystemState
+> {
+  constructor(props: EditableWritingSystemProps & LocalizeContextProps) {
+    super(props);
+    this.state = { ...props.ws, edit: false };
+  }
+
+  conditionalUpdate() {
+    const name: string = this.state.name;
+    const bcp47: string = this.state.bcp47;
+    const font: string = this.state.font;
+    if (
+      name !== this.props.ws.name ||
+      bcp47 !== this.props.ws.bcp47 ||
+      font !== this.props.ws.font
+    ) {
+      this.props.update({ name, bcp47, font }, this.props.index);
+    }
+    this.setState({ edit: false });
+  }
+
+  resetWritingSystem() {
+    this.setState({ ...this.props.ws, edit: false });
+  }
+
+  render() {
+    return (
+      <React.Fragment key={this.props.index}>
+        {this.state.edit ? (
+          <Grid container spacing={1}>
+            <Grid item>
+              <LanguagePicker
+                value={this.state.bcp47}
+                setCode={(bcp47: string) => this.setState({ bcp47 })}
+                name={this.state.name}
+                setName={(name: string) => this.setState({ name })}
+                font={this.state.font}
+                setFont={(font: string) => this.setState({ font })}
+                t={languagePickerStrings_en}
+              />
+            </Grid>
+            <Grid item>
+              <Button onClick={() => this.conditionalUpdate()}>
+                <Check />
+              </Button>
+            </Grid>
+            <Grid item>
+              <Button onClick={() => this.resetWritingSystem()}>
+                <Clear />
+              </Button>
+            </Grid>
+          </Grid>
+        ) : (
+          <Grid container spacing={1}>
+            {this.props.index !== undefined && (
+              <Grid item>{`${this.props.index + 1}. `}</Grid>
+            )}
+            <Grid item>
+              <Translate id="projectSettings.language.name" />
+              {": "}
+              {this.props.ws.name} {", "}
+            </Grid>
+            <Grid item>
+              <Translate id="projectSettings.language.bcp47" />
+              {": "}
+              {this.props.ws.bcp47}
+              {", "}
+            </Grid>
+            <Grid item>
+              <Translate id="projectSettings.language.font" />
+              {": "}
+              {this.props.ws.font}
+            </Grid>
+            <Grid item>
+              <Button onClick={() => this.setState({ edit: true })}>
+                <Edit />
+              </Button>
+            </Grid>
+          </Grid>
+        )}
+      </React.Fragment>
+    );
+  }
+}
+
+export default withLocalize(EditableWritingSystem);

--- a/src/components/ProjectSettings/ProjectLanguages/ProjectLanguages.tsx
+++ b/src/components/ProjectSettings/ProjectLanguages/ProjectLanguages.tsx
@@ -1,4 +1,4 @@
-import { Grid, Typography } from "@material-ui/core";
+import { Typography } from "@material-ui/core";
 import React from "react";
 import {
   LocalizeContextProps,
@@ -6,8 +6,10 @@ import {
   withLocalize,
 } from "react-localize-redux";
 
+import { updateProject } from "../../../backend";
 import { Project, WritingSystem } from "../../../types/project";
 import theme from "../../../types/theme";
+import EditableWritingSystem from "./EditableWritingSystem";
 
 interface LanguageProps {
   project: Project;
@@ -16,29 +18,23 @@ interface LanguageProps {
 class ProjectLanguages extends React.Component<
   LanguageProps & LocalizeContextProps
 > {
-  renderWritingSystem(ws: WritingSystem, index?: number) {
-    return (
-      <React.Fragment key={index}>
-        <Grid container spacing={1}>
-          {index !== undefined && <Grid item>{`${index + 1}. `}</Grid>}
-          <Grid item>
-            <Translate id="projectSettings.language.name" />
-            {": "}
-            {ws.name} {", "}
-          </Grid>
-          <Grid item>
-            <Translate id="projectSettings.language.bcp47" />
-            {": "}
-            {ws.bcp47}
-            {", "}
-          </Grid>
-          <Grid item>
-            <Translate id="projectSettings.language.font" />
-            {": "}
-            {ws.font}
-          </Grid>
-        </Grid>
-      </React.Fragment>
+  updateProjectWritingSystem(ws: WritingSystem, index?: number) {
+    let updatedProject: Project;
+    if (index === undefined) {
+      updatedProject = { ...this.props.project, vernacularWritingSystem: ws };
+    } else {
+      const updatedAnalysisWS: WritingSystem[] = [
+        ...this.props.project.analysisWritingSystems,
+      ];
+      updatedAnalysisWS[index] = ws;
+      updatedProject = {
+        ...this.props.project,
+        analysisWritingSystems: updatedAnalysisWS,
+      };
+    }
+
+    updateProject(updatedProject).catch(() =>
+      console.log("failed: " + updatedProject)
     );
   }
 
@@ -48,14 +44,22 @@ class ProjectLanguages extends React.Component<
         <Typography>
           <Translate id="projectSettings.language.vernacular" />
           {": "}
-          {this.renderWritingSystem(this.props.project.vernacularWritingSystem)}
+          <EditableWritingSystem
+            ws={this.props.project.vernacularWritingSystem}
+            update={this.updateProjectWritingSystem}
+          />
         </Typography>
         <Typography style={{ marginTop: theme.spacing(1) }}>
           <Translate id="projectSettings.language.analysis" />
           {": "}
           {this.props.project.analysisWritingSystems.map(
-            (writingSystem, index) =>
-              this.renderWritingSystem(writingSystem, index)
+            (writingSystem, index) => (
+              <EditableWritingSystem
+                ws={writingSystem}
+                index={index}
+                update={this.updateProjectWritingSystem}
+              />
+            )
           )}
         </Typography>
       </React.Fragment>


### PR DESCRIPTION
Component in place, but update project errors, possibly a race condition:
![image](https://user-images.githubusercontent.com/6411521/90905980-f4d29200-e39e-11ea-987e-60f80b021cd3.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/631)
<!-- Reviewable:end -->
