### PR TITLE
Remove temporary .zip files generated during Lift import and export

### DIFF
--- a/Backend.Tests/Controllers/LiftControllerTests.cs
+++ b/Backend.Tests/Controllers/LiftControllerTests.cs
@@ -168,10 +168,19 @@ namespace Backend.Tests.Controllers
         {
             var zipFile = Path.GetTempFileName();
             File.WriteAllBytes(zipFile, fileContents);
-            var extractionPath = Path.Combine(Path.GetTempPath(), Path.GetFileNameWithoutExtension(zipFile) + "-dir");
+            var extractionPath = ExtractZipFile(zipFile, true);
+            return extractionPath;
+        }
+
+        private static string ExtractZipFile(string zipFilePath, bool deleteZipFile = false)
+        {
+            var extractionPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             Directory.CreateDirectory(extractionPath);
-            ZipFile.ExtractToDirectory(zipFile, extractionPath);
-            File.Delete(zipFile);
+            ZipFile.ExtractToDirectory(zipFilePath, extractionPath);
+            if (deleteZipFile)
+            {
+                File.Delete(zipFilePath);
+            }
             return extractionPath;
         }
 
@@ -183,7 +192,8 @@ namespace Backend.Tests.Controllers
             public string EntryGuid { get; set; }
             public string SenseGuid { get; set; }
 
-            public RoundTripObj(string lang, List<string> audio, int words, string entryGuid = "", string senseGuid = "")
+            public RoundTripObj(
+                string lang, List<string> audio, int words, string entryGuid = "", string senseGuid = "")
             {
                 Language = lang;
                 AudioFiles = audio;
@@ -263,10 +273,9 @@ namespace Backend.Tests.Controllers
                 "e44420dd-a867-4d71-a43f-e472fd3a8f82" /*id of its first sense*/);
             fileMapping.Add("SingleEntryLiftWithTwoSound.zip", singleEntryLiftWithTwoSound);
 
-            foreach (var dataSet in fileMapping)
+            foreach (var (filename, roundTripContents) in fileMapping)
             {
-                var actualFilename = dataSet.Key;
-                var pathToStartZip = Path.Combine(pathToStartZips, actualFilename);
+                var pathToStartZip = Path.Combine(pathToStartZips, filename);
 
                 // Upload the zip file
 
@@ -278,50 +287,47 @@ namespace Backend.Tests.Controllers
                 if (File.Exists(pathToStartZip))
                 {
                     var fstream = File.OpenRead(pathToStartZip);
-                    var fileUpload = InitFile(fstream, actualFilename);
+                    var fileUpload = InitFile(fstream, filename);
 
                     // Make api call
                     var result = _liftController.UploadLiftFile(proj.Id, fileUpload).Result;
                     Assert.That(!(result is BadRequestObjectResult));
 
                     proj = _projServ.GetProject(proj.Id).Result;
-                    Assert.AreEqual(proj.VernacularWritingSystem.Bcp47, dataSet.Value.Language);
+                    Assert.AreEqual(proj.VernacularWritingSystem.Bcp47, roundTripContents.Language);
 
                     fstream.Close();
 
                     var allWords = _wordrepo.GetAllWords(proj.Id).Result;
-                    Assert.AreEqual(allWords.Count, dataSet.Value.NumOfWords);
+                    Assert.AreEqual(allWords.Count, roundTripContents.NumOfWords);
                     // We are currently only testing guids on the single-entry data sets
-                    if (dataSet.Value.EntryGuid != "" && allWords.Count == 1)
+                    if (roundTripContents.EntryGuid != "" && allWords.Count == 1)
                     {
-                        Assert.AreEqual(allWords[0].Guid.ToString(), dataSet.Value.EntryGuid);
-                        if (dataSet.Value.SenseGuid != "")
+                        Assert.AreEqual(allWords[0].Guid.ToString(), roundTripContents.EntryGuid);
+                        if (roundTripContents.SenseGuid != "")
                         {
-                            Assert.AreEqual(allWords[0].Senses[0].Guid.ToString(), dataSet.Value.SenseGuid);
+                            Assert.AreEqual(allWords[0].Senses[0].Guid.ToString(), roundTripContents.SenseGuid);
                         }
                     }
 
                     // Export
                     var exportedFilePath = _liftController.CreateLiftExport(proj.Id);
-                    var exportedDirectory = Path.GetDirectoryName(exportedFilePath);
+                    var exportedDirectory = ExtractZipFile(exportedFilePath, false);
 
                     // Assert the file was created with desired heirarchy
                     Assert.That(Directory.Exists(exportedDirectory));
-                    Assert.That(Directory.Exists(Path.Combine(exportedDirectory, "LiftExport", "Lift", "audio")));
-                    foreach (var audioFile in dataSet.Value.AudioFiles)
+                    Assert.That(Directory.Exists(Path.Combine(exportedDirectory, "Lift", "audio")));
+                    foreach (var audioFile in roundTripContents.AudioFiles)
                     {
                         Assert.That(File.Exists(Path.Combine(
-                            exportedDirectory, "LiftExport", "Lift", "audio", audioFile)));
+                            exportedDirectory, "Lift", "audio", audioFile)));
                     }
