### PR TITLE
Disable TLS 1.0 and 1.1 and enable TLS 1.3 in NGINX configuration

### DIFF
--- a/nginx/templates/thecombine.conf.template
+++ b/nginx/templates/thecombine.conf.template
@@ -17,6 +17,7 @@ server {
   server_name         ${SERVER_NAME};
   ssl_certificate     ${SSL_CERTIFICATE};
   ssl_certificate_key ${SSL_PRIVATE_KEY};
+  ssl_protocols       TLSv1.2 TLSv1.3;
   charset             utf-8;
 
   # Allow clients to import large projects.


### PR DESCRIPTION
TLS 1.0 and 1.1 have known security concerns. All major browser support at least TLS 1.2.

This disables the default NGINX configuration portion that enables support for TLS 1.0 and 1.1, and also adds support for TLS 1.3, the new standard that is more secure and can also be more performant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/779)
<!-- Reviewable:end -->
