### PR TITLE
Split frontend and backend unit testing into two scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,26 +113,60 @@ Runs only the API.
 
 Runs only the mongo database.
 
-### `npm test`
+### `npm test-*`
+
+#### `npm run test-backend`
+
+Run all backend unit tests.
+
+To run a subset of tests, use the 
+[`--filter`](https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?pivots=nunit)
+option.
+
+```batch
+# Note the extra -- needed to separate arguments for npm vs script.
+> npm run test-backend -- --filter FullyQualifiedName~Backend.Tests.Models.ProjectTests
+```
+
+#### `npm run test-frontend`
 
 Launches the test runners in the interactive watch mode.<br>
 See the section about
 [running tests](https://facebook.github.io/create-react-app/docs/running-tests)
 for more information.
 
-#### `npm run coverage`
+To run a subset of tests, pass in the name of a partial file path to filter:
 
-Launches the test runners to calculate the test coverage of the front and
-back ends of the app.
+```batch
+# Note the extra -- needed to separate arguments for npm vs script.
+> npm run test-frontend -- DataEntry
+```
+
+#### `npm run coverage-*`
+
+Launches the test runners to calculate the test coverage of the frontend or
+backend of the app.
 
 ##### Frontend Code Coverage Report
+
+Run:
+
+```batch
+> npm run coverage-backend
+```
 
 To view the frontend code coverage open `coverage/lcov-report/index.html`
 in a browser.
 
 ##### Backend Code Coverage Report
 
-After `npm run coverage` has run, generate the HTML coverage report:
+Run:
+
+```batch
+> npm run coverage-backend
+```
+
+Generate the HTML coverage report:
 
 ```batch
 > npm run gen-backend-coverage-report

--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ To run a subset of tests, use the
 [`--filter`](https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?pivots=nunit)
 option.
 
-```
+```bash
 # Note the extra -- needed to separate arguments for npm vs script.
-> npm run test-backend -- --filter FullyQualifiedName~Backend.Tests.Models.ProjectTests
+$ npm run test-backend -- --filter FullyQualifiedName~Backend.Tests.Models.ProjectTests
 ```
 
 #### `npm run test-frontend`
@@ -139,9 +139,9 @@ for more information.
 
 To run a subset of tests, pass in the name of a partial file path to filter:
 
-```
+```bash
 # Note the extra -- needed to separate arguments for npm vs script.
-> npm run test-frontend -- DataEntry
+$ npm run test-frontend -- DataEntry
 ```
 
 #### `npm run coverage-*`

--- a/README.md
+++ b/README.md
@@ -422,7 +422,8 @@ otherwise an error will be logged and the exit code will be non-`0`.
 
 ### Production
 
-The process for configuring and deploying _TheCombine_ for production targets is described in ./docs/docker_deploy/README.md
+The process for configuring and deploying _TheCombine_ for production targets is
+described in ./docs/docker_deploy/README.md
 
 ## Learn More
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ Runs only the API.
 
 Runs only the mongo database.
 
-### `npm test-*`
+### `npm test`
+
+Run all backend and frontend tests.
 
 #### `npm run test-backend`
 
@@ -123,7 +125,7 @@ To run a subset of tests, use the
 [`--filter`](https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?pivots=nunit)
 option.
 
-```batch
+```
 # Note the extra -- needed to separate arguments for npm vs script.
 > npm run test-backend -- --filter FullyQualifiedName~Backend.Tests.Models.ProjectTests
 ```
@@ -137,7 +139,7 @@ for more information.
 
 To run a subset of tests, pass in the name of a partial file path to filter:
 
-```batch
+```
 # Note the extra -- needed to separate arguments for npm vs script.
 > npm run test-frontend -- DataEntry
 ```

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ $ npm run gen-backend-coverage-report
 
 Open `coverage-backend/index.html` in a browser.
 
-#### `npm run test:debug`
+#### `npm run test-frontend:debug`
 
 Runs Jest tests for debugging, awaiting for an attach from an IDE.
 

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ backend of the app.
 
 Run:
 
-```batch
-> npm run coverage-backend
+```bash
+$ npm run coverage-backend
 ```
 
 To view the frontend code coverage open `coverage/lcov-report/index.html`
@@ -164,14 +164,14 @@ in a browser.
 
 Run:
 
-```batch
-> npm run coverage-backend
+```bash
+$ npm run coverage-backend
 ```
 
 Generate the HTML coverage report:
 
-```batch
-> npm run gen-backend-coverage-report
+```bash
+$ npm run gen-backend-coverage-report
 ```
 
 Open `coverage-backend/index.html` in a browser.
@@ -230,8 +230,8 @@ To browse the database locally during development, open MongoDB Compass Communit
 
 To completely erase the current Mongo database, run:
 
-```batch
-> npm run drop-database
+```bash
+$ npm run drop-database
 ```
 
 ### Create Database Admin User
@@ -243,9 +243,9 @@ To completely erase the current Mongo database, run:
 To create a new admin user, first set the `COMBINE_ADMIN_PASSWORD`
 environment variable and then run:
 
-```batch
-> cd Backend
-> dotnet run create-admin-username=admin
+```bash
+$ cd Backend
+$ dotnet run create-admin-username=admin
 ```
 
 The exit code will be set to `0` on success and non-`0` otherwise.
@@ -255,23 +255,23 @@ The exit code will be set to `0` on success and non-`0` otherwise.
 To grant an _existing_ user database administrator rights (all permissions for
 all database objects), create a user normally and then execute:
 
-```batch
+```bash
 # Note the -- before the user name.
-> npm run set-admin-user -- <USERNAME>
+$ npm run set-admin-user -- <USERNAME>
 ```
 
 ### Generate License Report
 
 To generate a summary of licenses used in production:
 
-```batch
-> npm run license-summary
+```bash
+$ npm run license-summary
 ```
 
 To generate a full report of the licenses used in production:
 
-```batch
-> npm run license-report
+```bash
+$ npm run license-report
 ```
 
 ### Set Project Version
@@ -285,8 +285,8 @@ To update the version of the project:
 
 To retrieve the current version of the project from the terminal:
 
-```batch
-> npm run --silent version
+```bash
+$ npm run --silent version
 ```
 
 ## Docker
@@ -317,9 +317,9 @@ _TheCombine_ in Docker containers.
   [`py`](https://docs.python.org/3/using/windows.html#getting-started) launcher
   installed globally into the `PATH`.
 
-  ```batch
-  > py -m venv venv
-  > venv\Scripts\activate
+  ```bash
+  $ py -m venv venv
+  $ venv\Scripts\activate
   ```
 
 ##### Linux Only
@@ -342,8 +342,8 @@ $ venv/bin/activate
 
 With an active virtual environment, install `Jinja2`:
 
-```batch
-(venv) > python -m pip install Jinja2
+```bash
+(venv) $ python -m pip install Jinja2
 ```
 
 #### Configure Docker
@@ -351,8 +351,8 @@ With an active virtual environment, install `Jinja2`:
 Run the configuration script in an activated virtual environment to generate
 the necessary configuration files.
 
-```batch
-(venv) > python docker_setup.py
+```bash
+(venv) $ python docker_setup.py
 
 # To view options, run with --help
 ```
@@ -374,14 +374,14 @@ For information on _Docker Compose_ see the
 
 3. Build the images for the Docker containers
 
-   ```batch
-   > docker-compose build --parallel
+   ```bash
+   $ docker-compose build --parallel
    ```
 
 4. Start the containers
 
-   ```batch
-   > docker-compose up --detach
+   ```bash
+   $ docker-compose up --detach
    ```
 
 5. Browse to https://localhost.
@@ -390,14 +390,14 @@ For information on _Docker Compose_ see the
 
 6. To view logs:
 
-   ```batch
-   > docker-compose logs --follow
+   ```bash
+   $ docker-compose logs --follow
    ```
 
 7. To stop and remove any stored data:
 
-   ```batch
-   > docker-compose down --volumes
+   ```bash
+   $ docker-compose down --volumes
    ```
 
 ### Create a New Admin User (Docker Environment)
@@ -412,8 +412,8 @@ Edit `.env.backend` as follows:
 
 Run the following command to install the admin user in the _CombineDatabase_:
 
-```batch
-> docker-compose up --abort-on-container-exit
+```bash
+$ docker-compose up --abort-on-container-exit
 ```
 
 This will create the user and exit. If successful, the exit code will be `0`,

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "prettier-check": "prettier --check \"./src/**/*.{js,jsx,ts,tsx,json}\"",
     "set-admin-user": "tsc setAdminUser.ts && node setAdminUser.js",
     "start": "npm install && npm-run-all --parallel frontend database api",
+    "test": "npm run test-backend && npm run test-frontend",
     "test-backend": "dotnet test Backend.Tests/Backend.Tests.csproj",
     "test-frontend": "react-scripts test",
     "test:ci": "dotnet test Backend.Tests/Backend.Tests.csproj && CI=true react-scripts test --ci --all --testResultsProcessor jest-teamcity-reporter",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "api": "dotnet run --project Backend/BackendFramework.csproj",
     "build": "react-scripts build",
-    "coverage": "dotnet test Backend.Tests/Backend.Tests.csproj /p:CollectCoverage=true /p:CoverletOutputFormat=lcov && react-scripts test --coverage --watchAll=false",
+    "coverage-backend": "dotnet test Backend.Tests/Backend.Tests.csproj /p:CollectCoverage=true /p:CoverletOutputFormat=lcov",
+    "coverage-frontend": "react-scripts test --coverage --watchAll=false",
     "database": "mongod --dbpath=./mongo_database",
     "dotnet-format": "dotnet-format",
     "dotnet-format-check": "dotnet-format --check",
@@ -23,7 +24,8 @@
     "prettier-check": "prettier --check \"./src/**/*.{js,jsx,ts,tsx,json}\"",
     "set-admin-user": "tsc setAdminUser.ts && node setAdminUser.js",
     "start": "npm install && npm-run-all --parallel frontend database api",
-    "test": "dotnet test Backend.Tests/Backend.Tests.csproj && react-scripts test",
+    "test-backend": "dotnet test Backend.Tests/Backend.Tests.csproj",
+    "test-frontend": "react-scripts test",
     "test:ci": "dotnet test Backend.Tests/Backend.Tests.csproj && CI=true react-scripts test --ci --all --testResultsProcessor jest-teamcity-reporter",
     "test:debug": "react-scripts --inspect-brk test --runInBand --no-cache",
     "version": "node printVersion.js"

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "test": "npm run test-backend && npm run test-frontend",
     "test-backend": "dotnet test Backend.Tests/Backend.Tests.csproj",
     "test-frontend": "react-scripts test",
+    "test-frontend:debug": "react-scripts --inspect-brk test --runInBand --no-cache",
     "test:ci": "dotnet test Backend.Tests/Backend.Tests.csproj && CI=true react-scripts test --ci --all --testResultsProcessor jest-teamcity-reporter",
-    "test:debug": "react-scripts --inspect-brk test --runInBand --no-cache",
     "version": "node printVersion.js"
   },
   "dependencies": {


### PR DESCRIPTION
Closes #704

- Split `npm run test` into two, one for backend and one for frontend
- Also document CLI instructions for running a subset of either set of tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/732)
<!-- Reviewable:end -->
