### PR TITLE
Convert AvatarUpload testing from react-dom to react-test-renderer.

### DIFF
--- a/src/components/UserSettings/tests/AvatarUpload.test.tsx
+++ b/src/components/UserSettings/tests/AvatarUpload.test.tsx
@@ -1,22 +1,25 @@
 import React from "react";
-import ReactDOM from "react-dom";
 import configureMockStore from "redux-mock-store";
-import { defaultState } from "../../App/DefaultState";
 import { Provider } from "react-redux";
+import renderer, { ReactTestRenderer } from "react-test-renderer";
+
+import { defaultState } from "../../App/DefaultState";
 import AvatarUpload from "../AvatarUpload";
 
 const createMockStore = configureMockStore([]);
+const mockStore = createMockStore(defaultState);
 
-it("renders without crashing", () => {
-  const mockStore = createMockStore({
-    ...defaultState,
+let testRenderer: ReactTestRenderer;
+
+describe("AvatarUpload", () => {
+  it("renders without crashing", () => {
+    renderer.act(() => {
+      testRenderer = renderer.create(
+        <Provider store={mockStore}>
+          <AvatarUpload />
+        </Provider>
+      );
+    });
+    expect(testRenderer.root.findAllByType(AvatarUpload).length).toBe(1);
   });
-  const div = document.createElement("div");
-  ReactDOM.render(
-    <Provider store={mockStore}>
-      <AvatarUpload />
-    </Provider>,
-    div
-  );
-  ReactDOM.unmountComponentAtNode(div);
 });


### PR DESCRIPTION
This resolves three warnings thrown by `npm run test-frontend -- AvatarUpload`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/840)
<!-- Reviewable:end -->
