### PR TITLE
Set AWS profile for ECR to ecr_read_only

### DIFF
--- a/docker_deploy/group_vars/qa/main.yml
+++ b/docker_deploy/group_vars/qa/main.yml
@@ -23,7 +23,7 @@ aws_user: "{{ combine_user }}"
 aws_group: "{{ combine_group }}"
 
 aws_backup_profile: s3_read_write
-aws_ecr_profile: ecr_read_write
+aws_ecr_profile: ecr_read_only
 
 my_aws_profiles:
     - "{{ aws_backup_profile }}"


### PR DESCRIPTION
Set the profile used to access the AWS Elastic Container Registry to ecr_read_only for QA servers.  Servers (QA & Live server) only need to download docker images; they do not create images to upload to the registry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/831)
<!-- Reviewable:end -->
