### PR TITLE
Only cache the path to exported lift files rather than contents

### DIFF
--- a/Backend.Tests/Controllers/LiftControllerTests.cs
+++ b/Backend.Tests/Controllers/LiftControllerTests.cs
@@ -211,11 +211,12 @@ namespace Backend.Tests.Controllers
 
             const string userId = "testId";
             _liftController.ExportLiftFile(proj.Id, userId).Wait();
-            var result = _liftController.DownloadLiftFile(userId) as OkObjectResult;
+            var result = _liftController.DownloadLiftFile(userId).Result as OkObjectResult;
+            Assert.NotNull(result);
             var fileContents = Convert.FromBase64String(result.Value as string);
 
             // Ensure that downloading a Lift file deletes the temporary in-memory copy.
-            var notFoundResult = _liftController.DownloadLiftFile(userId) as NotFoundObjectResult;
+            var notFoundResult = _liftController.DownloadLiftFile(userId).Result as NotFoundObjectResult;
             Assert.NotNull(notFoundResult);
 
             // Write LiftFile contents to a temporary directory.

--- a/Backend/Controllers/LiftController.cs
+++ b/Backend/Controllers/LiftController.cs
@@ -213,11 +213,9 @@ namespace BackendFramework.Controllers
 
             // Export the data to a zip, read into memory, and delete zip
             var exportedFilepath = CreateLiftExport(projectId);
-            var file = await System.IO.File.ReadAllBytesAsync(exportedFilepath);
-            System.IO.File.Delete(exportedFilepath);
 
-            // Encode file as string and store for user to download later
-            _liftService.StoreExport(userId, file);
+            // Store the temporary path to the exported file for user to download later.
+            _liftService.StoreExport(userId, exportedFilepath);
             return new OkObjectResult(projectId);
         }
 
@@ -225,13 +223,13 @@ namespace BackendFramework.Controllers
         /// <remarks> GET: v1/projects/{projectId}/words/download </remarks>
         /// <returns> Lift file as base-64 string </returns>
         [HttpGet("download")]
-        public IActionResult DownloadLiftFile()
+        public async Task<IActionResult> DownloadLiftFile()
         {
             var userId = _permissionService.GetUserId(HttpContext);
-            return DownloadLiftFile(userId);
+            return await DownloadLiftFile(userId);
         }
 
-        public IActionResult DownloadLiftFile(string userId)
+        public async Task<IActionResult> DownloadLiftFile(string userId)
         {
             if (!_permissionService.HasProjectPermission(HttpContext, Permission.ImportExport))
             {
@@ -239,14 +237,16 @@ namespace BackendFramework.Controllers
             }
 
             // Ensure export exists.
-            var file = _liftService.RetrieveExport(userId);
-            if (file is null)
+            var filePath = _liftService.RetrieveExport(userId);
+            if (filePath is null)
             {
                 return new NotFoundObjectResult(userId);
             }
-            _liftService.DeleteExport(userId);
 
             // Return as Base64 string to allow embedding into HTTP OK message.
+            var file = await System.IO.File.ReadAllBytesAsync(filePath);
+            _liftService.DeleteExport(userId);
+
             var encodedFile = Convert.ToBase64String(file);
             return new OkObjectResult(encodedFile);
         }

--- a/Backend/Interfaces/ILiftService.cs
+++ b/Backend/Interfaces/ILiftService.cs
@@ -11,8 +11,8 @@ namespace BackendFramework.Interfaces
         string LiftExport(string projectId, IWordRepository wordRepo, IProjectService projectService);
 
         // Methods to store, retrieve, and delete an export string in a common dictionary
-        void StoreExport(string key, byte[] file);
-        byte[]? RetrieveExport(string key);
+        void StoreExport(string key, string filePath);
+        string? RetrieveExport(string key);
         bool DeleteExport(string key);
     }
 }

--- a/Backend/Services/LiftApiServices.cs
+++ b/Backend/Services/LiftApiServices.cs
@@ -76,8 +76,8 @@ namespace BackendFramework.Services
 
     public class LiftService : ILiftService
     {
-        /// A dictionary shared by all Projects for storing and retrieving exported projects.
-        private readonly Dictionary<string, byte[]> _liftExports;
+        /// A dictionary shared by all Projects for storing and retrieving paths to exported projects.
+        private readonly Dictionary<string, string> _liftExports;
 
         public LiftService()
         {
@@ -86,16 +86,16 @@ namespace BackendFramework.Services
                 Sldr.Initialize(true);
             }
 
-            _liftExports = new Dictionary<string, byte[]>();
+            _liftExports = new Dictionary<string, string>();
         }
 
-        public void StoreExport(string userId, byte[] file)
+        public void StoreExport(string userId, string filePath)
         {
             _liftExports.Remove(userId);
-            _liftExports.Add(userId, file);
+            _liftExports.Add(userId, filePath);
         }
 
-        public byte[]? RetrieveExport(string userId)
+        public string? RetrieveExport(string userId)
         {
             if (!_liftExports.ContainsKey(userId))
             {
@@ -105,13 +105,16 @@ namespace BackendFramework.Services
             return _liftExports[userId];
         }
 
-        /// <summary>
-        /// Delete a stored Lift export.
-        /// </summary>
+        /// <summary> Delete a stored Lift export path and its file on disk. </summary>
         /// <returns>true if the element is successfully found and removed; otherwise, false.</returns>
         public bool DeleteExport(string userId)
         {
-            return _liftExports.Remove(userId);
+            var removeSuccessful = _liftExports.Remove(userId, out var filePath);
+            if (removeSuccessful)
+            {
+                File.Delete(filePath);
+            }
+            return removeSuccessful;
         }
 
         /// <summary> Imports main character set for a project from an ldml file </summary>


### PR DESCRIPTION
Closes #822 

Worst case, if the user never downloads the project, only the file path to the export is leaked, rather than the entire contents of the export.