### PR TITLE
Upgrade Python dev-dependencies

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,23 +5,23 @@
 #    pip-compile dev-requirements.in
 #
 appdirs==1.4.4            # via black, virtualenv
+atomicwrites==1.4.0       # via pytest
 attrs==20.2.0             # via pytest
 black==20.8b1             # via -r dev-requirements.in
 click==7.1.2              # via black
+colorama==0.4.4           # via pytest, tox
 coverage==5.3             # via pytest-cov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 flake8-polyfill==1.0.2    # via pep8-naming
-flake8==3.8.3             # via -r dev-requirements.in, flake8-polyfill
-importlib-metadata==1.7.0  # via flake8, pluggy, pytest, tox, virtualenv
-importlib-resources==3.0.0  # via virtualenv
-iniconfig==1.0.1          # via pytest
-isort==5.5.4              # via -r dev-requirements.in
+flake8==3.8.4             # via -r dev-requirements.in, flake8-polyfill
+iniconfig==1.1.1          # via pytest
+isort==5.6.4              # via -r dev-requirements.in
 jinja2==2.11.2            # via -r dev-requirements.in
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
 mypy-extensions==0.4.3    # via black, mypy
-mypy==0.782               # via -r dev-requirements.in
+mypy==0.790               # via -r dev-requirements.in
 packaging==20.4           # via pytest, tox
 pathspec==0.8.0           # via black
 pep8-naming==0.11.1       # via -r dev-requirements.in
@@ -31,12 +31,11 @@ pycodestyle==2.6.0        # via flake8
 pyflakes==2.2.0           # via flake8
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.1        # via -r dev-requirements.in
-pytest==6.1.0             # via -r dev-requirements.in, pytest-cov
-regex==2020.9.27          # via black
+pytest==6.1.1             # via -r dev-requirements.in, pytest-cov
+regex==2020.10.15         # via black
 six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via black, pytest, tox
-tox==3.20.0               # via -r dev-requirements.in
+tox==3.20.1               # via -r dev-requirements.in
 typed-ast==1.4.1          # via black, mypy
 typing-extensions==3.7.4.3  # via black, mypy
-virtualenv==20.0.32       # via tox
-zipp==3.2.0               # via importlib-metadata, importlib-resources
+virtualenv==20.0.35       # via tox


### PR DESCRIPTION
Weekly update of Python dev-dependencies.

```bash
(venv) $ pip-compile --upgrade dev-requirements.in
```

Developers who are running Python linting locally will want to `rm -r .tox/` to ensure their tox environments are recreated with the latest dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/767)
<!-- Reviewable:end -->