-                    Assert.That(Directory.Exists(Path.Combine(exportedDirectory, "LiftExport", "Lift", "WritingSystems")));
+                    Assert.That(Directory.Exists(Path.Combine(exportedDirectory, "Lift", "WritingSystems")));
                     Assert.That(File.Exists(Path.Combine(
                         exportedDirectory,
-                        "LiftExport", "Lift", "WritingSystems", dataSet.Value.Language + ".ldml")));
-                    Assert.That(File.Exists(Path.Combine(exportedDirectory, "LiftExport", "Lift", "NewLiftFile.lift")));
-                    var dirList = new List<string>(
-                        Directory.GetDirectories(Path.GetDirectoryName(exportedDirectory)));
-                    dirList.Remove(exportedDirectory);
-                    Assert.That(Directory.Exists(Path.Combine(Path.GetDirectoryName(exportedDirectory), dirList.Single())));
+                        "Lift", "WritingSystems", roundTripContents.Language + ".ldml")));
+                    Assert.That(File.Exists(Path.Combine(exportedDirectory, "Lift", "NewLiftFile.lift")));
+                    Directory.Delete(exportedDirectory, true);
 
                     _wordrepo.DeleteAllWords(proj.Id);
 
@@ -334,50 +340,51 @@ namespace Backend.Tests.Controllers
 
                     // Generate api parameter with filestream
                     fstream = File.OpenRead(exportedFilePath);
-                    fileUpload = InitFile(fstream, actualFilename);
+                    fileUpload = InitFile(fstream, filename);
 
                     // Make api call
                     var result2 = _liftController.UploadLiftFile(proj2.Id, fileUpload).Result;
                     Assert.That(!(result is BadRequestObjectResult));
 
                     proj2 = _projServ.GetProject(proj2.Id).Result;
-                    Assert.AreEqual(proj2.VernacularWritingSystem.Bcp47, dataSet.Value.Language);
+                    Assert.AreEqual(proj2.VernacularWritingSystem.Bcp47, roundTripContents.Language);
 
                     fstream.Close();
 
+                    // Clean up zip file.
+                    File.Delete(exportedFilePath);
+
                     allWords = _wordrepo.GetAllWords(proj2.Id).Result;
-                    Assert.AreEqual(allWords.Count, dataSet.Value.NumOfWords);
+                    Assert.AreEqual(allWords.Count, roundTripContents.NumOfWords);
                     // We are currently only testing guids on the single-entry data sets
-                    if (dataSet.Value.EntryGuid != "" && allWords.Count == 1)
+                    if (roundTripContents.EntryGuid != "" && allWords.Count == 1)
                     {
-                        Assert.AreEqual(allWords[0].Guid.ToString(), dataSet.Value.EntryGuid);
-                        if (dataSet.Value.SenseGuid != "")
+                        Assert.AreEqual(allWords[0].Guid.ToString(), roundTripContents.EntryGuid);
+                        if (roundTripContents.SenseGuid != "")
                         {
-                            Assert.AreEqual(allWords[0].Senses[0].Guid.ToString(), dataSet.Value.SenseGuid);
+                            Assert.AreEqual(allWords[0].Senses[0].Guid.ToString(), roundTripContents.SenseGuid);
                         }
                     }
 
                     // Export
                     exportedFilePath = _liftController.CreateLiftExport(proj2.Id);
-                    exportedDirectory = Path.GetDirectoryName(exportedFilePath);
+                    exportedDirectory = ExtractZipFile(exportedFilePath);
 
                     // Assert the file was created with desired hierarchy
                     Assert.That(Directory.Exists(exportedDirectory));
