### PR TITLE
Use new canonical dotnet Docker image name

### DIFF
--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -1,5 +1,5 @@
 ﻿# Docker multi-stage build.
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:3.1 AS builder
 WORKDIR /app
 
 # Copy csproj and restore (fetch dependencies) as distinct layers.
@@ -11,7 +11,7 @@ COPY . ./
 RUN dotnet publish -c Release -o build
 
 # Build runtime image.
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
+FROM mcr.microsoft.com/dotnet/aspnet:3.1
 
 ENV ASPNETCORE_URLS=http://+:5000
 ENV COMBINE_IS_IN_CONTAINER=1


### PR DESCRIPTION
Per this announcement, point to the new names for canonical `dotnet` Docker images: https://github.com/dotnet/dotnet-docker/issues/2375

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/884)
<!-- Reviewable:end -->
