### PR TITLE
Add GitHub release badge and 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 [![Language grade: JavaScript][lgtm-js-badge]][lgtm-js]
 [![Total alerts][lgtm-alerts-badge]][lgtm-alerts]
 [![Python Actions Status][github-actions-python-badge]][github-actions]
-[![GitHub release][github-version-badge]][github-version]
+
+[![GitHub release][github-release-badge]][github-version]
+[![GitHub version][github-version-badge]][github-version]
 ![Localization][localization-badge]
 [![GitHub][github-license-badge]][github-license]
 [![GitHub contributors][github-contribs-badge]][github-contribs]
@@ -25,6 +27,7 @@
 [lgtm-alerts]: https://lgtm.com/projects/g/sillsdev/TheCombine/alerts
 [localization-badge]: https://img.shields.io/badge/localization-En%20Es%20Fr-blue
 [github-version-badge]: https://img.shields.io/github/package-json/v/sillsdev/TheCombine
+[github-release-badge]: https://img.shields.io/github/v/release/sillsdev/TheCombine
 [github-version]: https://github.com/sillsdev/TheCombine/releases
 [github-license-badge]: https://img.shields.io/github/license/sillsdev/TheCombine
 [github-license]: https://github.com/sillsdev/TheCombine/blob/master/LICENSE


### PR DESCRIPTION
Our repo shows the latest version of `master`, but it didn't show the latest release. Users of Combine would likely be interested in knowing what our latest release is, since they will not be (generally) using pre-release versions.

- Also separate build status badges from project info with new line to make it easier to read

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/769)
<!-- Reviewable:end -->
