### PR TITLE
Move Tooltip inside RecorderIcon.

### DIFF
--- a/src/components/Pronunciations/AudioRecorder.tsx
+++ b/src/components/Pronunciations/AudioRecorder.tsx
@@ -1,6 +1,4 @@
-import { Tooltip } from "@material-ui/core";
 import React from "react";
-import { Translate } from "react-localize-redux";
 
 import Recorder from "./Recorder";
 import RecorderIcon from "./RecorderIcon";
@@ -49,12 +47,10 @@ export default function AudioRecorder(props: RecorderProps) {
   }
 
   return (
-    <Tooltip title={<Translate id="pronunciations.recordTooltip" />}>
-      <RecorderIcon
-        wordId={props.wordId}
-        startRecording={startRecording}
-        stopRecording={stopRecording}
-      />
-    </Tooltip>
+    <RecorderIcon
+      wordId={props.wordId}
+      startRecording={startRecording}
+      stopRecording={stopRecording}
+    />
   );
 }

--- a/src/components/Pronunciations/RecorderIcon.tsx
+++ b/src/components/Pronunciations/RecorderIcon.tsx
@@ -1,7 +1,9 @@
+import { IconButton, makeStyles, Tooltip } from "@material-ui/core";
+import { FiberManualRecord } from "@material-ui/icons";
 import React from "react";
-import FiberManualRecord from "@material-ui/icons/FiberManualRecord";
-import { makeStyles, IconButton } from "@material-ui/core";
-import { useSelector, useDispatch } from "react-redux";
+import { Translate } from "react-localize-redux";
+import { useDispatch, useSelector } from "react-redux";
+
 import { updateRecordingStatus } from "../../goals/ReviewEntries/ReviewEntriesComponent/ReviewEntriesActions";
 import { recorderStatus } from "../../types/theme";
 
@@ -67,24 +69,26 @@ export default function RecorderIcon(props: RecorderIconProps) {
   }
 
   return (
-    <IconButton
-      tabIndex={-1}
-      onMouseDown={toggleIsRecordingToTrue}
-      onTouchStart={handleTouchStart}
-      onMouseUp={toggleIsRecordingToFalse}
-      onTouchEnd={handleTouchEnd}
-      className={classes.button}
-      aria-label="record"
-      id="recordingButton"
-    >
-      <FiberManualRecord
-        className={
-          isRecording && props.wordId === wordBeingRecorded
-            ? classes.iconPress
-            : classes.iconRelease
-        }
-        id="icon"
-      />
-    </IconButton>
+    <Tooltip title={<Translate id="pronunciations.recordTooltip" />}>
+      <IconButton
+        tabIndex={-1}
+        onMouseDown={toggleIsRecordingToTrue}
+        onTouchStart={handleTouchStart}
+        onMouseUp={toggleIsRecordingToFalse}
+        onTouchEnd={handleTouchEnd}
+        className={classes.button}
+        aria-label="record"
+        id="recordingButton"
+      >
+        <FiberManualRecord
+          className={
+            isRecording && props.wordId === wordBeingRecorded
+              ? classes.iconPress
+              : classes.iconRelease
+          }
+          id="icon"
+        />
+      </IconButton>
+    </Tooltip>
   );
 }

--- a/src/components/Pronunciations/tests/__snapshots__/Pronunciations.test.tsx.snap
+++ b/src/components/Pronunciations/tests/__snapshots__/Pronunciations.test.tsx.snap
@@ -3,8 +3,9 @@
 exports[`pronunciation tests displays buttons 1`] = `
 Array [
   <button
+    aria-describedby={null}
     aria-label="record"
-    className="MuiButtonBase-root MuiIconButton-root makeStyles-button-6"
+    className="MuiButtonBase-root MuiIconButton-root makeStyles-button-1"
     disabled={false}
     id="recordingButton"
     onBlur={[Function]}
@@ -14,11 +15,13 @@ Array [
     onKeyUp={[Function]}
     onMouseDown={[Function]}
     onMouseLeave={[Function]}
+    onMouseOver={[Function]}
     onMouseUp={[Function]}
     onTouchEnd={[Function]}
     onTouchMove={[Function]}
     onTouchStart={[Function]}
     tabIndex={-1}
+    title={null}
     type="button"
   >
     <span
@@ -26,7 +29,7 @@ Array [
     >
       <svg
         aria-hidden={true}
-        className="MuiSvgIcon-root makeStyles-iconRelease-8"
+        className="MuiSvgIcon-root makeStyles-iconRelease-3"
         focusable="false"
         id="icon"
         viewBox="0 0 24 24"

--- a/src/resources/translations.json
+++ b/src/resources/translations.json
@@ -669,14 +669,14 @@
       "Maintenez le bouton enfoncée pour enregistrer."
     ],
     "playTooltip": [
-      "Press to play, shift click to delete",
-      "Presiona para jugar, presiona shift para eliminar",
-      "Appuyez sur pour lire, Maj + clic pour effacer"
+      "Press to play, shift click to delete.",
+      "Presiona para jugar, presiona shift para eliminar.",
+      "Appuyez sur pour lire, Maj + clic pour effacer."
     ],
     "noMicAccess": [
-      "Recording error: Could not access a microphone",
-      "Error de grabación: no se pudo acceder a un micrófono",
-      "Erreur d'enregistrement : Impossible d'accéder à un microphone"
+      "Recording error: Could not access a microphone.",
+      "Error de grabación: no se pudo acceder a un micrófono.",
+      "Erreur d'enregistrement : Impossible d'accéder à un microphone."
     ],
     "deleteRecording": [
       "Delete Recording",


### PR DESCRIPTION
Replaces #838.

The `ref` property is not implicit with a functional component as it is for a traditional component.
Thus, `Tooltip` cannot be used around a functional component, because it tries to pass its `ref` to its children.
Previously in `AudioRecorder`, we had `Tooltip` wrapped around the functional component `RecorderIcon`.
To fix the associated warnings, this pr moves `Tooltip` to within `RecorderIcon`.
Should we ever need tooltip around a functional component: https://material-ui.com/guides/composition/#caveat-with-refs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/839)
<!-- Reviewable:end -->
