### PR TITLE
Properly use async/await in all areas it can be used in backend

### DIFF
--- a/Backend.Tests/Mocks/PermissionServiceMock.cs
+++ b/Backend.Tests/Mocks/PermissionServiceMock.cs
@@ -32,9 +32,9 @@ namespace Backend.Tests.Mocks
             return Task.FromResult(request is null || request.Request.Headers["Authorization"] != UnauthorizedHeader);
         }
 
-        public bool IsViolationEdit(HttpContext request, string userEditId, string projectId)
+        public Task<bool> IsViolationEdit(HttpContext request, string userEditId, string projectId)
         {
-            return false;
+            return Task.FromResult(false);
         }
 
         public string GetUserId(HttpContext request)

--- a/Backend/Controllers/UserController.cs
+++ b/Backend/Controllers/UserController.cs
@@ -39,7 +39,7 @@ namespace BackendFramework.Controllers
         {
             // find user attached to email or username
             var emailOrUsername = data.EmailOrUsername.ToLowerInvariant();
-            var user = _userService.GetAllUsers().Result.SingleOrDefault(user =>
+            var user = (await _userService.GetAllUsers()).SingleOrDefault(user =>
                 user.Email.ToLowerInvariant().Equals(emailOrUsername) ||
                 user.Username.ToLowerInvariant().Equals(emailOrUsername));
 

--- a/Backend/Controllers/UserEditController.cs
+++ b/Backend/Controllers/UserEditController.cs
@@ -148,7 +148,7 @@ namespace BackendFramework.Controllers
             }
 
             // Check to see if user is changing the correct user edit
-            if (_permissionService.IsViolationEdit(HttpContext, userEditId, projectId))
+            if (await _permissionService.IsViolationEdit(HttpContext, userEditId, projectId))
             {
                 return new BadRequestObjectResult("You can not edit another users UserEdit");
             }
@@ -193,7 +193,7 @@ namespace BackendFramework.Controllers
             }
 
             // Check to see if user is changing the correct user edit
-            if (_permissionService.IsViolationEdit(HttpContext, userEditId, projectId))
+            if (await _permissionService.IsViolationEdit(HttpContext, userEditId, projectId))
             {
                 return new BadRequestObjectResult("You can not edit another users UserEdit");
             }

--- a/Backend/Interfaces/IPermissionService.cs
+++ b/Backend/Interfaces/IPermissionService.cs
@@ -8,7 +8,7 @@ namespace BackendFramework.Interfaces
     {
         Task<bool> HasProjectPermission(HttpContext request, Permission permission);
         bool IsUserIdAuthorized(HttpContext request, string userId);
-        bool IsViolationEdit(HttpContext request, string userEditId, string projectId);
+        Task<bool> IsViolationEdit(HttpContext request, string userEditId, string projectId);
         string GetUserId(HttpContext request);
     }
 }

--- a/Backend/Services/LiftApiServices.cs
+++ b/Backend/Services/LiftApiServices.cs
@@ -215,8 +215,8 @@ namespace BackendFramework.Services
             liftWriter.WriteHeader(header);
 
             // Write out every word with all of its information
-            var allWords = wordRepo.GetAllWords(projectId).Result;
-            var frontier = wordRepo.GetFrontier(projectId).Result;
+            var allWords = await wordRepo.GetAllWords(projectId);
+            var frontier = await wordRepo.GetFrontier(projectId);
             var activeWords = frontier.Where(
                 x => x.Senses.Any(s => s.Accessibility == State.Active)).ToList();
 
@@ -303,7 +303,7 @@ namespace BackendFramework.Services
                 string sdList;
                 using (var reader = new StreamReader(resource, Encoding.UTF8))
                 {
-                    sdList = reader.ReadToEndAsync().Result;
+                    sdList = await reader.ReadToEndAsync();
                 }
 
                 var sdLines = sdList.Split(Environment.NewLine);

--- a/Backend/Services/PermissionService.cs
+++ b/Backend/Services/PermissionService.cs
@@ -92,10 +92,10 @@ namespace BackendFramework.Services
             return false;
         }
 
-        public bool IsViolationEdit(HttpContext request, string userEditId, string projectId)
+        public async Task<bool> IsViolationEdit(HttpContext request, string userEditId, string projectId)
         {
             var userId = GetUserId(request);
-            var userObj = _userService.GetUser(userId).Result;
+            var userObj = await _userService.GetUser(userId);
             return userObj.WorkedProjects[projectId] != userEditId;
         }
 

