### PR TITLE
Fix defects from PR#777

### DIFF
--- a/certmgr/Dockerfile
+++ b/certmgr/Dockerfile
@@ -29,9 +29,9 @@ RUN apt-get update && \
         /usr/local/aws-cli/v2/*/dist/awscli/data/ac.index \
         /usr/local/aws-cli/v2/*/dist/awscli/examples
 
-RUN mkdir /scripts
+RUN mkdir -p /opt/certmgr
 
-WORKDIR /scripts
+WORKDIR /opt/certmgr
 
 COPY scripts/*.py ./
 

--- a/certmgr/Dockerfile
+++ b/certmgr/Dockerfile
@@ -33,6 +33,6 @@ RUN mkdir /scripts
 
 WORKDIR /scripts
 
-COPY scripts/*.py .
+COPY scripts/*.py ./
 
 ENTRYPOINT ["./entrypoint.py"]

--- a/certmgr/scripts/func.py
+++ b/certmgr/scripts/func.py
@@ -39,7 +39,7 @@ def update_link(src: Path, dest: Path) -> None:
     print(f"linking {src} to {dest}")
     if dest.exists():
         if dest.is_symlink():
-            link_target: str = dest.readlink()
+            link_target: str = os.readlink(dest)
             if link_target != src:
                 dest.unlink()
             else:

--- a/certmgr/scripts/letsencrypt_cert.py
+++ b/certmgr/scripts/letsencrypt_cert.py
@@ -41,7 +41,7 @@ class LetsEncryptCert(BaseCert):
 
         is_letsencrypt_cert = False
         if self.nginx_cert_dir.is_symlink():
-            link_target = self.nginx_cert_dir.readlink()
+            link_target = os.readlink(self.nginx_cert_dir)
             if link_target == self.cert_dir:
                 is_letsencrypt_cert = True
 


### PR DESCRIPTION
PR #777 introduced 2 defects:

- in `certmgr/Dockerfile`, the destination directory for the entrypoint scripts needs a trailing '/'
- from the review, the python scripts were updated to use pathlib instead of strings for file paths.  One function, `Path.readlink()` is not available until Python 3.9; the certmgr container is at Python 3.7.  The 2 uses of `Path.readlink()` are changed to use `os.readlink()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/781)
<!-- Reviewable:end -->
