### PR TITLE
Set cache expiration for frontend route

### DIFF
--- a/nginx/templates/thecombine.conf.template
+++ b/nginx/templates/thecombine.conf.template
@@ -35,9 +35,13 @@ server {
   }
 
   location / {
-    root      /usr/share/nginx/html;
-    index     index.html index.htm;
-    try_files $uri $uri/ /index.html;
+    root       /usr/share/nginx/html;
+    index      index.html index.htm;
+    try_files  $uri $uri/ /index.html;
+    # Set cache expiration so that if the server's frontend implementation is updated,
+    # clients will automatically pull in a fresh version at the beginning of the next day.
+    expires    12h;
+    add_header Cache-Control "public, no-transform"
   }
 
   error_page   500 502 503 504  /50x.html;


### PR DESCRIPTION
Set cache expiration to 12 hours on the frontend routes so that if the server's frontend implementation is updated, clients will automatically pull in a fresh version at the beginning of the next day.

This fixes the issue where users have to manually refresh to update their cached frontend implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/809)
<!-- Reviewable:end -->
