### PR TITLE
Set ecr profile read only

### DIFF
--- a/docker_deploy/group_vars/qa/main.yml
+++ b/docker_deploy/group_vars/qa/main.yml
@@ -23,7 +23,7 @@ aws_user: "{{ combine_user }}"
 aws_group: "{{ combine_group }}"
 
 aws_backup_profile: s3_read_write
-aws_ecr_profile: ecr_read_write
+aws_ecr_profile: ecr_read_only
 
 my_aws_profiles:
     - "{{ aws_backup_profile }}"

--- a/docker_deploy/roles/combine_backup/templates/combine-backup.j2
+++ b/docker_deploy/roles/combine_backup/templates/combine-backup.j2
@@ -49,7 +49,7 @@ while [[ $# -gt 0 ]] ; do
   shift
 done
 
-echo_verbose "1. Setup some useful environment variables"
+echo_verbose "1. Setup some useful environment variables."
 DATE_STR=`date +%Y-%m-%d-%H-%M-%S`
 COMBINE_HOST="{{ combine_server_name | replace('.', '-') }}"
 BACKUP_FILE="combine-backup.tar.gz"
@@ -61,7 +61,7 @@ DB_FILES_SUBDIR="{{ mongo_files_subdir }}"
 
 cd ${COMBINE_APP_DIR}
 
-echo_verbose "2. Prepare the backup directory"
+echo_verbose "2. Prepare the backup directory."
 if [ ! -e "${BACKUP_DIR}" ] ; then
   mkdir -p ${BACKUP_DIR}
 else
@@ -73,28 +73,28 @@ else
   done
 fi
 
-echo_verbose "3. Stop the current containers"
+echo_verbose "3. Stop the current containers."
 docker-compose down
 
-echo_verbose "4. Start up just the backend and the database"
+echo_verbose "4. Start up just the backend and the database."
 aws ecr get-login-password --profile {{ aws_ecr_profile }} | docker login --username AWS --password-stdin {{ aws_ecr }}
 docker-compose up --detach database backend
 
 
-echo_verbose "5. Dump the database"
+echo_verbose "5. Dump the database."
 docker-compose exec database mongodump --db CombineDatabase --gzip --quiet
 DB_CONTAINER=`docker ps | grep database | sed "s/.* \([^ ][^ ]*\)$/\1/"`
 docker cp ${DB_CONTAINER}:${DB_FILES_SUBDIR}/ ${BACKUP_DIR}
 
-echo_verbose "6. Copy the backend files (commands are run relative the 'app' user's home directory)"
+echo_verbose "6. Copy the backend files (commands are run relative the 'app' user's home directory)."
 BE_CONTAINER=`docker ps | grep backend | sed "s/.* \([^ ][^ ]*\)$/\1/"`
 docker cp ${BE_CONTAINER}:/home/app/${BACKEND_FILES_SUBDIR}/ ${BACKUP_DIR}
 
-echo_verbose "7. create the tarball for the backup"
+echo_verbose "7. Create the tarball for the backup."
 cd ${BACKUP_DIR}
 tar --create --file=${BACKUP_FILE} --gzip --verbose ${BACKEND_FILES_SUBDIR} ${DB_FILES_SUBDIR}
 
-echo_verbose "8. Remove old backup files"
+echo_verbose "8. Remove old backup files."
 # Running in ${BACKUP_DIR}
 rm -rf ${BACKEND_FILES_SUBDIR} ${DB_FILES_SUBDIR}
 ALL_BACKUPS=(`ls combine-backup*.tar.gz`)
@@ -106,12 +106,12 @@ for bu in "${ALL_BACKUPS[@]}"; do
   fi
 done
 
-echo_verbose "9. push backup to AWS S3 storage"
+echo_verbose "9. Push backup to AWS S3 storage."
 #    need to specify full path because $PATH does not contain
 #    /usr/local/bin when run as a cron job
 /usr/local/bin/aws s3 cp ${BACKUP_FILE} ${AWS_FILE} --profile {{ aws_backup_profile }}
 
-echo_verbose "10. Restart the containers"
+echo_verbose "10. Restart the containers."
 cd ${COMBINE_APP_DIR}
 docker-compose down
 docker-compose up --detach

--- a/docker_deploy/roles/combine_backup/templates/combine-restore.j2
+++ b/docker_deploy/roles/combine_backup/templates/combine-restore.j2
@@ -60,7 +60,7 @@ while [[ $# -gt 0 ]] ; do
   shift
 done
 
-echo_verbose "1. Prepare for the restore"
+echo_verbose "1. Prepare for the restore."
 
 COMBINE_HOST={{ ansible_hostname }}
 RESTORE_FILE="combine-backup.tar.gz"
@@ -72,7 +72,7 @@ DB_FILES_SUBDIR="{{ mongo_files_subdir }}"
 
 cd ${COMBINE_APP_DIR}
 
-echo_verbose "2. Prepare the restore directory"
+echo_verbose "2. Prepare the restore directory."
 if [ ! -e "${RESTORE_DIR}" ] ; then
   mkdir -p ${RESTORE_DIR}
 else
@@ -130,28 +130,28 @@ if [ -z "${BACKUP}" ] ; then
 fi
 echo "BACKUP == '${BACKUP}'"
 
-echo_verbose "3. Fetch the selected backup, ${BACKUP}"
+echo_verbose "3. Fetch the selected backup, ${BACKUP}."
 AWS_FILE="${AWS_BACKUPS}/${BACKUP}"
 /usr/local/bin/aws s3 cp ${AWS_FILE} ${RESTORE_DIR}/${RESTORE_FILE} --profile {{ aws_backup_profile }}
 
-echo_verbose "4. Unpack the backup"
+echo_verbose "4. Unpack the backup."
 tar xzvf ${RESTORE_DIR}/${RESTORE_FILE} -C ${RESTORE_DIR}
 
-echo verbose "5. Stop the current containers"
+echo verbose "5. Stop the current containers."
 docker-compose down
 
-echo_verbose "6. Start up just the backend and the database"
+echo_verbose "6. Start up just the backend and the database."
 aws ecr get-login-password --profile {{ aws_ecr_profile }} | docker login --username AWS --password-stdin {{ aws_ecr }}
 docker-compose up --detach database backend
 
 
-echo_verbose "7. Restore the database"
+echo_verbose "7. Restore the database."
 DB_CONTAINER=`docker ps | grep database | sed "s/.* \([^ ][^ ]*\)$/\1/"`
 docker cp ${RESTORE_DIR}/${DB_FILES_SUBDIR}/ ${DB_CONTAINER}:${DB_FILES_SUBDIR}
 docker-compose exec database mongorestore --drop --gzip --quiet
 docker-compose exec database rm -rf ${DB_FILES_SUBDIR}
 
-echo_verbose "8. Copy the backend files"
+echo_verbose "8. Copy the backend files."
 # if CLEAN is set, delete the existing files
 if [ "$CLEAN" == "1" ] ; then
   # we run the rm command inside a bash shell so that the shell will do wildcard
@@ -166,9 +166,9 @@ docker cp ${RESTORE_DIR}/${BACKEND_FILES_SUBDIR}/ ${BE_CONTAINER}:/home/app
 # different host with different UIDs.
 docker-compose exec --user root backend find /home/app/${BACKEND_FILES_SUBDIR} -exec chown app:app {} \;
 
-echo_verbose "9. Cleanup Restore files"
+echo_verbose "9. Cleanup Restore files."
 rm -rf ${RESTORE_DIR}
 
-echo_verbose "10. Restart the containers"
+echo_verbose "10. Restart the containers."
 docker-compose down
 docker-compose up --detach

--- a/docker_deploy/roles/combine_config/tasks/main.yml
+++ b/docker_deploy/roles/combine_config/tasks/main.yml
@@ -17,7 +17,6 @@
     state: directory
   with_items:
     - "{{ combine_app_dir }}"
-    - "{{ combine_app_dir }}/uploads"
     - "{{ combine_app_dir }}/nginx/scripts"
 
 - name: install docker-compose.yml file

--- a/docs/docker_deploy/README.md
+++ b/docs/docker_deploy/README.md
@@ -41,14 +41,14 @@ This document describes how to install the framework that is needed to deploy
    2. [Vault Password](#vault-password)
    3. [Updating Packages](#updating-packages)
 
-## Step-by-step Instructions
+# Step-by-step Instructions
 This section gives you step-by-step instructions for installing *The Combine*
 on a new NUC/PC with links to more detailed information.  The instructions
 assume that the target system already has Ubuntu Server 18.04 installed and
 is accessible via `ssh`.
 
-### Prepare your host system
-#### Linux Host
+## Prepare your host system
+### Linux Host
 
 Install the following components:
  * Ubuntu 18.04 (Desktop or Server), 64-bit
@@ -67,7 +67,7 @@ Install the following components:
    ssh-copy-id <target_user>@<target>
    ```
 
-#### Windows host
+### Windows host
 The scripts for installing TheCombine use *Ansible* to manage an installation of
 *TheCombine*.  *Ansible* is not available for Windows but will run in the
 Windows Subsystem for Linux (WSL).  Microsoft has instructions for installing
@@ -79,7 +79,7 @@ including Ubuntu 18.04.
 Once Ubuntu is installed, run the Ubuntu subsystem and follow the instructions
 for the [Linux Host](#linux-host)
 
-### Installing and Running *TheCombine*
+## Installing and Running *TheCombine*
 
 To install and start up *TheCombine* you will need to run the following Ansible
 playbooks.  Each time you will be prompted for passwords:
@@ -88,14 +88,14 @@ playbooks.  Each time you will be prompted for passwords:
  * `Vault password` - some of the Ansible variable files are encrypted in
    Ansible vaults.  See the current owner (above) for the Vault password.
 
-#### Minimum System Requirements
+### Minimum System Requirements
 
 The minimum system requirements for installing *TheCombine* on a target are:
 - Ubuntu 18.04 Server operating system (see [Install Ubuntu Bionic Server](#install-ubuntu-bionic-server))
 - 2 GB RAM
 - 15 GB Storage
 
-#### Install Combine Pre-requisites
+### Install Combine Pre-requisites
 
 Run the first playbook to install all the packages that are needed by *TheCombine*
 and to setup the Docker configuration files:
@@ -111,14 +111,14 @@ Notes:
   \<COMBINE\>/docker_deploy).  If it is not, then you need to create your
   own inventory file (see [below](#creating-your-own-inventory-file)).
 
-#### Running the *TheCombine* Docker Containers
+### Running the *TheCombine* Docker Containers
 
 *TheCombine*'s docker containers are built by SIL's *TeamCity* server.  Once they
 are built successfully, they are pushed to
 Amazon's Elastic Container Registry (AWS ECR).  The production `docker-compose.yml`
 files will pull the images from AWS_ECR.
 
-#### Creating Your Own Inventory File
+### Creating Your Own Inventory File
 
 You can create your own inventory file to enable Ansible to install the combine
 on a target that is not listed in the hosts.yml inventory file or if you want


### PR DESCRIPTION
Set the profile used to access AWS Elastic Container Registry (ECR) to `ecr_read_only`.

Servers only need to download docker images; they do not need to upload new ones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/830)
<!-- Reviewable:end -->
