### PR TITLE
ExportLIFT gets url instead of file from backend

### DIFF
--- a/Backend/Controllers/LiftController.cs
+++ b/Backend/Controllers/LiftController.cs
@@ -205,9 +205,7 @@ namespace BackendFramework.Controllers
             // Export the data to a zip directory
             var exportedFilepath = CreateLiftExport(projectId);
 
-            var file = System.IO.File.ReadAllBytes(exportedFilepath);
-            var encodedFile = Convert.ToBase64String(file);
-            return new OkObjectResult(encodedFile);
+            return new OkObjectResult(exportedFilepath);
         }
 
         // This method is extracted so that it can be unit tested

--- a/src/backend/index.tsx
+++ b/src/backend/index.tsx
@@ -322,7 +322,7 @@ export async function exportLift(projectId?: string) {
       headers: { ...authHeader(), Accept: "application/zip" },
     }
   );
-  return `data:application/zip;base64,${resp.data}`;
+  return resp.data;
 }
 
 export async function uploadAudio(


### PR DESCRIPTION
This doesn't doesn't play nice with local absolute paths. and I'm not sure how to test its behavior on a remotely hosted TheCombine. In my test, the .zip file is located at `/home/dror/.CombineFiles/5f4001464d14445cedb7dc9e/Export/LiftExportCompressed-5f4001464d14445cedb7dc9e_2020-08-24_03-38-42.zip` but the frontend strips of the initial `\` and treats it as a relative path.
![image](https://user-images.githubusercontent.com/6411521/91088795-a0d6e000-e620-11ea-8484-377b9addf2cf.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/637)
<!-- Reviewable:end -->
