### PR TITLE
Make ProjectService.CanImportLift async

### DIFF
--- a/Backend.Tests/Mocks/ProjectServiceMock.cs
+++ b/Backend.Tests/Mocks/ProjectServiceMock.cs
@@ -106,9 +106,9 @@ namespace Backend.Tests.Mocks
             return Task.FromResult(false);
         }
 
-        public bool CanImportLift(string projectId)
+        public Task<bool> CanImportLift(string projectId)
         {
-            return true;
+            return Task.FromResult(true);
         }
     }
 }

--- a/Backend/Controllers/LiftController.cs
+++ b/Backend/Controllers/LiftController.cs
@@ -55,7 +55,7 @@ namespace BackendFramework.Controllers
             }
 
             // Ensure Lift file has not already been imported.
-            if (!_projectService.CanImportLift(projectId))
+            if (!await _projectService.CanImportLift(projectId))
             {
                 return new BadRequestObjectResult("A Lift file has already been uploaded");
             }

--- a/Backend/Controllers/ProjectController.cs
+++ b/Backend/Controllers/ProjectController.cs
@@ -282,13 +282,9 @@ namespace BackendFramework.Controllers
             return new StatusCodeResult(304);
         }
 
-        // Check if lift import has already happened for this project
+        /// <summary> Check if lift import has already happened for this project </summary>
         [HttpGet("{projectId}/liftcheck")]
-        // Temporarily disable warning about missing await in this method.
-        // It's needed for the return type to be correct, but nothing inside the function is awaiting yet.
-#pragma warning disable 1998
         public async Task<IActionResult> CanUploadLift(string projectId)
-#pragma warning restore 1998
         {
             if (!_permissionService.HasProjectPermission(HttpContext, Permission.ImportExport))
             {
@@ -301,7 +297,7 @@ namespace BackendFramework.Controllers
                 return new UnsupportedMediaTypeResult();
             }
 
-            return new OkObjectResult(_projectService.CanImportLift(projectId));
+            return new OkObjectResult(await _projectService.CanImportLift(projectId));
         }
 
         /// <summary> Generates invite link and sends email containing link </summary>

--- a/Backend/Interfaces/IProjectService.cs
+++ b/Backend/Interfaces/IProjectService.cs
@@ -17,6 +17,6 @@ namespace BackendFramework.Interfaces
         Task<bool> EmailLink(string emailAddress, string emailMessage, string link, string domain, Project project);
         Task<bool> RemoveTokenAndCreateUserRole(Project project, User user, EmailInvite emailInvite);
         Task<bool> DuplicateCheck(string projectName);
-        bool CanImportLift(string projectId);
+        Task<bool> CanImportLift(string projectId);
     }
 }

--- a/Backend/Services/ProjectApiServices.cs
+++ b/Backend/Services/ProjectApiServices.cs
@@ -184,9 +184,9 @@ namespace BackendFramework.Services
             return false;
         }
 
-        public bool CanImportLift(string projectId)
+        public async Task<bool> CanImportLift(string projectId)
         {
-            var project = GetProject(projectId).Result;
+            var project = await GetProject(projectId);
             return !project.LiftImported;
         }
     }


### PR DESCRIPTION
- Remove compiler warning suppression and instead properly use async/await in `CanUploadLift` methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/876)
<!-- Reviewable:end -->
