### PR TITLE
[ProjectScreen] Fix property assignment in analysis language picker

### DIFF
--- a/src/components/ProjectScreen/CreateProject/CreateProjectComponent.tsx
+++ b/src/components/ProjectScreen/CreateProject/CreateProjectComponent.tsx
@@ -223,9 +223,9 @@ export class CreateProject extends React.Component<
             <LanguagePicker
               value={this.state.analysisLanguages[0].bcp47}
               setCode={(bcp47: string) => this.setAnalysisBcp47(bcp47)}
-              name={this.state.analysisLanguages[0].bcp47}
+              name={this.state.analysisLanguages[0].name}
               setName={(name: string) => this.setAnalysisLangName(name)}
-              font={this.state.analysisLanguages[0].bcp47}
+              font={this.state.analysisLanguages[0].font}
               setFont={(font: string) => this.setAnalysisFont(font)}
               t={languagePickerStrings_en}
             />


### PR DESCRIPTION
The bpc47 code had mistakenly been given to LanguagePicker for `name` and `font` properties. See "en" showing up twice below:
![image](https://user-images.githubusercontent.com/6411521/91213589-d42c7400-e6df-11ea-8ade-cff07b3192df.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/644)
<!-- Reviewable:end -->
