### PR TITLE
README Install list: remove 'server' from 'MongoDB'

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A rapid word collection tool.
    - [.NET Core SDK 3.1 (LTS)](https://dotnet.microsoft.com/download/dotnet-core/3.1)
      - On Ubuntu 18.04, follow these
        [instructions](https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-ubuntu-1804).
-   - [MongoDB Server](https://docs.mongodb.com/manual/administration/install-community/) and add
+   - [MongoDB](https://docs.mongodb.com/manual/administration/install-community/) and add
      /bin to PATH Environment Variable
      - On Windows, if using [Chocolatey][chocolatey]: `choco install mongodb`
    - [VS Code](https://code.visualstudio.com/download) and Prettier code


### PR DESCRIPTION
I remember being confused because the instructions say to install 'MongoDB server' but the link is to "Install MongoDB Community Edition" (which includes the server, but doesn't say so explicitly on the page).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/700)
<!-- Reviewable:end -->
