### PR TITLE
Remove GC.Collect() call from Lift Export

### DIFF
--- a/Backend/Controllers/LiftController.cs
+++ b/Backend/Controllers/LiftController.cs
@@ -227,7 +227,6 @@ namespace BackendFramework.Controllers
 
             // Clean up temporary file after reading it.
             System.IO.File.Delete(exportedFilepath);
-            GC.Collect();
 
             var encodedFile = Convert.ToBase64String(file);
 


### PR DESCRIPTION
Revert #801

This did not have any noticeable improvement on memory usage.

#811 is tracking trying to fix this issue more holistically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/813)
<!-- Reviewable:end -->
