### PR TITLE
Restrict large file uploads to only the Lift Upload endpoint

### DIFF
--- a/Backend/Controllers/LiftController.cs
+++ b/Backend/Controllers/LiftController.cs
@@ -41,6 +41,10 @@ namespace BackendFramework.Controllers
         /// <remarks> POST: v1/projects/{projectId}/words/upload </remarks>
         /// <returns> Number of words added </returns>
         [HttpPost("upload")]
+        // Allow clients to POST large import files to the server (default limit is 28MB).
+        // Note: The HTTP Proxy in front, such as NGNIX, also needs to be configured
+        //     to allow large requests through as well.
+        [RequestSizeLimit(250_000_000)]  // 250MB.
         public async Task<IActionResult> UploadLiftFile(string projectId, [FromForm] FileUpload fileUpload)
         {
             if (!_permissionService.HasProjectPermission(HttpContext, Permission.ImportExport))

--- a/Backend/Program.cs
+++ b/Backend/Program.cs
@@ -12,14 +12,6 @@ namespace BackendFramework
 
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .ConfigureKestrel((context, options) =>
-                {
-                    // Allow clients to POST large files to servers, such as project imports.
-                    // Note: The HTTP Proxy in front, such as NGNIX, also needs to be configured
-                    //     to allow large requests through as well.
-                    // 250MB.
-                    options.Limits.MaxRequestBodySize = 250_000_000;
-                })
                 .UseStartup<Startup>();
     }
 }

--- a/user_guide/docs/project.md
+++ b/user_guide/docs/project.md
@@ -27,7 +27,7 @@ and associated with new data entries.
 
 !!! note
 
-    Currently, the maximum Lift files supported for import is 250MB.
+    Currently, the maximum size of Lift files supported for import is 250MB.
 
 !!! note
 

--- a/user_guide/docs/project.md
+++ b/user_guide/docs/project.md
@@ -25,7 +25,13 @@ and associated with new data entries.
 
 ### Import and Export
 
-Currently, only one LIFT file can be imported per project.
+!!! note
+
+    Currently, the maximum Lift files supported for import is 250MB.
+
+!!! note
+
+    Currently, only one LIFT file can be imported per project.
 
 After clicking the Export button, you can navigate to other parts of the website. A notification will appear in the App
 Bar when the export is ready for download. A project that has reached hundreds of MB is size may take tens of minutes to

--- a/user_guide/mkdocs.yml
+++ b/user_guide/mkdocs.yml
@@ -33,3 +33,5 @@ nav:
   - Data Entry: dataEntry.md
   - Data Cleanup: goals.md
   - Admin: admin.md
+markdown_extensions:
+  - admonition


### PR DESCRIPTION
- Restrict large file uploads to only the Lift Upload endpoint 
  - Rather than open up the entire backend to large file uploads (for example avatars and audio), only selectively extend the max request size for Lift Import
- Also document this limitation in the user guide.
- Add admonition MkDocs extension
- Related to #694 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/875)
<!-- Reviewable:end -->
