### PR TITLE
Normalize backend starting npm script name

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ You will also see any lint errors in the console.
 
 Runs only the front end of the app in the development mode.
 
-#### `npm run api`
+#### `npm run backend`
 
-Runs only the API.
+Runs only the backend.
 
 #### `npm run database`
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "api": "dotnet run --project Backend/BackendFramework.csproj",
+    "backend": "dotnet run --project Backend/BackendFramework.csproj",
     "build": "react-scripts build",
     "database": "mongod --dbpath=./mongo_database",
     "drop-database": "tsc scripts/dropDB.ts && node scripts/dropDB.js",
@@ -21,7 +21,7 @@
     "lint": "eslint --ext js,ts,tsx,jsx src",
     "predatabase": "tsc scripts/setupMongo.ts && node scripts/setupMongo.js",
     "set-admin-user": "tsc scripts/setAdminUser.ts && node scripts/setAdminUser.js",
-    "start": "npm install && npm-run-all --parallel frontend database api",
+    "start": "npm install && npm-run-all --parallel backend database frontend",
     "test": "npm run test-backend && npm run test-frontend",
     "test-backend": "dotnet test Backend.Tests/Backend.Tests.csproj",
     "test-backend:coverage": "dotnet test Backend.Tests/Backend.Tests.csproj /p:CollectCoverage=true /p:CoverletOutputFormat=lcov",


### PR DESCRIPTION
Everywhere else, the backend is referred to as `backend`. Use the same term for the `npm` script used to start the backend.

Relates to #757

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/760)
<!-- Reviewable:end -->
