### PR TITLE
Add wrapper inside tooltip around functional component.

### DIFF
--- a/src/components/Pronunciations/AudioRecorder.tsx
+++ b/src/components/Pronunciations/AudioRecorder.tsx
@@ -48,9 +48,19 @@ export default function AudioRecorder(props: RecorderProps) {
       });
   }
 
+  // Tooltip cannot be used around a functional component,
+  // because it tries to pass its ref to its children.
+  // This wrapper handles the associated warnings.
+  // https://material-ui.com/guides/composition/#caveat-with-refs
+  const WrappedRecorderIcon = React.forwardRef(
+    (props: React.ComponentProps<typeof RecorderIcon>, _) => (
+      <RecorderIcon {...props} />
+    )
+  );
+
   return (
     <Tooltip title={<Translate id="pronunciations.recordTooltip" />}>
-      <RecorderIcon
+      <WrappedRecorderIcon
         wordId={props.wordId}
         startRecording={startRecording}
         stopRecording={stopRecording}


### PR DESCRIPTION
Workaround that will need to be generalized if we use Tooltip around functional components in more places.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/838)
<!-- Reviewable:end -->
