### PR TITLE
Create local url for file export

### DIFF
--- a/src/components/ProjectSettings/ProjectExport/ExportProjectButton.tsx
+++ b/src/components/ProjectSettings/ProjectExport/ExportProjectButton.tsx
@@ -15,24 +15,28 @@ interface ExportProjectButtonProps {
 export default function ExportProjectButton(
   props: ButtonProps & ExportProjectButtonProps
 ) {
-  const [exportedFile, setExportedFile] = React.useState<null | string>(null);
+  const [fileUrl, setFileUrl] = React.useState<null | string>(null);
   const [loading, setLoading] = React.useState<boolean>(false);
   let downloadLink = React.createRef<HTMLAnchorElement>();
 
   async function getFile() {
     setLoading(true);
+    let fileString: string;
     props.projectId
-      ? setExportedFile(await exportLift(props.projectId))
-      : setExportedFile(await exportLift());
+      ? (fileString = await exportLift(props.projectId))
+      : (fileString = await exportLift());
+    const file = await fetch(fileString).then(async (res) => res.blob());
+    setFileUrl(URL.createObjectURL(file));
     setLoading(false);
   }
 
   useEffect(() => {
-    if (downloadLink.current && exportedFile !== null) {
+    if (downloadLink.current && fileUrl !== null) {
       downloadLink.current.click();
-      setExportedFile(null);
+      URL.revokeObjectURL(fileUrl);
+      setFileUrl(null);
     }
-  }, [downloadLink, exportedFile]);
+  }, [downloadLink, fileUrl]);
 
   return (
     <React.Fragment>
@@ -44,8 +48,8 @@ export default function ExportProjectButton(
       >
         <Translate id="buttons.export" />
       </LoadingButton>
-      {exportedFile && (
-        <a ref={downloadLink} href={exportedFile} style={{ display: "none" }}>
+      {fileUrl && (
+        <a ref={downloadLink} href={fileUrl} style={{ display: "none" }}>
           (This link should not be visible)
         </a>
       )}


### PR DESCRIPTION
Projects more than ~5MB made the export fail. By creating a temp url instead of using the file directly on the link, larger projects can now be exported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/638)
<!-- Reviewable:end -->
