### PR TITLE
Fix memory leak in Lift Export

### DIFF
--- a/Backend.Tests/Controllers/LiftControllerTests.cs
+++ b/Backend.Tests/Controllers/LiftControllerTests.cs
@@ -209,10 +209,14 @@ namespace Backend.Tests.Controllers
             _wordService.Update(proj.Id, wordToUpdate.Id, word);
             _wordService.DeleteFrontierWord(proj.Id, wordToDelete.Id);
 
-            var userId = "testId";
+            const string userId = "testId";
             _liftController.ExportLiftFile(proj.Id, userId).Wait();
             var result = _liftController.DownloadLiftFile(userId) as OkObjectResult;
             var fileContents = Convert.FromBase64String(result.Value as string);
+
+            // Ensure that downloading a Lift file deletes the temporary in-memory copy.
+            var notFoundResult = _liftController.DownloadLiftFile(userId) as NotFoundObjectResult;
+            Assert.NotNull(notFoundResult);
 
             // Write LiftFile contents to a temporary directory.
             var extractedExportDir = ExtractZipFileContents(fileContents);

--- a/Backend/Controllers/LiftController.cs
+++ b/Backend/Controllers/LiftController.cs
@@ -217,9 +217,7 @@ namespace BackendFramework.Controllers
             System.IO.File.Delete(exportedFilepath);
 
             // Encode file as string and store for user to download later
-            var encodedFile = Convert.ToBase64String(file);
-            _liftService.StoreExport(userId, encodedFile);
-
+            _liftService.StoreExport(userId, file);
             return new OkObjectResult(projectId);
         }
 
@@ -240,13 +238,16 @@ namespace BackendFramework.Controllers
                 return new ForbidResult();
             }
 
-            // Ensure export exists
-            var encodedFile = _liftService.RetrieveExport(userId);
-            if (encodedFile is null)
+            // Ensure export exists.
+            var file = _liftService.RetrieveExport(userId);
+            if (file is null)
             {
                 return new NotFoundObjectResult(userId);
             }
+            _liftService.DeleteExport(userId);
 
+            // Return as Base64 string to allow embedding into HTTP OK message.
+            var encodedFile = Convert.ToBase64String(file);
             return new OkObjectResult(encodedFile);
         }
 

--- a/Backend/Interfaces/ILiftService.cs
+++ b/Backend/Interfaces/ILiftService.cs
@@ -11,8 +11,8 @@ namespace BackendFramework.Interfaces
         string LiftExport(string projectId, IWordRepository wordRepo, IProjectService projectService);
 
         // Methods to store, retrieve, and delete an export string in a common dictionary
-        void StoreExport(string key, string value);
-        string? RetrieveExport(string key);
-        void DeleteExport(string key);
+        void StoreExport(string key, byte[] file);
+        byte[]? RetrieveExport(string key);
+        bool DeleteExport(string key);
     }
 }

--- a/Backend/Services/LiftApiServices.cs
+++ b/Backend/Services/LiftApiServices.cs
@@ -76,6 +76,9 @@ namespace BackendFramework.Services
 
     public class LiftService : ILiftService
     {
+        /// A dictionary shared by all Projects for storing and retrieving exported projects.
+        private readonly Dictionary<string, byte[]> _liftExports;
+
         public LiftService()
         {
             if (!Sldr.IsInitialized)
@@ -83,27 +86,32 @@ namespace BackendFramework.Services
                 Sldr.Initialize(true);
             }
 
-            LiftExports = new Dictionary<string, string>();
+            _liftExports = new Dictionary<string, byte[]>();
         }
 
-        // A common dictionary for storing and retrieving exported projects
-        private Dictionary<string, string> LiftExports;
-        public void StoreExport(string userId, string encodedFile)
+        public void StoreExport(string userId, byte[] file)
         {
-            LiftExports.Remove(userId);
-            LiftExports.Add(userId, encodedFile);
+            _liftExports.Remove(userId);
+            _liftExports.Add(userId, file);
         }
-        public string? RetrieveExport(string userId)
+
+        public byte[]? RetrieveExport(string userId)
         {
-            if (!LiftExports.ContainsKey(userId))
+            if (!_liftExports.ContainsKey(userId))
             {
                 return null;
             }
-            return LiftExports[userId];
+
+            return _liftExports[userId];
         }
-        public void DeleteExport(string userId)
+
+        /// <summary>
+        /// Delete a stored Lift export.
+        /// </summary>
+        /// <returns>true if the element is successfully found and removed; otherwise, false.</returns>
+        public bool DeleteExport(string userId)
         {
-            LiftExports.Remove(userId);
+            return _liftExports.Remove(userId);
         }
 
         /// <summary> Imports main character set for a project from an ldml file </summary>


### PR DESCRIPTION
Follow on to #819 

Relate to #814 

- Fix memory leak in Lift export where Lift exported files are never removed from an internal dictionary
- Reduce medium-term memory usage of lift export by 33% by only storing binary contents of export rather than base64 encoded contents before download

Note: There is still a possibility of a memory leak if a user exports a project but never downloads it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/820)
<!-- Reviewable:end -->
