### PR TITLE
Update Python dependencies

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,52 +4,144 @@
 #
 #    pip-compile dev-requirements.in
 #
-appdirs==1.4.4            # via black, virtualenv
-atomicwrites==1.4.0       # via pytest
-attrs==20.3.0             # via pytest
-black==20.8b1             # via -r dev-requirements.in
-click==7.1.2              # via black, mkdocs, nltk
-colorama==0.4.4           # via pytest, tox
-coverage==5.3             # via pytest-cov
-distlib==0.3.1            # via virtualenv
-filelock==3.0.12          # via tox, virtualenv
-flake8-polyfill==1.0.2    # via pep8-naming
-flake8==3.8.4             # via -r dev-requirements.in, flake8-polyfill
-future==0.18.2            # via lunr
-iniconfig==1.1.1          # via pytest
-isort==5.6.4              # via -r dev-requirements.in
-jinja2==2.11.2            # via -r dev-requirements.in, mkdocs
-joblib==0.17.0            # via nltk
-livereload==2.6.3         # via mkdocs
-lunr[languages]==0.5.8    # via mkdocs
-markdown==3.3.3           # via mkdocs, mkdocs-material, pymdown-extensions
-markupsafe==1.1.1         # via jinja2
-mccabe==0.6.1             # via flake8
-mkdocs-material-extensions==1.0.1  # via mkdocs-material
-mkdocs-material==6.1.7    # via -r dev-requirements.in, mkdocs-material-extensions
-mkdocs==1.1.2             # via mkdocs-material
-mypy-extensions==0.4.3    # via black, mypy
-mypy==0.790               # via -r dev-requirements.in
-nltk==3.5                 # via lunr
-packaging==20.4           # via pytest, tox
-pathspec==0.8.1           # via black
-pep8-naming==0.11.1       # via -r dev-requirements.in
-pluggy==0.13.1            # via pytest, tox
-py==1.9.0                 # via pytest, tox
-pycodestyle==2.6.0        # via flake8
-pyflakes==2.2.0           # via flake8
-pygments==2.7.3           # via mkdocs-material
-pymdown-extensions==8.0.1  # via mkdocs-material
-pyparsing==2.4.7          # via packaging
-pytest-cov==2.10.1        # via -r dev-requirements.in
-pytest==6.1.2             # via -r dev-requirements.in, pytest-cov
-pyyaml==5.3.1             # via mkdocs
-regex==2020.11.13         # via black, nltk
-six==1.15.0               # via livereload, lunr, packaging, tox, virtualenv
-toml==0.10.2              # via black, pytest, tox
-tornado==6.1              # via livereload, mkdocs
-tox==3.20.1               # via -r dev-requirements.in
-tqdm==4.54.1              # via nltk
-typed-ast==1.4.1          # via black, mypy
-typing-extensions==3.7.4.3  # via black, mypy
-virtualenv==20.1.0        # via tox
+appdirs==1.4.4
+    # via
+    #   black
+    #   virtualenv
+atomicwrites==1.4.0
+    # via pytest
+attrs==20.3.0
+    # via pytest
+black==20.8b1
+    # via -r dev-requirements.in
+click==7.1.2
+    # via
+    #   black
+    #   mkdocs
+    #   nltk
+colorama==0.4.4
+    # via
+    #   pytest
+    #   tox
+coverage==5.3.1
+    # via pytest-cov
+distlib==0.3.1
+    # via virtualenv
+filelock==3.0.12
+    # via
+    #   tox
+    #   virtualenv
+flake8-polyfill==1.0.2
+    # via pep8-naming
+flake8==3.8.4
+    # via
+    #   -r dev-requirements.in
+    #   flake8-polyfill
+future==0.18.2
+    # via lunr
+iniconfig==1.1.1
+    # via pytest
+isort==5.7.0
+    # via -r dev-requirements.in
+jinja2==2.11.2
+    # via
+    #   -r dev-requirements.in
+    #   mkdocs
+joblib==1.0.0
+    # via nltk
+livereload==2.6.3
+    # via mkdocs
+lunr[languages]==0.5.8
+    # via mkdocs
+markdown==3.3.3
+    # via
+    #   mkdocs
+    #   mkdocs-material
+    #   pymdown-extensions
+markupsafe==1.1.1
+    # via jinja2
+mccabe==0.6.1
+    # via flake8
+mkdocs-material-extensions==1.0.1
+    # via mkdocs-material
+mkdocs-material==6.2.3
+    # via
+    #   -r dev-requirements.in
+    #   mkdocs-material-extensions
+mkdocs==1.1.2
+    # via mkdocs-material
+mypy-extensions==0.4.3
+    # via
+    #   black
+    #   mypy
+mypy==0.790
+    # via -r dev-requirements.in
+nltk==3.5
+    # via lunr
+packaging==20.8
+    # via
+    #   pytest
+    #   tox
+pathspec==0.8.1
+    # via black
+pep8-naming==0.11.1
+    # via -r dev-requirements.in
+pluggy==0.13.1
+    # via
+    #   pytest
+    #   tox
+py==1.10.0
+    # via
+    #   pytest
+    #   tox
+pycodestyle==2.6.0
+    # via flake8
+pyflakes==2.2.0
+    # via flake8
+pygments==2.7.3
+    # via mkdocs-material
+pymdown-extensions==8.1
+    # via mkdocs-material
+pyparsing==2.4.7
+    # via packaging
+pytest-cov==2.10.1
+    # via -r dev-requirements.in
+pytest==6.2.1
+    # via
+    #   -r dev-requirements.in
+    #   pytest-cov
+pyyaml==5.3.1
+    # via mkdocs
+regex==2020.11.13
+    # via
+    #   black
+    #   nltk
+six==1.15.0
+    # via
+    #   livereload
+    #   lunr
+    #   tox
+    #   virtualenv
+toml==0.10.2
+    # via
+    #   black
+    #   pytest
+    #   tox
+tornado==6.1
+    # via
+    #   livereload
+    #   mkdocs
+tox==3.20.1
+    # via -r dev-requirements.in
+tqdm==4.55.0
+    # via nltk
+typed-ast==1.4.2
+    # via
+    #   black
+    #   mypy
+typing-extensions==3.7.4.3
+    # via
+    #   black
+    #   mypy
+virtualenv==20.2.2
+    # via tox


### PR DESCRIPTION
Note that `pip-tools>=5.5.0` should be used to upgrade Python dependencies going forward as they changed the formatting of the output `*-requirements.txt` file. The diff noise lower if `pip-tools>=5.5.0` is used going forward.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/891)
<!-- Reviewable:end -->