-                    Assert.That(Directory.Exists(Path.Combine(exportedDirectory, "LiftExport", "Lift", "audio")));
-                    foreach (var audioFile in dataSet.Value.AudioFiles)
+                    Assert.That(Directory.Exists(Path.Combine(exportedDirectory, "Lift", "audio")));
+                    foreach (var audioFile in roundTripContents.AudioFiles)
                     {
-                        var path = Path.Combine(exportedDirectory, "LiftExport", "Lift", "audio", audioFile);
+                        var path = Path.Combine(exportedDirectory, "Lift", "audio", audioFile);
                         Assert.That(File.Exists(path),
-                            "The file " + audioFile + " can not be found at this path: " + path);
+                            $"The file {audioFile} can not be found at this path: {path}");
                     }
-                    Assert.That(Directory.Exists(Path.Combine(exportedDirectory, "LiftExport", "Lift", "WritingSystems")));
+                    Assert.That(Directory.Exists(Path.Combine(exportedDirectory, "Lift", "WritingSystems")));
                     Assert.That(File.Exists(Path.Combine(
                         exportedDirectory,
-                        "LiftExport", "Lift", "WritingSystems", dataSet.Value.Language + ".ldml")));
-                    Assert.That(File.Exists(Path.Combine(exportedDirectory, "LiftExport", "Lift", "NewLiftFile.lift")));
-                    dirList = new List<string>(Directory.GetDirectories(Path.GetDirectoryName(exportedDirectory)));
-                    dirList.Remove(exportedDirectory);
-                    Assert.That(Directory.Exists(Path.Combine(Path.GetDirectoryName(exportedDirectory), dirList.Single())));
+                        "Lift", "WritingSystems", roundTripContents.Language + ".ldml")));
+                    Assert.That(File.Exists(Path.Combine(exportedDirectory, "Lift", "NewLiftFile.lift")));
+                    Directory.Delete(exportedDirectory, true);
 
                     _wordrepo.DeleteAllWords(proj.Id);
                 }

--- a/Backend/Controllers/LiftController.cs
+++ b/Backend/Controllers/LiftController.cs
@@ -93,6 +93,9 @@ namespace BackendFramework.Controllers
             Directory.CreateDirectory(extractDir);
             ZipFile.ExtractToDirectory(fileUpload.FilePath, extractDir);
 
+            // Clean up the temporary zip file
+            System.IO.File.Delete(fileUpload.FilePath);
+
             // Check number of directories extracted
             var directoriesExtracted = Directory.GetDirectories(extractDir);
             var extractedDirPath = "";
@@ -211,8 +214,11 @@ namespace BackendFramework.Controllers
             }
             // Export the data to a zip directory
             var exportedFilepath = CreateLiftExport(projectId);
-
             var file = await System.IO.File.ReadAllBytesAsync(exportedFilepath);
+
+            // Clean up temporary file after reading it.
+            System.IO.File.Delete(exportedFilepath);
+
             var encodedFile = Convert.ToBase64String(file);
             return new OkObjectResult(encodedFile);
         }

--- a/Backend/Services/LiftApiServices.cs
+++ b/Backend/Services/LiftApiServices.cs
@@ -267,6 +267,9 @@ namespace BackendFramework.Services
                 Path.Combine($"LiftExportCompressed-{proj.Id}_{DateTime.Now:yyyy-MM-dd_hh-mm-ss}.zip"));
             ZipFile.CreateFromDirectory(Path.GetDirectoryName(zipDir), destinationFileName);
 
+            // Clean up the temporary folder structure that was compressed.
+            Directory.Delete(Path.Combine(exportDir, "LiftExport"), true);
+
             return destinationFileName;
         }
 

--- a/Backend/Services/LiftApiServices.cs
+++ b/Backend/Services/LiftApiServices.cs
@@ -108,6 +108,7 @@ namespace BackendFramework.Services
         }
 
         /// <summary> Exports information from a project to a lift package zip </summary>
+        /// <returns> Path to compressed zip file containing export. </returns>
         public string LiftExport(string projectId, IWordRepository wordRepo, IProjectService projService)
         {
             // Generate the zip dir.


### PR DESCRIPTION
Closes #786

Should help some with #656

- The fix for LIFT export fixes a true disk space leak.
- Since Lift import can only be performed once, there is no recurring leak fixed on the import side, but the temporary file is still removed

The following files will no longer persist after an import in `.CombineFiles/<ProjectID>/Import`:
- `<temp-name-with-date>.zip`

Or after an export in `.CombineFiles/<ProjectID>/Export`:
- `<temp-name>.zip`
- `LiftExport`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/791)
<!-- Reviewable:end -->