--- a/Backend/Services/UserApiServices.cs
+++ b/Backend/Services/UserApiServices.cs
@@ -136,7 +136,7 @@ namespace BackendFramework.Services
             foreach (var (projectRoleKey, projectRoleValue) in user.ProjectRoles)
             {
                 // Convert each userRoleId to its respective role and add to the mapping
-                var permissions = _userRole.GetUserRole(projectRoleKey, projectRoleValue).Result.Permissions;
+                var permissions = (await _userRole.GetUserRole(projectRoleKey, projectRoleValue)).Permissions;
                 var validEntry = new ProjectPermissions(projectRoleKey, permissions);
                 projectPermissionMap.Add(validEntry);
             }

--- a/Backend/Services/UserEditApiServices.cs
+++ b/Backend/Services/UserEditApiServices.cs
@@ -27,11 +27,11 @@ namespace BackendFramework.Services
             newUserEdit.Edits.Add(edit);
 
             // Replace the old UserEdit object with the new one that contains the new list entry
-            var replaceSucceeded = _repo.Replace(projectId, userEditId, newUserEdit).Result;
+            var replaceSucceeded = await _repo.Replace(projectId, userEditId, newUserEdit);
             var indexOfNewestEdit = -1;
             if (replaceSucceeded)
             {
-                var newestEdit = _repo.GetUserEdit(projectId, userEditId).Result;
+                var newestEdit = await _repo.GetUserEdit(projectId, userEditId);
                 indexOfNewestEdit = newestEdit.Edits.Count - 1;
             }
 
@@ -45,7 +45,7 @@ namespace BackendFramework.Services
             var addUserEdit = await _repo.GetUserEdit(projectId, userEditId);
             var newUserEdit = addUserEdit.Clone();
             newUserEdit.Edits[goalIndex].StepData.Add(userEdit);
-            var updateResult = _repo.Replace(projectId, userEditId, newUserEdit).Result;
+            var updateResult = await _repo.Replace(projectId, userEditId, newUserEdit);
             return updateResult;
         }
     }

--- a/Backend/Services/WordApiServices.cs
+++ b/Backend/Services/WordApiServices.cs
@@ -21,12 +21,12 @@ namespace BackendFramework.Services
         /// <returns> A bool: success of operation </returns>
         public async Task<bool> Delete(string projectId, string wordId)
         {
-            var wordIsInFrontier = _repo.DeleteFrontier(projectId, wordId).Result;
+            var wordIsInFrontier = await _repo.DeleteFrontier(projectId, wordId);
 
             // We only want to add the deleted word if the word started in the frontier
             if (wordIsInFrontier)
             {
-                var wordToDelete = _repo.GetWord(projectId, wordId).Result;
+                var wordToDelete = await _repo.GetWord(projectId, wordId);
                 wordToDelete.Id = "";
                 wordToDelete.History = new List<string>() { wordId };
                 wordToDelete.Accessibility = State.Deleted;
@@ -46,9 +46,8 @@ namespace BackendFramework.Services
         /// <returns> New word </returns>
         public async Task<Word> Delete(string projectId, string wordId, string fileName)
         {
-            var wordWithAudioToDelete = _repo.GetWord(projectId, wordId).Result;
-
-            var wordIsInFrontier = _repo.DeleteFrontier(projectId, wordId).Result;
+            var wordWithAudioToDelete = await _repo.GetWord(projectId, wordId);
+            var wordIsInFrontier = await _repo.DeleteFrontier(projectId, wordId);
 
             // We only want to update words that are in the frontier
             if (wordIsInFrontier)
@@ -110,7 +109,7 @@ namespace BackendFramework.Services
         /// <returns> A bool: success of operation </returns>
         public async Task<bool> Update(string projectId, string wordId, Word word)
         {
-            var wordIsInFrontier = _repo.DeleteFrontier(projectId, wordId).Result;
+            var wordIsInFrontier = await _repo.DeleteFrontier(projectId, wordId);
 
             // We only want to update words that are in the frontier
             if (wordIsInFrontier)


### PR DESCRIPTION
Fixes part of #882.

Use `async` / `await` rather than `.Result` in all API methods to increase performance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/893)
<!-- Reviewable:end -->
