### PR TITLE
Enable formatting prose in Markdown

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,9 +8,12 @@ src/resources/dictionaries/* linguist-detectable=false
 *.sh text eol=lf
 *.py text eol=lf
 
-# Force LF for JavaScript/TypeScript files to conform with standards and not conflict with Prettier.
+# Force LF for JavaScript/TypeScript files to conform with standards
+# and not conflict with Prettier.
 *.js eol=lf
 *.jsx eol=lf
 *.ts eol=lf
 *.tsx eol=lf
 *.json eol=lf
+*.md eol=lf
+*.yml eol=lf

--- a/docs/api/projects/get_semantic_domains.md
+++ b/docs/api/projects/get_semantic_domains.md
@@ -1,10 +1,12 @@
 # Parse Semantic Domains of Project
 
 Takes the sematic domains of your project and returns a JSON object in the structure needed by the Tree View component.
-The app currently has copies of the semantic domains in English, Spanish, and French. This tool can be used to localize the Tree View component to other languages.
-This function is not currently operating, so the source code must be changed.
+The app currently has copies of the semantic domains in English, Spanish, and French. This tool can be used to localize
+the Tree View component to other languages. This function is not currently operating, so the source code must be
+changed.
 
-1. In the file [~/TheCombine/Backend/Services/LiftApiServices.cs](../../../Backend/Services/LiftApiServices.cs), uncomment the code in the method `ProcessRangeElement()`.
+1. In the file [~/TheCombine/Backend/Services/LiftApiServices.cs](../../../Backend/Services/LiftApiServices.cs),
+   uncomment the code in the method `ProcessRangeElement()`.
 
 ![Code](code.PNG)
 
@@ -15,11 +17,14 @@ This function is not currently operating, so the source code must be changed.
 
 ![DevTools](DevToolProjId.PNG)
 
-6. Navigate in-browser to `localhost:5001/v1/projeccts/{projectId}/semanticdomains` with the project id you found, which will give you the plaintext result. It should look something like this:
+6. Navigate in-browser to `localhost:5001/v1/projeccts/{projectId}/semanticdomains` with the project id you found, which
+   will give you the plaintext result. It should look something like this:
 
 ![SemDom](semdoms.PNG)
 
-7.  Save this data to a JSON file in [~/TheCombine/src/resources/semantic-domains](../../../src/resources/semantic-domains) with the language code as its name (e.g. `en.json` for English) will allow the data from this language to be used in the Tree View component.
+7.  Save this data to a JSON file in
+    [~/TheCombine/src/resources/semantic-domains](../../../src/resources/semantic-domains) with the language code as its
+    name (e.g. `en.json` for English) will allow the data from this language to be used in the Tree View component.
 
 **URL** : `/v1/projects/{projectId}/semanticdomains`
 

--- a/docs/api/projects/project.md
+++ b/docs/api/projects/project.md
@@ -8,7 +8,8 @@
 
 **analysisWritingSystems** : Language code of glossing systems
 
-**validCharacters** : 𠮷 appears to be a single character but is represented with two unicode codepoints: `"\uD842\uDFB7"`. Currently, the front-end splits on codepoints, so this character would be broken up.
+**validCharacters** : 𠮷 appears to be a single character but is represented with two unicode codepoints:
+`"\uD842\uDFB7"`. Currently, the front-end splits on codepoints, so this character would be broken up.
 
 **rejectedCharacters** :
 
@@ -17,9 +18,8 @@
 **wordFields** :
 
 > **Typing of this is uncertain**  
-> It would make sense to have this strictly typed since we know
-> all possible values at runtime we should probably add a enum that looks
-> something like
+> It would make sense to have this strictly typed since we know all possible values at runtime we should probably add a
+> enum that looks something like
 >
 > ```typescript
 > enum {

--- a/docs/api/projects/project_with_user.md
+++ b/docs/api/projects/project_with_user.md
@@ -1,6 +1,7 @@
 # Project With User
 
-Extension of [`Project`](project.md) with [`User`](..\users\user.md) attribute. Used as return type from [Project Creation](post.md)
+Extension of [`Project`](project.md) with [`User`](..\users\user.md) attribute. Used as return type from
+[Project Creation](post.md)
 
 ## Raw type
 

--- a/docs/api/projects/words/gloss.md
+++ b/docs/api/projects/words/gloss.md
@@ -1,7 +1,7 @@
 # Gloss
 
-A gloss is a series of brief explanations of a word,
-such as definitions or pronunciations, in an analysis writing system.
+A gloss is a series of brief explanations of a word, such as definitions or pronunciations, in an analysis writing
+system.
 
 ## Raw Type
 

--- a/docs/api/projects/words/semanticDomain.md
+++ b/docs/api/projects/words/semanticDomain.md
@@ -1,7 +1,6 @@
 # Semantic Domain
 
-A semantic domain refers to a category of words.
-These words are nested by their number.
+A semantic domain refers to a category of words. These words are nested by their number.
 
 ```
 1. Universe, Creation

--- a/docs/api/projects/words/sense.md
+++ b/docs/api/projects/words/sense.md
@@ -1,7 +1,6 @@
 # Sense
 
-A word may have multiple senses, like the word bank,
-meaning a place where money is stored or land by a river.
+A word may have multiple senses, like the word bank, meaning a place where money is stored or land by a river.
 
 ## Raw Type
 

--- a/docs/data_model.md
+++ b/docs/data_model.md
@@ -40,7 +40,8 @@
 
 - Modified
 
-- History - We are storing the history of a word in a linked tree. Each word will point to the previous word(s) in its history.
+- History - We are storing the history of a word in a linked tree. Each word will point to the previous word(s) in its
+  history.
 
 - Part of Speech
 

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -1,14 +1,17 @@
 # How To Deploy TheCombine Application
 
-This document describes how to build and deploy _TheCombine_ project. It is designed to run on an Intel NUC, for use in the field, or on the demonstration server, thecombine.languagetechnology.org.
+This document describes how to build and deploy _TheCombine_ project. It is designed to run on an Intel NUC, for use in
+the field, or on the demonstration server, thecombine.languagetechnology.org.
 
 ### Intended Audience
 
-These instructions are for developers that have login access to thecombine.languagetechnology.org and have <tt>sudo</tt> priveleges there.
+These instructions are for developers that have login access to thecombine.languagetechnology.org and have <tt>sudo</tt>
+priveleges there.
 
 ### Conventions
 
-- most of the commands described in this document are to be run from within the <tt>git</tt> repository for _TheCombine_ that has been cloned on the host machine. This directory shall referred to as <tt>\${COMBINE}</tt>.
+- most of the commands described in this document are to be run from within the <tt>git</tt> repository for _TheCombine_
+  that has been cloned on the host machine. This directory shall referred to as <tt>\${COMBINE}</tt>.
 
 ## Contents
 
@@ -27,7 +30,8 @@ These instructions are for developers that have login access to thecombine.langu
 
 ## Step-by-step Instructions
 
-This section gives you step-by-step instructions for installing _The Combine_ on a new NUC/PC with links to more detailed information.
+This section gives you step-by-step instructions for installing _The Combine_ on a new NUC/PC with links to more
+detailed information.
 
 ### Prepare your host system
 
@@ -39,7 +43,8 @@ Install the following components:
 - Git
 - [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#latest-releases-via-apt-ubuntu)
 - [Nodejs](https://github.com/nodesource/distributions/blob/master/README.md#debinstall), install the LTS version, 12.x.
-- [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/linux-package-manager/ubuntu18-04) Be sure to select _Ubuntu 18.04 - x64_ from the dropdown menu on the page.
+- [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/linux-package-manager/ubuntu18-04) Be sure to select _Ubuntu
+  18.04 - x64_ from the dropdown menu on the page.
 - clone the project repo:
   ```
   git clone --recurse-submodules https://github.com/sillsdev/TheCombine
@@ -47,10 +52,14 @@ Install the following components:
 
 #### Windows host
 
-The scripts for installing TheCombine use _Ansible_ to manage an installation of _TheCombine_. _Ansible_ is not available for Windows. There is a _Vagrant_ vm that is available to provide an Ubuntu environment to build and install the application on an _Intel NUC_ that can be deployed in the field. If you only have access to a Windows PC, follow these instructions to build and deploy _TheCombine_.
+The scripts for installing TheCombine use _Ansible_ to manage an installation of _TheCombine_. _Ansible_ is not
+available for Windows. There is a _Vagrant_ vm that is available to provide an Ubuntu environment to build and install
+the application on an _Intel NUC_ that can be deployed in the field. If you only have access to a Windows PC, follow
+these instructions to build and deploy _TheCombine_.
 
 - Install [VirtualBox](https://www.virtualbox.org/wiki/Downloads).
-- Install [Vagrant](https://www.vagrantup.com/downloads.html). Note that if you are installing Vagrant on an Ubuntu host, you should select the Debian package rather than the generic Linux package.
+- Install [Vagrant](https://www.vagrantup.com/downloads.html). Note that if you are installing Vagrant on an Ubuntu
+  host, you should select the Debian package rather than the generic Linux package.
 - Clone the project repo:
   ```
   git clone --recurse-submodules https://github.com/sillsdev/TheCombine
@@ -68,15 +77,21 @@ The scripts for installing TheCombine use _Ansible_ to manage an installation of
      Username: vagrant
      Password: vagrant
   ```
-- Open a terminal window (_Ctrl-Alt-T_). This terminal window may be used to run the commands in the [Installing _TheCombine_](#installing-thecombine) section.
+- Open a terminal window (_Ctrl-Alt-T_). This terminal window may be used to run the commands in the
+  [Installing _TheCombine_](#installing-thecombine) section.
 
-Note that _TheCombine_ project is only cloned the first time the vm is created and provisioned. If you have created a vagrant-installer vm in the past, use <tt>git pull</tt> to update your repo and install the updated software on a target.
+Note that _TheCombine_ project is only cloned the first time the vm is created and provisioned. If you have created a
+vagrant-installer vm in the past, use <tt>git pull</tt> to update your repo and install the updated software on a
+target.
 
 #### Create SSH config
 
-In order to run the playbook that registers the NUC on the certificate server (or "demo server") you need to be able to <tt>ssh</tt> to the certificate server from your host machine (or from the VM if you are running Windows on your host machine).
+In order to run the playbook that registers the NUC on the certificate server (or "demo server") you need to be able to
+<tt>ssh</tt> to the certificate server from your host machine (or from the VM if you are running Windows on your host
+machine).
 
-Create an SSH config file (<tt>~/.ssh/config</tt>) to enable an <tt>ssh</tt> connection to the demo server. The SSH config file shall contain the following configuration:
+Create an SSH config file (<tt>~/.ssh/config</tt>) to enable an <tt>ssh</tt> connection to the demo server. The SSH
+config file shall contain the following configuration:
 
 ```
     Host thecombine
@@ -93,7 +108,8 @@ Notes
 
 ### Installing _TheCombine_
 
-These instructions are for installing _TheCombine_ on a blank device. See [Updating _TheCombine_](#updating-thecombine) for instructions on updating the application on an existing installation.
+These instructions are for installing _TheCombine_ on a blank device. See [Updating _TheCombine_](#updating-thecombine)
+for instructions on updating the application on an existing installation.
 
 | Step                                                                                                                                                                      | Comments                                                                                                                                                                                                                                                                                              |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -106,24 +122,29 @@ These instructions are for installing _TheCombine_ on a blank device. See [Updat
 
 ### Running _TheCombine_
 
-To run _TheCombine_ on the NUC, connect to the WiFi access point created by the server; the access point SSID is _nuc_hostname_<tt>\_ap</tt>.
+To run _TheCombine_ on the NUC, connect to the WiFi access point created by the server; the access point SSID is
+_nuc_hostname_<tt>\_ap</tt>.
 
-Once you have connected to the WiFi Access Point, connect to the local instance of _TheCombine_ by navigating to https://thecombine.languagetechnology.org with your web browser.
+Once you have connected to the WiFi Access Point, connect to the local instance of _TheCombine_ by navigating to
+https://thecombine.languagetechnology.org with your web browser.
 
 ### Updating _TheCombine_
 
-Once _TheCombine_ has been installed on the NUC, you can update the application by running steps 5 - 8 in the section [Installing _TheCombine_](#installing-thecombine).
+Once _TheCombine_ has been installed on the NUC, you can update the application by running steps 5 - 8 in the section
+[Installing _TheCombine_](#installing-thecombine).
 
 # Additional Details
 
 ## Install Ubuntu Bionic Server
 
-1. Download the ISO image for Ubuntu Server from Ubuntu (currently at http://cdimage.ubuntu.com/releases/18.04.3/release/ubuntu-18.04.3-server-amd64.iso)
+1. Download the ISO image for Ubuntu Server from Ubuntu (currently at
+   http://cdimage.ubuntu.com/releases/18.04.3/release/ubuntu-18.04.3-server-amd64.iso)
 
 1. copy the .iso file to a bootable USB stick:
 
    1. Ubuntu host: Use the _Startup Disk Creator_, or
-   2. Windows host: follow the [tutorial](https://ubuntu.com/tutorials/tutorial-create-a-usb-stick-on-windows#1-overview) on ubuntu.com.
+   2. Windows host: follow the
+      [tutorial](https://ubuntu.com/tutorials/tutorial-create-a-usb-stick-on-windows#1-overview) on ubuntu.com.
 
 1. Boot the PC from the bootable media and follow the installation instructions. In particular,
 
@@ -134,27 +155,37 @@ Once _TheCombine_ has been installed on the NUC, you can update the application 
 
 ## Vault Password
 
-The Ansible playbooks require that some of the variable files are encrypted. When running one of the playbooks, you will need to provide the password for the encrypted files. The password can be provided by:
+The Ansible playbooks require that some of the variable files are encrypted. When running one of the playbooks, you will
+need to provide the password for the encrypted files. The password can be provided by:
 
-1. entering the password when prompted. Add the <tt>--ask-vault-pass</tt> option for <tt>ansible-playbook</tt> to be prompted for the password when it is required. This is the default for <tt>./setup-nuc.sh</tt>
-2. specify a file that has the password. Add the <tt>--vault-password-file</tt> option for <tt>ansible-playbook</tt> followed by the path of a file that holds the vault password.
-3. set the environment variable <tt>ANSIBLE*VAULT_PASSWORD_FILE</tt> to the path of a file that holds the vault password. This prevents you from needing to provide the vault password whenever you run an ansible playbook, either directly or from within a script such as <tt>setup-nuc.sh</tt>. \_Make sure that you are the only one with read permission for the password file!*
+1. entering the password when prompted. Add the <tt>--ask-vault-pass</tt> option for <tt>ansible-playbook</tt> to be
+   prompted for the password when it is required. This is the default for <tt>./setup-nuc.sh</tt>
+2. specify a file that has the password. Add the <tt>--vault-password-file</tt> option for <tt>ansible-playbook</tt>
+   followed by the path of a file that holds the vault password.
+3. set the environment variable <tt>ANSIBLE*VAULT_PASSWORD_FILE</tt> to the path of a file that holds the vault
+   password. This prevents you from needing to provide the vault password whenever you run an ansible playbook, either
+   directly or from within a script such as <tt>setup-nuc.sh</tt>. \_Make sure that you are the only one with read
+   permission for the password file!*
 
 If you use a file to hold the vault password, then:
 
 - _Make sure that you are the only one with read permission for the password file!_
-- _Make sure that the password file is not tracked in the git repository!_ <p>For example, use hidden file in your home directory, such as <tt>\$HOME/.ansible-vault</tt>, with mode of <tt>0600</tt>.</p>
+- _Make sure that the password file is not tracked in the git repository!_ <p>For example, use hidden file in your home
+  directory, such as <tt>\$HOME/.ansible-vault</tt>, with mode of <tt>0600</tt>.</p>
 
 ## Setup NUC Options
 
-There are some additional options for using the <tt>setup-nuc.sh</tt> script
-and the <tt>playbook_publish.yml</tt> playbook.
+There are some additional options for using the <tt>setup-nuc.sh</tt> script and the <tt>playbook_publish.yml</tt>
+playbook.
 
 1. <tt>setup-nuc.sh</tt> recognizes the following options:
    - <tt>--copyid</tt> copies your ssh public key to the NUC
-   - <tt>--vault</tt> or <tt>--vault-password-file</tt> allows you to specify the name of a file that holds the Ansible vault password as the next argumnt.
+   - <tt>--vault</tt> or <tt>--vault-password-file</tt> allows you to specify the name of a file that holds the Ansible
+     vault password as the next argumnt.
    - <tt>-h</tt> or <tt>--help</tt> prints the usage text and exits
-1. Any options that are not recognized by <tt>setup-nuc.sh</tt> are passed to the ansible playbooks that are called by <tt>setup-nuc.sh</tt>. This is especially useful for specifying an alternate inventory file for development or testing purposes. Note that files whose names end in <tt>".hosts"</tt> are ignored by git.
+1. Any options that are not recognized by <tt>setup-nuc.sh</tt> are passed to the ansible playbooks that are called by
+   <tt>setup-nuc.sh</tt>. This is especially useful for specifying an alternate inventory file for development or
+   testing purposes. Note that files whose names end in <tt>".hosts"</tt> are ignored by git.
 
 ## Demo Server
 
@@ -176,5 +207,9 @@ In order to setup the Demo Server,
   ansible-playbook playbook_publish.yml -K --limit thecombine --ask-vault-pass
   ```
   Notes:
-  - <tt>playbook*server.yml</tt> only needs to be run once. In order to update to a newer version of \_TheCombine*, only the <tt>playbook_publish.yml</tt> needs to be run.
-  - <tt>playbook_server.yml</tt> currently uses the geerlingguy.certbot role to create the letsencrypt SSL certificate. This role only supports the <tt>standalone</tt> challenge method. Run the specified <tt>certbot</tt> command to convert the renewal to use webroot. The <tt>standalone</tt> certificate requires shutting down the Apache web server to renew the certificate and then restarting it.
+  - <tt>playbook*server.yml</tt> only needs to be run once. In order to update to a newer version of \_TheCombine*, only
+    the <tt>playbook_publish.yml</tt> needs to be run.
+  - <tt>playbook_server.yml</tt> currently uses the geerlingguy.certbot role to create the letsencrypt SSL certificate.
+    This role only supports the <tt>standalone</tt> challenge method. Run the specified <tt>certbot</tt> command to
+    convert the renewal to use webroot. The <tt>standalone</tt> certificate requires shutting down the Apache web server
+    to renew the certificate and then restarting it.

--- a/docs/docker_deploy/README.md
+++ b/docs/docker_deploy/README.md
@@ -1,7 +1,7 @@
 # Deploy _TheCombine_ In Docker Containers
 
-This document describes how to install the framework that is needed to deploy
-_TheCombine_ to a target machine in Docker containers.
+This document describes how to install the framework that is needed to deploy _TheCombine_ to a target machine in Docker
+containers.
 
 <table>
 <tr>
@@ -14,15 +14,11 @@ _TheCombine_ to a target machine in Docker containers.
 
 ## Conventions
 
-- most of the commands described in this document are to be run from within
-  the <tt>git</tt> repository for _TheCombine_ that has been cloned on the
-  host machine. This directory shall referred to as \<COMBINE\>.
-- the target machine where _TheCombine_ is being installed will be referred
-  to as _\<target\>_
-- the user on the target machine that will be used for installing docker, etc.
-  will be referred to as _\<target_user\>_. You must be able to login to
-  _\<target\>_ as _\<target_user\>_ and _\<target_user\>_ must have `sudo`
-  privileges.
+- most of the commands described in this document are to be run from within the <tt>git</tt> repository for _TheCombine_
+  that has been cloned on the host machine. This directory shall referred to as \<COMBINE\>.
+- the target machine where _TheCombine_ is being installed will be referred to as _\<target\>_
+- the user on the target machine that will be used for installing docker, etc. will be referred to as _\<target_user\>_.
+  You must be able to login to _\<target\>_ as _\<target_user\>_ and _\<target_user\>_ must have `sudo` privileges.
 
 ## Contents
 
@@ -44,10 +40,9 @@ _TheCombine_ to a target machine in Docker containers.
 
 # Step-by-step Instructions
 
-This section gives you step-by-step instructions for installing _The Combine_
-on a new NUC/PC with links to more detailed information. The instructions
-assume that the target system already has Ubuntu Server 18.04 installed and
-is accessible via `ssh`.
+This section gives you step-by-step instructions for installing _The Combine_ on a new NUC/PC with links to more
+detailed information. The instructions assume that the target system already has Ubuntu Server 18.04 installed and is
+accessible via `ssh`.
 
 ## Prepare your host system
 
@@ -73,26 +68,22 @@ Install the following components:
 
 ### Windows host
 
-The scripts for installing TheCombine use _Ansible_ to manage an installation of
-_TheCombine_. _Ansible_ is not available for Windows but will run in the
-Windows Subsystem for Linux (WSL). Microsoft has instructions for installing
-WSL on Windows 10 at [Windows Subsystem for Linux Installation Guide for Windows
-10](https://docs.microsoft.com/en-us/windows/wsl/install-win10). At the end of
-the instructions there are instructions for installing various Linux images
-including Ubuntu 18.04.
+The scripts for installing TheCombine use _Ansible_ to manage an installation of _TheCombine_. _Ansible_ is not
+available for Windows but will run in the Windows Subsystem for Linux (WSL). Microsoft has instructions for installing
+WSL on Windows 10 at
+[Windows Subsystem for Linux Installation Guide for Windows 10](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
+At the end of the instructions there are instructions for installing various Linux images including Ubuntu 18.04.
 
-Once Ubuntu is installed, run the Ubuntu subsystem and follow the instructions
-for the [Linux Host](#linux-host)
+Once Ubuntu is installed, run the Ubuntu subsystem and follow the instructions for the [Linux Host](#linux-host)
 
 ## Installing and Running _TheCombine_
 
-To install and start up _TheCombine_ you will need to run the following Ansible
-playbooks. Each time you will be prompted for passwords:
+To install and start up _TheCombine_ you will need to run the following Ansible playbooks. Each time you will be
+prompted for passwords:
 
-- `BECOME password` - enter your `sudo` password for the _\<target_user\>_
-  on the _\<target\>_ machine.
-- `Vault password` - some of the Ansible variable files are encrypted in
-  Ansible vaults. See the current owner (above) for the Vault password.
+- `BECOME password` - enter your `sudo` password for the _\<target_user\>_ on the _\<target\>_ machine.
+- `Vault password` - some of the Ansible variable files are encrypted in Ansible vaults. See the current owner (above)
+  for the Vault password.
 
 ### Minimum System Requirements
 
@@ -104,8 +95,8 @@ The minimum system requirements for installing _TheCombine_ on a target are:
 
 ### Install Combine Pre-requisites
 
-Run the first playbook to install all the packages that are needed by _TheCombine_
-and to setup the Docker configuration files:
+Run the first playbook to install all the packages that are needed by _TheCombine_ and to setup the Docker configuration
+files:
 
 ```
 cd <COMBINE>/docker_deploy
@@ -114,69 +105,60 @@ ansible-playbook playbook_target_setup.yml --limit <target> -u <target_user> -K 
 
 Notes:
 
-- Do not add the `-K` option if you do not need to enter your password to
-  run `sudo` commands _on the target machine_.
-- The _\<target\>_ must be listed in the hosts.yml file (in
-  \<COMBINE\>/docker_deploy). If it is not, then you need to create your
-  own inventory file (see [below](#creating-your-own-inventory-file)).
+- Do not add the `-K` option if you do not need to enter your password to run `sudo` commands _on the target machine_.
+- The _\<target\>_ must be listed in the hosts.yml file (in \<COMBINE\>/docker_deploy). If it is not, then you need to
+  create your own inventory file (see [below](#creating-your-own-inventory-file)).
 
 ### Running the _TheCombine_ Docker Containers
 
-_TheCombine_'s docker containers are built by SIL's _TeamCity_ server. Once they
-are built successfully, they are pushed to
-Amazon's Elastic Container Registry (AWS ECR). The production `docker-compose.yml`
-files will pull the images from AWS_ECR.
+_TheCombine_'s docker containers are built by SIL's _TeamCity_ server. Once they are built successfully, they are pushed
+to Amazon's Elastic Container Registry (AWS ECR). The production `docker-compose.yml` files will pull the images from
+AWS_ECR.
 
 ### Creating Your Own Inventory File
 
-You can create your own inventory file to enable Ansible to install the combine
-on a target that is not listed in the hosts.yml inventory file or if you want
-to override a variable that is used to configure the target.
+You can create your own inventory file to enable Ansible to install the combine on a target that is not listed in the
+hosts.yml inventory file or if you want to override a variable that is used to configure the target.
 
 To use your own inventory file:
 
-- have the filename match the pattern \*.hosts.yml, e.g. dev.hosts.yml, or save
-  it in a directory that is not in the combine source tree;
-- use hosts.yml as a model. The host will need to be in the `server` or the
-  `qa` group presently. Machines in the `qa` group will use a self-signed
-  certificate; machines in the `server` group will get a certificate from
-  letsencrypt and must be reachable from the internet.
+- have the filename match the pattern \*.hosts.yml, e.g. dev.hosts.yml, or save it in a directory that is not in the
+  combine source tree;
+- use hosts.yml as a model. The host will need to be in the `server` or the `qa` group presently. Machines in the `qa`
+  group will use a self-signed certificate; machines in the `server` group will get a certificate from letsencrypt and
+  must be reachable from the internet.
 - define the following variables:
 
   - combine_server_name:
   - config_captcha_required:
   - config_captcha_sitekey:
 
-  config_captcha_required should be "true" or "false" (including the quotes);
-  if it is "false", config_captcha_sitekey can be an empty string.
+  config_captcha_required should be "true" or "false" (including the quotes); if it is "false", config_captcha_sitekey
+  can be an empty string.
 
 - add any variables whose default value you want to override.
-- to use the custom inventory file, add the following option to the
-  ansible-playbook commands above: `-i custom-inventory.yml` where
-  `custom-inventory.yml` is the name of the inventory file that you created.
+- to use the custom inventory file, add the following option to the ansible-playbook commands above:
+  `-i custom-inventory.yml` where `custom-inventory.yml` is the name of the inventory file that you created.
 
 See the Ansible documentation,
-[Build Your Inventory](https://docs.ansible.com/ansible/latest/network/getting_started/first_inventory.html)
-for more information on inventory files.
+[Build Your Inventory](https://docs.ansible.com/ansible/latest/network/getting_started/first_inventory.html) for more
+information on inventory files.
 
 # Backups
 
 ## Automated Backups
 
-If the ansible variables `backup_hours` and `backup_minutes` are defined for a
-target, then `cron` will be setup to create a backup of _TheCombine_ database and
-backend files every day at the specified times. The hours/minutes can be set to
-any string that is recognized by `cron`. The backups are stored in an Amazon S3
-bucket.
+If the ansible variables `backup_hours` and `backup_minutes` are defined for a target, then `cron` will be setup to
+create a backup of _TheCombine_ database and backend files every day at the specified times. The hours/minutes can be
+set to any string that is recognized by `cron`. The backups are stored in an Amazon S3 bucket.
 
 ## Running a Backup Manually
 
-A backup can be initiated on demand whether or not an automatic backup has been
-setup. To run a backup, perform the following steps:
+A backup can be initiated on demand whether or not an automatic backup has been setup. To run a backup, perform the
+following steps:
 
 1.  `ssh` to the target using your account.
-2.  Switch user to `combine`, e.g. `sudo su -l combine`. Make sure you use the
-    `-l` option.
+2.  Switch user to `combine`, e.g. `sudo su -l combine`. Make sure you use the `-l` option.
 3.  `cd /opt/combine`
 4.  `bin/combine-backup`
 
@@ -184,27 +166,23 @@ setup. To run a backup, perform the following steps:
 
 ## Restoring Database and Backend From a Previous Backup
 
-_TheCombine_ database and backend files can be restored from a previous backup by
-performing the following steps:
+_TheCombine_ database and backend files can be restored from a previous backup by performing the following steps:
 
 1. `ssh` to the target using your account.
-2. Switch user to `combine`, e.g. `sudo su -l combine`. Make sure you use the
-   `-l` option.
+2. Switch user to `combine`, e.g. `sudo su -l combine`. Make sure you use the `-l` option.
 3. `cd /opt/combine`
 4. `bin/combine-restore`
 
-You may provide the backup to restore as an argument to `bin/combine-restore`; if
-no backup is specified, `combine-restore` will list the backups that are available
-in the AWS S3 bucket and allow you to select one.
+You may provide the backup to restore as an argument to `bin/combine-restore`; if no backup is specified,
+`combine-restore` will list the backups that are available in the AWS S3 bucket and allow you to select one.
 
 `bin/combine-restore -h` will print the usage information.
 
 # Design
 
-_TheCombine_ is deployed to target systems using Ansible. When deploying in
-Docker containers, `docker-compose` is used to manage the containers that make
-up _TheCombine_. The following files are used to define the containers and
-their dependencies:
+_TheCombine_ is deployed to target systems using Ansible. When deploying in Docker containers, `docker-compose` is used
+to manage the containers that make up _TheCombine_. The following files are used to define the containers and their
+dependencies:
 
 - ./docker-compose.yml
 - ./Dockerfile
@@ -214,14 +192,13 @@ their dependencies:
 - ./certmgr/Dockerfile
 - ./.env.certmgr
 
-With these files, we can use `docker-compose` to startup _TheCombine_ in the
-development environment (see the project top-level README.md).
+With these files, we can use `docker-compose` to startup _TheCombine_ in the development environment (see the project
+top-level README.md).
 
-`playbook_target_setup.yml` is an Ansible playbook that is used to install docker,
-docker-compose, and the files to configure the docker containers. It only needs
-to be run once. When running this playbook, it needs to be run as a user on the
-target system that can be elevated to `root` privileges. It needs to be run
-once at initial setup and if ever the playbook or its roles change.
+`playbook_target_setup.yml` is an Ansible playbook that is used to install docker, docker-compose, and the files to
+configure the docker containers. It only needs to be run once. When running this playbook, it needs to be run as a user
+on the target system that can be elevated to `root` privileges. It needs to be run once at initial setup and if ever the
+playbook or its roles change.
 
 `playbook_target_setup.yml` does the following:
 
@@ -230,10 +207,9 @@ once at initial setup and if ever the playbook or its roles change.
    1. install docker prerequisite packages
    2. setup docker package repository
    3. install Docker Engine
-   4. install Docker Compose (including a link from `/usr/bin` to the
-      executable)
-3. Create a combine user - the combine user will be used for installing,
-   building and running _TheCombine_. The default user name is `combine`.
+   4. install Docker Compose (including a link from `/usr/bin` to the executable)
+3. Create a combine user - the combine user will be used for installing, building and running _TheCombine_. The default
+   user name is `combine`.
    1. Create the primary group for `combine`
    2. Create the `combine` user:
       1. primary group is the group created above
@@ -243,10 +219,9 @@ once at initial setup and if ever the playbook or its roles change.
    1. Create folders for the docker installation:
       - combine app dir (`/opt/combine`)
       - Nginx script dir (`/opt/combine/nginx/scripts`)
-   2. Install the `docker-compose.yml` that defines the containers and their
-      environment;
-   3. Create the environment variable files for the frontend and backend
-      containers, `.env.frontend`, `.env.backend`, and `.env.certmgr`;
+   2. Install the `docker-compose.yml` that defines the containers and their environment;
+   3. Create the environment variable files for the frontend and backend containers, `.env.frontend`, `.env.backend`,
+      and `.env.certmgr`;
    4. Create the runtime configuration for the UI;
 5. Setup access to the Amazon Web Services
    1. Install the `aws-cli` package
@@ -268,14 +243,12 @@ To install the OS on a new target machine, such as, a new NUC, follow these step
 1. copy the .iso file to a bootable USB stick:
 
    1. Ubuntu host: Use the _Startup Disk Creator_, or
-   2. Windows host: follow the [tutorial](https://ubuntu.com/tutorials/tutorial-create-a-usb-stick-on-windows#1-overview)
-      on ubuntu.com.
+   2. Windows host: follow the
+      [tutorial](https://ubuntu.com/tutorials/tutorial-create-a-usb-stick-on-windows#1-overview) on ubuntu.com.
 
-1. Boot the PC from the bootable media and follow the installation instructions.
-   In particular,
+1. Boot the PC from the bootable media and follow the installation instructions. In particular,
 
-   1. You will want the installer to format the entire \[virtual\] disk.
-      Using LVM is not recommended.
+   1. You will want the installer to format the entire \[virtual\] disk. Using LVM is not recommended.
 
    1. _Make sure that you select the OpenSSH server when prompted to select the software for your server:_
       ![alt text](images/ubuntu-software-selection.png "Ubuntu Server Software Selection")
@@ -291,35 +264,28 @@ To install the OS on a new target machine, such as, a new NUC, follow these step
 
 ## Vault Password
 
-The Ansible playbooks require that some of the variable files are encrypted.
-When running one of the playbooks, you will need to provide the password for
-the encrypted files. The password can be provided by:
+The Ansible playbooks require that some of the variable files are encrypted. When running one of the playbooks, you will
+need to provide the password for the encrypted files. The password can be provided by:
 
-1. entering the password when prompted. Add the <tt>--ask-vault-pass</tt>
-   option for <tt>ansible-playbook</tt> to be prompted for the password when
-   it is required.
-2. specify a file that has the password. Add the <tt>--vault-password-file</tt>
-   option for <tt>ansible-playbook</tt> followed by the path of a file that holds
-   the vault password.
-3. set the environment variable <tt>ANSIBLE_VAULT_PASSWORD_FILE</tt> to the
-   path of a file that holds the vault password. This prevents you from
-   needing to provide the vault password whenever you run an ansible playbook,
-   either directly or from within a script such as <tt>setup-nuc.sh</tt>.
+1. entering the password when prompted. Add the <tt>--ask-vault-pass</tt> option for <tt>ansible-playbook</tt> to be
+   prompted for the password when it is required.
+2. specify a file that has the password. Add the <tt>--vault-password-file</tt> option for <tt>ansible-playbook</tt>
+   followed by the path of a file that holds the vault password.
+3. set the environment variable <tt>ANSIBLE_VAULT_PASSWORD_FILE</tt> to the path of a file that holds the vault
+   password. This prevents you from needing to provide the vault password whenever you run an ansible playbook, either
+   directly or from within a script such as <tt>setup-nuc.sh</tt>.
 
 If you use a file to hold the vault password, then:
 
 - _Make sure that you are the only one with read permission for the password file!_
 - _Make sure that the password file is not tracked in the git repository!_
 
-For example, use hidden file in your home directory, such as
-<tt>\$HOME/.ansible-vault</tt>, with mode of <tt>0600</tt>.
+For example, use hidden file in your home directory, such as <tt>\$HOME/.ansible-vault</tt>, with mode of <tt>0600</tt>.
 
 ## Updating Packages
 
-Currently, `docker-compose` is not managed by an _Ubuntu_ software repository and
-the software version is specified in the command that fetches the software from
-the source repository. To make managing software versions easier,
-`./docker_deploy/vars/packages.yml` has been created to specify the software
-version of `docker-compose` and similar packages. To update the version of
-one of these packages, update the version in this file and re-run the specified
+Currently, `docker-compose` is not managed by an _Ubuntu_ software repository and the software version is specified in
+the command that fetches the software from the source repository. To make managing software versions easier,
+`./docker_deploy/vars/packages.yml` has been created to specify the software version of `docker-compose` and similar
+packages. To update the version of one of these packages, update the version in this file and re-run the specified
 playbook.

--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -1,7 +1,7 @@
 # The Combine Frontend Docs
 
-The Combine is a web-based tool used to clean up the data collected after a Rapid Word Collection workshop. We use the following technologies on the
-frontend:
+The Combine is a web-based tool used to clean up the data collected after a Rapid Word Collection workshop. We use the
+following technologies on the frontend:
 
 - [React](https://reactjs.org/)
 - [Redux](https://redux.js.org/)

--- a/docs/frontend/addingComponents.md
+++ b/docs/frontend/addingComponents.md
@@ -4,21 +4,19 @@ Let's say you want to add a Login component to the app.
 
 First, create the React component that handles login.
 
-The component will need methods to register a user account, as well as to login.
-This will require a database call or two. To make the component as reusable as
-possible, we will pass in these methods through the component's props.
+The component will need methods to register a user account, as well as to login. This will require a database call or
+two. To make the component as reusable as possible, we will pass in these methods through the component's props.
 
-The component will also need access to the Redux store. The data you need from
-the store should be passed in through props as well. To pass in the data, you
-want to create a
+The component will also need access to the Redux store. The data you need from the store should be passed in through
+props as well. To pass in the data, you want to create a
 [connected component](https://redux.js.org/basics/usage-with-react).
 
-You will need to create action creators and reducers, since you want to
-be able to dispatch login actions to the store, and respond to the actions. The
-reducer should be added to the root reducer, located in [src/rootReducer.tsx](../../src/rootReducer.tsx).
+You will need to create action creators and reducers, since you want to be able to dispatch login actions to the store,
+and respond to the actions. The reducer should be added to the root reducer, located in
+[src/rootReducer.tsx](../../src/rootReducer.tsx).
 
-Adding a login component will require adding new state types to the store. You
-want to add login state to the store. This should be defined in your login reducers
-file. The state should be added to the store state in [src/types/index.tsx](../../src/types/index.tsx).
+Adding a login component will require adding new state types to the store. You want to add login state to the store.
+This should be defined in your login reducers file. The state should be added to the store state in
+[src/types/index.tsx](../../src/types/index.tsx).
 
 Don't forget to write unit tests.

--- a/docs/frontend/fileStructure/backend.md
+++ b/docs/frontend/fileStructure/backend.md
@@ -1,4 +1,4 @@
 # Backend
 
-Backend contains the api used to access the backend api. It is the only place
-in the frontend where requests are made to the backend api.
+Backend contains the api used to access the backend api. It is the only place in the frontend where requests are made to
+the backend api.

--- a/docs/frontend/fileStructure/components.md
+++ b/docs/frontend/fileStructure/components.md
@@ -9,14 +9,12 @@ Each directory should contain at least:
 
 Sometimes, there will also be these files/folders:
 
-- index.tsx - a component that injects props into the component. These props are
-  retrieved from the Redux store
+- index.tsx - a component that injects props into the component. These props are retrieved from the Redux store
 - a file containing Redux actions
 - a file containing a Redux reducer
 
-Components can be nested. Nested components should be stored in
-subdirectories of their parent, unless there are other components that use
-them.
+Components can be nested. Nested components should be stored in subdirectories of their parent, unless there are other
+components that use them.
 
 Here is an example of what a directory in components should look like:
 

--- a/docs/frontend/fileStructure/goals.md
+++ b/docs/frontend/fileStructure/goals.md
@@ -1,8 +1,7 @@
 # Goals
 
-The Combine provides tools for people to clean up after a Rapid Word Collection
-workshop. We call each of these tools a goal that the user wants to accomplish.
-The goal types The Combine provides are:
+The Combine provides tools for people to clean up after a Rapid Word Collection workshop. We call each of these tools a
+goal that the user wants to accomplish. The goal types The Combine provides are:
 
 - Create Character Inventory
 - Create Structural Character Inventory
@@ -21,7 +20,6 @@ Each directory should contain at least:
 
 Sometimes, there will also be these files/folders:
 
-- index.tsx - a component that injects props into the component. These props are
-  retrieved from the Redux store
+- index.tsx - a component that injects props into the component. These props are retrieved from the Redux store
 - a file containing Redux actions
 - a file containing a Redux reducer

--- a/docs/frontend/fileStructure/index.tsx.md
+++ b/docs/frontend/fileStructure/index.tsx.md
@@ -1,4 +1,3 @@
 # index.tsx
 
-This is the top-level component in The Combine. Everything is wired together in
-this file.
+This is the top-level component in The Combine. Everything is wired together in this file.

--- a/docs/frontend/fileStructure/rootReducer.tsx.md
+++ b/docs/frontend/fileStructure/rootReducer.tsx.md
@@ -1,4 +1,3 @@
 # rootReducer.tsx
 
-The reducer for the Redux store is stored here. All of the reducers are combined
-here to make one large reducer.
+The reducer for the Redux store is stored here. All of the reducers are combined here to make one large reducer.

--- a/docs/frontend/fileStructure/serviceWorker.ts.md
+++ b/docs/frontend/fileStructure/serviceWorker.ts.md
@@ -1,6 +1,5 @@
 # serviceWorker.ts
 
-A service worker is run in the background. It allows for things like push
-notifications. It does not need to be modified. See
-https://developers.google.com/web/fundamentals/primers/service-workers/ for
-more information about service workers.
+A service worker is run in the background. It allows for things like push notifications. It does not need to be
+modified. See https://developers.google.com/web/fundamentals/primers/service-workers/ for more information about service
+workers.

--- a/docs/frontend/fileStructure/store.tsx.md
+++ b/docs/frontend/fileStructure/store.tsx.md
@@ -1,5 +1,4 @@
 # store.tsx
 
-This creates the Redux store, and applies any middleware you may be using. The
-Combine is using [thunk](https://github.com/reduxjs/redux-thunk) as its
-middleware.
+This creates the Redux store, and applies any middleware you may be using. The Combine is using
+[thunk](https://github.com/reduxjs/redux-thunk) as its middleware.

--- a/docs/frontend/fileStructure/types.md
+++ b/docs/frontend/fileStructure/types.md
@@ -1,4 +1,3 @@
 # Types
 
-Types contains data types for the data model, as well as types used with the
-Redux store.
+Types contains data types for the data model, as well as types used with the Redux store.

--- a/docs/meeting_notes/5-30_Cleaner_Workflow/cleaner_workflow_5-30.md
+++ b/docs/meeting_notes/5-30_Cleaner_Workflow/cleaner_workflow_5-30.md
@@ -10,8 +10,7 @@ Questions:
 
 The following cards are discrete actions we came up with. Included are some crazy-8s sketches we did.
 
-![Card Types 1](./cards1.jpg)
-![Card Types 2](./cards2.jpg)
+![Card Types 1](./cards1.jpg) ![Card Types 2](./cards2.jpg)
 
 We have broken cards into a hierarchy which helps facilitate workflow:
 
@@ -25,7 +24,9 @@ We have broken cards into a hierarchy which helps facilitate workflow:
 
 Our basic consensus for card ordering was this:
 
-We break the workflow into distinct `tasks` that the cleaner may want to use the app to accomplish. At any point the user can break out of the current task and switch into a new one, but we orient the UI to suggest they follow our ordering and finish each task before moving on to the next.
+We break the workflow into distinct `tasks` that the cleaner may want to use the app to accomplish. At any point the
+user can break out of the current task and switch into a new one, but we orient the UI to suggest they follow our
+ordering and finish each task before moving on to the next.
 
 Each `task` is broken down into `units`. The units are ordered within a task as such:
 
@@ -36,14 +37,14 @@ Each `task` is broken down into `units`. The units are ordered within a task as 
 
 Within each `unit` are one or more `exercises` which break up the `unit` into manageably sized chunks of work.
 
-The ordering within this structure will be simple to begin. If we have enough time, we can devote time to making more complex orders based on:
+The ordering within this structure will be simple to begin. If we have enough time, we can devote time to making more
+complex orders based on:
 
 - Better Workflow
 - Qualitative Productivity
 - Quantitative Productivity
 
-Here is a collection of sketches that we took to get to that point.
-![Sketches](./sketches.jpg)
+Here is a collection of sketches that we took to get to that point. ![Sketches](./sketches.jpg)
 
 ## Get More from Each Card
 
@@ -51,10 +52,10 @@ Here is a collection of sketches that we took to get to that point.
 
 ## Show Progress
 
-Below are the results of brainstorming for ways of showing progress to the user. These eventually led to the UI sketches shown above.
+Below are the results of brainstorming for ways of showing progress to the user. These eventually led to the UI sketches
+shown above.
 
-![progress1](./progress1.jpg)
-![progress2](./progress2.jpg)
+![progress1](./progress1.jpg) ![progress2](./progress2.jpg)
 
 ## When to Stop
 

--- a/docs/meeting_notes/cleaner_workflow_5-30.md
+++ b/docs/meeting_notes/cleaner_workflow_5-30.md
@@ -10,8 +10,7 @@ Questions:
 
 The following cards are discrete actions we came up with. Included are some crazy-8s sketches we did.
 
-![Card Types 1](./5-30_images/cards1.jpg)
-![Card Types 2](./5-30_images/cards2.jpg)
+![Card Types 1](./5-30_images/cards1.jpg) ![Card Types 2](./5-30_images/cards2.jpg)
 
 We have broken cards into a hierarchy which helps facilitate workflow:
 
@@ -25,7 +24,9 @@ We have broken cards into a hierarchy which helps facilitate workflow:
 
 Our basic consensus for card ordering was this:
 
-We break the workflow into distinct `tasks` that the cleaner may want to use the app to accomplish. At any point the user can break out of the current task and switch into a new one, but we orient the UI to suggest they follow our ordering and finish each task before moving on to the next.
+We break the workflow into distinct `tasks` that the cleaner may want to use the app to accomplish. At any point the
+user can break out of the current task and switch into a new one, but we orient the UI to suggest they follow our
+ordering and finish each task before moving on to the next.
 
 Each `task` is broken down into `units`. The units are ordered within a task as such:
 
@@ -36,14 +37,14 @@ Each `task` is broken down into `units`. The units are ordered within a task as 
 
 Within each `unit` are one or more `exercises` which break up the `unit` into manageably sized chunks of work.
 
-The ordering within this structure will be simple to begin. If we have enough time, we can devote time to making more complex orders based on:
+The ordering within this structure will be simple to begin. If we have enough time, we can devote time to making more
+complex orders based on:
 
 - Better Workflow
 - Qualitative Productivity
 - Quantitative Productivity
 
-Here is a collection of sketches that we took to get to that point.
-![Sketches](./5-30_images/sketches.jpg)
+Here is a collection of sketches that we took to get to that point. ![Sketches](./5-30_images/sketches.jpg)
 
 ## Get More from Each Card
 
@@ -51,10 +52,10 @@ Here is a collection of sketches that we took to get to that point.
 
 ## Show Progress
 
-Below are the results of brainstorming for ways of showing progress to the user. These eventually led to the UI sketches shown above.
+Below are the results of brainstorming for ways of showing progress to the user. These eventually led to the UI sketches
+shown above.
 
-![progress1](./5-30_images/progress1.jpg)
-![progress2](./5-30_images/progress2.jpg)
+![progress1](./5-30_images/progress1.jpg) ![progress2](./5-30_images/progress2.jpg)
 
 ## When to Stop
 

--- a/docs/ts_style_guide.md
+++ b/docs/ts_style_guide.md
@@ -144,7 +144,8 @@ interface Foo {}
 
 - Use `PascalCase` for names
 
-> Reason: Convention followed by the TypeScript team. Namespaces are effectively just a class with static members. Class names are `PascalCase` => Namespace names are `PascalCase`
+> Reason: Convention followed by the TypeScript team. Namespaces are effectively just a class with static members. Class
+> names are `PascalCase` => Namespace names are `PascalCase`
 
 **Bad**
 
@@ -178,7 +179,8 @@ enum Color {}
 
 - Use `PascalCase` for enum member
 
-> Reason: Convention followed by TypeScript team i.e. the language creators e.g `SyntaxKind.StringLiteral`. Also helps with translation (code generation) of other languages into TypeScript.
+> Reason: Convention followed by TypeScript team i.e. the language creators e.g `SyntaxKind.StringLiteral`. Also helps
+> with translation (code generation) of other languages into TypeScript.
 
 **Bad**
 
@@ -200,7 +202,8 @@ enum Color {
 
 - Prefer not to use either for explicit unavailability
 
-> Reason: these values are commonly used to keep a consistent structure between values. In TypeScript you use _types_ to denote the structure
+> Reason: these values are commonly used to keep a consistent structure between values. In TypeScript you use _types_ to
+> denote the structure
 
 **Bad**
 
@@ -258,7 +261,8 @@ if (error === null)
 if (error)
 ```
 
-- Use `== undefined` / `!= undefined` (not `===` / `!==`) to check for `null` / `undefined` on primitives as it works for both `null`/`undefined` but not other falsy values (like `''`,`0`,`false`) e.g.
+- Use `== undefined` / `!= undefined` (not `===` / `!==`) to check for `null` / `undefined` on primitives as it works
+  for both `null`/`undefined` but not other falsy values (like `''`,`0`,`false`) e.g.
 
 **Bad**
 
@@ -288,13 +292,19 @@ Use [Prettier](https://prettier.io/) to format TypeScript code as described in t
 
 - Use semicolons.
 
-> Reasons: Explicit semicolons helps language formatting tools give consistent results. Missing ASI (automatic semicolon insertion) can trip new devs e.g. `foo() \n (function(){})` will be a single statement (not two). TC39 [warning on this as well](https://github.com/tc39/ecma262/pull/1062). Example teams: [airbnb](https://github.com/airbnb/javascript), [idiomatic](https://github.com/rwaldron/idiomatic.js), [google/angular](https://github.com/angular/angular/), [facebook/react](https://github.com/facebook/react), [Microsoft/TypeScript](https://github.com/Microsoft/TypeScript/).
+> Reasons: Explicit semicolons helps language formatting tools give consistent results. Missing ASI (automatic semicolon
+> insertion) can trip new devs e.g. `foo() \n (function(){})` will be a single statement (not two). TC39
+> [warning on this as well](https://github.com/tc39/ecma262/pull/1062). Example teams:
+> [airbnb](https://github.com/airbnb/javascript), [idiomatic](https://github.com/rwaldron/idiomatic.js),
+> [google/angular](https://github.com/angular/angular/), [facebook/react](https://github.com/facebook/react),
+> [Microsoft/TypeScript](https://github.com/Microsoft/TypeScript/).
 
 ## Array
 
 - Annotate arrays as `foos:Foo[]` instead of `foos:Array<Foo>`.
 
-> Reasons: Its easier to read. Its used by the TypeScript team. Makes easier to know something is an array as the mind is trained to detect `[]`.
+> Reasons: Its easier to read. Its used by the TypeScript team. Makes easier to know something is an array as the mind
+> is trained to detect `[]`.
 
 ## Filename
 

--- a/package.json
+++ b/package.json
@@ -71,6 +71,17 @@
       "no-undef": "off"
     }
   },
+  "prettier": {
+    "overrides": [
+      {
+        "files": "**/*.md",
+        "options": {
+          "proseWrap": "always",
+          "printWidth": 120
+        }
+      }
+    ]
+  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/user_guide/docs/dataEntry.md
+++ b/user_guide/docs/dataEntry.md
@@ -18,4 +18,5 @@ There is only one note per entry, even if the entry has multiple senses, glosses
 
 ### Recording
 
