### PR TITLE
Remove tsc from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14701,11 +14701,6 @@
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.6.tgz",
       "integrity": "sha512-CrG5GqAAzMT7144Cl+UIFP7mz/iIhiy+xQ6GGcnjTezhALT02uPMRw7tgDSESgB5MsfKt55+GPWw4ir1kVtMIQ=="
     },
-    "tsc": {
-      "version": "1.20150623.0",
-      "resolved": "https://registry.npmjs.org/tsc/-/tsc-1.20150623.0.tgz",
-      "integrity": "sha1-Trw8d04WkUjLx2inNCUz8ILHpuU="
-    },
     "tslib": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "redux-devtools-extension": "^2.13.8",
     "redux-persist": "^5.10.0",
     "redux-thunk": "^2.3.0",
-    "tsc": "^1.20150623.0",
     "validator": "^13.1.1",
     "xml2js": "^0.4.23"
   },


### PR DESCRIPTION
The tsc in package.json (introduced in #724) causes a failure for me (Ubuntu 18.04) when running `npm start`:
```
> thecombine@0.2.0-alpha.1 predatabase /home/dror/sil/TheCombine
> tsc setupMongo.ts && node setupMongo.js

setupMongo.ts(5,37): error TS1005: ';' expected.
setupMongo.ts(6,9): error TS1005: ';' expected.
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! thecombine@0.2.0-alpha.1 predatabase: `tsc setupMongo.ts && node setupMongo.js`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the thecombine@0.2.0-alpha.1 predatabase script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/727)
<!-- Reviewable:end -->
