### PR TITLE
Uninstall @types/recordrtc; Use codecs=pcm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2022,12 +2022,6 @@
         "@types/react": "*"
       }
     },
-    "@types/recordrtc": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@types/recordrtc/-/recordrtc-5.6.0.tgz",
-      "integrity": "sha512-GKrAo5X0yT+iIeKHVhN52h0+3bRenLhv1oOgaCDgIR7KsxvtsX391jIImaKPJQXaOi8Fif609I79G0eM0QGhwA==",
-      "dev": true
-    },
     "@types/redux-mock-store": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/redux-mock-store/-/redux-mock-store-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "@types/react-redux": "^7.1.9",
     "@types/react-router-dom": "^5.1.5",
     "@types/react-test-renderer": "^16.9.2",
-    "@types/recordrtc": "^5.6.0",
     "@types/redux-mock-store": "^1.0.2",
     "@types/redux-thunk": "^2.1.0",
     "@types/validator": "^13.0.0",

--- a/src/components/Pronunciations/Recorder.ts
+++ b/src/components/Pronunciations/Recorder.ts
@@ -1,4 +1,4 @@
-import RecordRTC from "recordrtc";
+const RecordRTC = require("recordrtc");
 
 export default class Recorder {
   private recordRTC: any;
@@ -31,7 +31,7 @@ export default class Recorder {
     this.recordRTC = new RecordRTC(audioStream, {
       disableLogs: true, // Comment out or switch to false for dev
       type: "audio",
-      audioBitsPerSecond: 128000, // 128kbps is the maximum
+      mimeType: "audio/webm;codecs=pcm",
     });
   }
 


### PR DESCRIPTION
`mimeType: "audio/webm;codecs=pcm"` is presently unavailable in typescript, so reverting part of #649 in order to export the full audio stream

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/682)
<!-- Reviewable:end -->