-You can add multiple recordings to an entry (e.g., a male voice and a female voice), but as with the [Note](#note), they are associated with the entry and not its senses.
+You can add multiple recordings to an entry (e.g., a male voice and a female voice), but as with the [Note](#note), they
+are associated with the entry and not its senses.

--- a/user_guide/docs/project.md
+++ b/user_guide/docs/project.md
@@ -10,7 +10,9 @@ A project is for a single vernacular language.
 
 ## Manage a Project
 
-When a project has been created or selected, it becomes the active project, and the project name appears in the middle of the App Bar at the top of The Combine. Clicking on the project name brings up Project Settings for managing the project. The following settings are available for project users with sufficient permissions.
+When a project has been created or selected, it becomes the active project, and the project name appears in the middle
+of the App Bar at the top of The Combine. Clicking on the project name brings up Project Settings for managing the
+project. The following settings are available for project users with sufficient permissions.
 
 ### Project Name
 
@@ -18,19 +20,25 @@ When a project has been created or selected, it becomes the active project, and 
 
 The vernacular language specified at project creation is fixed.
 
-There may be multiple analysis languages associated with the project, but only the top one on the list here is active and associated with new data entries.
+There may be multiple analysis languages associated with the project, but only the top one on the list here is active
+and associated with new data entries.
 
 ### Import and Export
 
 Currently, only one LIFT file can be imported per project.
 
-After clicking the Export button, you can navigate to other parts of the website. A notification will appear in the App Bar when the export is ready for download. A project that has reached hundreds of MB is size may take tens of minutes to export.
+After clicking the Export button, you can navigate to other parts of the website. A notification will appear in the App
+Bar when the export is ready for download. A project that has reached hundreds of MB is size may take tens of minutes to
+export.
 
 ### Autocomplete
 
-The default setting is On: When a user is entering the [vernacular](dataEntry.md#vernacular) of a new entry in Data Entry, this setting gives suggestions of similar existing entries, allowing the user to select an existing entry and add a new sense to that entry, rather than creating a (mostly) duplicate to something previously entered.
+The default setting is On: When a user is entering the [vernacular](dataEntry.md#vernacular) of a new entry in Data
+Entry, this setting gives suggestions of similar existing entries, allowing the user to select an existing entry and add
+a new sense to that entry, rather than creating a (mostly) duplicate to something previously entered.
 
-(This does not effect the [gloss](dataEntry.md#gloss) spelling suggestions, which are based on a dictionary independent of existing project data.)
+(This does not effect the [gloss](dataEntry.md#gloss) spelling suggestions, which are based on a dictionary independent
+of existing project data.)
 
 ### Project Users
 


### PR DESCRIPTION
- Wrap Markdown lines at 120 characters for consistency. This also makes it possible for developers to view two Markdown pages side by side on the same monitor
- Set Git to require Unix Line Feeds for Markdown and YAML on all platforms to avoid Windows developers having Git conflict with Prettier

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/874)
<!-- Reviewable:end -->
