### PR TITLE
Backend Refactor

### DIFF
--- a/Backend.Tests/Backend.Tests.csproj
+++ b/Backend.Tests/Backend.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />

--- a/Backend.Tests/Controllers/AudioControllerTests.cs
+++ b/Backend.Tests/Controllers/AudioControllerTests.cs
@@ -54,11 +54,12 @@ namespace Backend.Tests.Controllers
         [Test]
         public void TestAudioImport()
         {
-            var filePath = Path.Combine(Util.AssetsDir, "sound.mp3");
+            const string soundFileName = "sound.mp3";
+            var filePath = Path.Combine(Util.AssetsDir, soundFileName);
 
             // Open the file to read to controller.
-            using var fstream = File.OpenRead(filePath);
-            var formFile = new FormFile(fstream, 0, fstream.Length, "name", "sound.mp3");
+            using var stream = File.OpenRead(filePath);
+            var formFile = new FormFile(stream, 0, stream.Length, "name", soundFileName);
             var fileUpload = new FileUpload { File = formFile, Name = "FileName" };
 
             var word = _wordRepo.Create(RandomWord()).Result;
@@ -82,7 +83,7 @@ namespace Backend.Tests.Controllers
             origWord.Audio.Add("a.wav");
 
             // Test delete function
-            var action = _audioController.Delete(_projId, origWord.Id, "a.wav").Result;
+            _ = _audioController.Delete(_projId, origWord.Id, "a.wav").Result;
 
             // Original word persists
             Assert.IsTrue(_wordRepo.GetAllWords(_projId).Result.Count == 2);

--- a/Backend.Tests/Controllers/AvatarControllerTests.cs
+++ b/Backend.Tests/Controllers/AvatarControllerTests.cs
@@ -56,9 +56,9 @@ namespace Backend.Tests.Controllers
         public void TestAvatarImport()
         {
             var filePath = Path.Combine(Util.AssetsDir, "combine.png");
-            using var fstream = File.OpenRead(filePath);
+            using var stream = File.OpenRead(filePath);
 
-            var formFile = new FormFile(fstream, 0, fstream.Length, "dave", "combine.png");
+            var formFile = new FormFile(stream, 0, stream.Length, "dave", "combine.png");
             var fileUpload = new FileUpload { File = formFile, Name = "FileName" };
 
             _ = _avatarController.UploadAvatar(_jwtAuthenticatedUser.Id, fileUpload).Result;

--- a/Backend.Tests/Controllers/LiftControllerTests.cs
+++ b/Backend.Tests/Controllers/LiftControllerTests.cs
@@ -353,11 +353,6 @@ namespace Backend.Tests.Controllers
 
             // Init the project the .zip info is added to.
             var proj2 = _projServ.Create(RandomProject()).Result;
-            if (proj2 is null)
-            {
-                Assert.Fail();
-                return;
-            }
 
             // Upload the exported words again.
             // Generate api parameter with filestream.

--- a/Backend.Tests/Controllers/LiftControllerTests.cs
+++ b/Backend.Tests/Controllers/LiftControllerTests.cs
@@ -223,7 +223,9 @@ namespace Backend.Tests.Controllers
 
             var wordToUpdate = _wordRepo.Create(word).Result;
             wordToDelete = _wordRepo.Create(wordToDelete).Result;
-            var untouchedWord = _wordRepo.Create(secondWord).Result;
+
+            // Create untouched word.
+            _ = _wordRepo.Create(secondWord).Result;
 
             word.Id = "";
             word.Vernacular = "updated";
@@ -248,7 +250,8 @@ namespace Backend.Tests.Controllers
             var exportPath = Path.Combine(extractedExportDir,
                 Path.Combine("Lift", "NewLiftFile.lift"));
             var text = await File.ReadAllTextAsync(exportPath, Encoding.UTF8);
-            //TODO: Add SIL or other XML assertion library and verify with xpath that the correct entries are kept vs deleted
+            // TODO: Add SIL or other XML assertion library and verify with xpath that the correct entries are
+            //      kept vs deleted
             // Make sure we exported 2 live and one dead entry
             Assert.That(Regex.Matches(text, "<entry").Count, Is.EqualTo(3));
             // There is only one deleted word

--- a/Backend.Tests/Controllers/LiftControllerTests.cs
+++ b/Backend.Tests/Controllers/LiftControllerTests.cs
@@ -292,9 +292,9 @@ namespace Backend.Tests.Controllers
 
             // Upload the zip file.
             // Generate api parameter with filestream.
-            using (var fstream = File.OpenRead(pathToStartZip))
+            using (var stream = File.OpenRead(pathToStartZip))
             {
-                var fileUpload = InitFile(fstream, roundTripObj.Filename);
+                var fileUpload = InitFile(stream, roundTripObj.Filename);
 
                 // Make api call.
                 var result = _liftController.UploadLiftFile(proj1.Id, fileUpload).Result;

--- a/Backend.Tests/Controllers/ProjectControllerTests.cs
+++ b/Backend.Tests/Controllers/ProjectControllerTests.cs
@@ -110,7 +110,7 @@ namespace Backend.Tests.Controllers
             _projectService.Create(RandomProject());
 
             var action = _controller.Get(project.Id).Result;
-            Assert.That(action, Is.InstanceOf<ObjectResult>());
+            Assert.IsInstanceOf<ObjectResult>(action);
 
             var foundProjects = ((ObjectResult)action).Value as Project;
             Assert.AreEqual(project, foundProjects);

--- a/Backend.Tests/Controllers/ProjectControllerTests.cs
+++ b/Backend.Tests/Controllers/ProjectControllerTests.cs
@@ -175,8 +175,8 @@ namespace Backend.Tests.Controllers
         public void TestProjectDuplicateCheck()
         {
             var project1 = _projectService.Create(RandomProject()).Result;
-            var project2 = _projectService.Create(RandomProject()).Result;
-            var project3 = _projectService.Create(RandomProject()).Result;
+            _ = _projectService.Create(RandomProject()).Result;
+            _ = _projectService.Create(RandomProject()).Result;
             var modProject = project1.Clone();
             modProject.Name = "Proj";
             _ = _controller.Put(modProject.Id, modProject);

--- a/Backend.Tests/Controllers/UserControllerTests.cs
+++ b/Backend.Tests/Controllers/UserControllerTests.cs
@@ -61,10 +61,17 @@ namespace Backend.Tests.Controllers
             _userService.Create(RandomUser());
 
             var action = _controller.Get(user.Id).Result;
-            Assert.That(action, Is.InstanceOf<ObjectResult>());
+            Assert.IsInstanceOf<ObjectResult>(action);
 
             var foundUser = ((ObjectResult)action).Value as User;
             Assert.AreEqual(user, foundUser);
+        }
+
+        [Test]
+        public void TestGetMissingUser()
+        {
+            var action = _controller.Get("INVALID_USER_ID").Result;
+            Assert.IsInstanceOf<NotFoundObjectResult>(action);
         }
 
         [Test]

--- a/Backend.Tests/Controllers/UserEditControllerTests.cs
+++ b/Backend.Tests/Controllers/UserEditControllerTests.cs
@@ -137,7 +137,7 @@ namespace Backend.Tests.Controllers
             const int modGoalIndex = 0;
             var wrapperObj = new UserEditObjectWrapper(modGoalIndex, stringUserEdit);
 
-            var action = _userEditController.Put(_projId, origUserEdit.Id, wrapperObj);
+            _ = _userEditController.Put(_projId, origUserEdit.Id, wrapperObj);
 
             Assert.That(_userEditRepo.GetAllUserEdits(_projId).Result, Has.Count.EqualTo(count + 1));
             Assert.Contains(stringUserEdit, _userEditRepo.GetUserEdit(

--- a/Backend.Tests/Controllers/UserEditControllerTests.cs
+++ b/Backend.Tests/Controllers/UserEditControllerTests.cs
@@ -140,8 +140,14 @@ namespace Backend.Tests.Controllers
             _ = _userEditController.Put(_projId, origUserEdit.Id, wrapperObj);
 
             Assert.That(_userEditRepo.GetAllUserEdits(_projId).Result, Has.Count.EqualTo(count + 1));
-            Assert.Contains(stringUserEdit, _userEditRepo.GetUserEdit(
-                _projId, origUserEdit.Id).Result.Edits[modGoalIndex].StepData);
+
+            var userEdit = _userEditRepo.GetUserEdit(_projId, origUserEdit.Id).Result;
+            if (userEdit is null)
+            {
+                Assert.Fail();
+                return;
+            }
+            Assert.Contains(stringUserEdit, userEdit.Edits[modGoalIndex].StepData);
         }
 
         [Test]
@@ -168,6 +174,13 @@ namespace Backend.Tests.Controllers
             _ = _userEditController.Delete(_projId).Result;
 
             Assert.That(_userEditRepo.GetAllUserEdits(_projId).Result, Has.Count.EqualTo(0));
+        }
+
+        [Test]
+        public void TestGetMissingUserEdit()
+        {
+            var action = _userEditController.Get(_projId, "INVALID_USER_EDIT_ID").Result;
+            Assert.That(action, Is.InstanceOf<NotFoundObjectResult>());
         }
     }
 }

--- a/Backend.Tests/Controllers/UserEditControllerTests.cs
+++ b/Backend.Tests/Controllers/UserEditControllerTests.cs
@@ -84,7 +84,7 @@ namespace Backend.Tests.Controllers
             _userEditRepo.Create(RandomUserEdit());
 
             var action = _userEditController.Get(_projId, userEdit.Id).Result;
-            Assert.That(action, Is.InstanceOf<ObjectResult>());
+            Assert.IsInstanceOf<ObjectResult>(action);
 
             var foundUserEdit = ((ObjectResult)action).Value as UserEdit;
             Assert.AreEqual(userEdit, foundUserEdit);
@@ -180,7 +180,7 @@ namespace Backend.Tests.Controllers
         public void TestGetMissingUserEdit()
         {
             var action = _userEditController.Get(_projId, "INVALID_USER_EDIT_ID").Result;
-            Assert.That(action, Is.InstanceOf<NotFoundObjectResult>());
+            Assert.IsInstanceOf<NotFoundObjectResult>(action);
         }
     }
 }

--- a/Backend.Tests/Controllers/UserRoleControllerTests.cs
+++ b/Backend.Tests/Controllers/UserRoleControllerTests.cs
@@ -84,8 +84,7 @@ namespace Backend.Tests.Controllers
             _userRoleService.Create(RandomUserRole());
 
             var action = _userRoleController.Get(_projId, userRole.Id).Result;
-
-            Assert.That(action, Is.InstanceOf<ObjectResult>());
+            Assert.IsInstanceOf<ObjectResult>(action);
 
             var foundUserRole = ((ObjectResult)action).Value as UserRole;
             Assert.AreEqual(userRole, foundUserRole);

--- a/Backend.Tests/Controllers/UserRoleControllerTests.cs
+++ b/Backend.Tests/Controllers/UserRoleControllerTests.cs
@@ -91,6 +91,13 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
+        public void TestGetMissingUserRole()
+        {
+            var action = _userRoleController.Get(_projId, "INVALID_USER_ROLE_ID").Result;
+            Assert.IsInstanceOf<NotFoundObjectResult>(action);
+        }
+
+        [Test]
         public void TestGetUserRolesMissingProject()
         {
             var userRole = _userRoleService.Create(RandomUserRole()).Result;

--- a/Backend.Tests/Controllers/WordControllerTests.cs
+++ b/Backend.Tests/Controllers/WordControllerTests.cs
@@ -265,7 +265,7 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public void TestMissingWord()
+        public void TestGetMissingWord()
         {
             var action = _wordController.Get(_projId, "INVALID_WORD_ID").Result;
             Assert.That(action, Is.InstanceOf<NotFoundObjectResult>());

--- a/Backend.Tests/Controllers/WordControllerTests.cs
+++ b/Backend.Tests/Controllers/WordControllerTests.cs
@@ -96,8 +96,7 @@ namespace Backend.Tests.Controllers
             _repo.Create(RandomWord());
 
             var action = _wordController.Get(_projId, word.Id).Result;
-
-            Assert.That(action, Is.InstanceOf<ObjectResult>());
+            Assert.IsInstanceOf<ObjectResult>(action);
 
             var foundWord = ((ObjectResult)action).Value as Word;
             Assert.AreEqual(word, foundWord);
@@ -268,7 +267,7 @@ namespace Backend.Tests.Controllers
         public void TestGetMissingWord()
         {
             var action = _wordController.Get(_projId, "INVALID_WORD_ID").Result;
-            Assert.That(action, Is.InstanceOf<NotFoundObjectResult>());
+            Assert.IsInstanceOf<NotFoundObjectResult>(action);
         }
     }
 }

--- a/Backend.Tests/Controllers/WordControllerTests.cs
+++ b/Backend.Tests/Controllers/WordControllerTests.cs
@@ -64,11 +64,11 @@ namespace Backend.Tests.Controllers
                     new SemanticDomain(), new SemanticDomain(), new SemanticDomain()
                 };
 
-                foreach (var semdom in sense.SemanticDomains)
+                foreach (var semDom in sense.SemanticDomains)
                 {
-                    semdom.Name = Util.RandString();
-                    semdom.Id = Util.RandString();
-                    semdom.Description = Util.RandString();
+                    semDom.Name = Util.RandString();
+                    semDom.Id = Util.RandString();
+                    semDom.Description = Util.RandString();
                 }
             }
 
@@ -158,7 +158,7 @@ namespace Backend.Tests.Controllers
             var origWord = _repo.Create(RandomWord()).Result;
 
             // Test delete function
-            var action = _wordController.Delete(_projId, origWord.Id).Result;
+            _ = _wordController.Delete(_projId, origWord.Id).Result;
 
             // Original word persists
             Assert.Contains(origWord, _repo.GetAllWords(_projId).Result);

--- a/Backend.Tests/Controllers/WordControllerTests.cs
+++ b/Backend.Tests/Controllers/WordControllerTests.cs
@@ -136,7 +136,7 @@ namespace Backend.Tests.Controllers
             var origWord = _repo.Create(RandomWord()).Result;
 
             var modWord = origWord.Clone();
-            modWord.Vernacular = "Yoink";
+            modWord.Vernacular = "NewVernacular";
 
             var id = (string)((ObjectResult)_wordController.Put(_projId, modWord.Id, modWord).Result).Value;
 
@@ -250,7 +250,7 @@ namespace Backend.Tests.Controllers
             Assert.AreEqual(dbParent.Senses.Count, 3);
             Assert.AreEqual(dbParent.History.Count, 3);
 
-            // Check the separarte words were made
+            // Check that separate words were made
             Assert.AreEqual(newWordList.Count, 4);
 
             foreach (var word in newWordList)

--- a/Backend.Tests/Controllers/WordControllerTests.cs
+++ b/Backend.Tests/Controllers/WordControllerTests.cs
@@ -213,6 +213,11 @@ namespace Backend.Tests.Controllers
             // Check that new word has the right history
             Assert.That(newWords.First().History, Has.Count.EqualTo(1));
             var intermediateWord = _repo.GetWord(_projId, newWords.First().History.First()).Result;
+            if (intermediateWord is null)
+            {
+                Assert.Fail();
+                return;
+            }
             Assert.That(intermediateWord.History, Has.Count.EqualTo(1));
             Assert.AreEqual(intermediateWord.History.First(), thisWord.Id);
         }
@@ -257,6 +262,13 @@ namespace Backend.Tests.Controllers
             {
                 Assert.Contains(_repo.GetWord(_projId, word.Id).Result, _repo.GetAllWords(_projId).Result);
             }
+        }
+
+        [Test]
+        public void TestMissingWord()
+        {
+            var action = _wordController.Get(_projId, "INVALID_WORD_ID").Result;
+            Assert.That(action, Is.InstanceOf<NotFoundObjectResult>());
         }
     }
 }

--- a/Backend.Tests/Controllers/WordControllerTests.cs
+++ b/Backend.Tests/Controllers/WordControllerTests.cs
@@ -249,8 +249,7 @@ namespace Backend.Tests.Controllers
             var newWordList = _wordService.Merge(_projId, parentChildMergeObject).Result;
 
             // Check for parent is in the db
-            var dbParent = newWordList.FirstOrDefault();
-            Assert.IsNotNull(dbParent);
+            var dbParent = newWordList.First();
             Assert.AreEqual(dbParent.Senses.Count, 3);
             Assert.AreEqual(dbParent.History.Count, 3);
 

--- a/Backend.Tests/Helper/Sanitization.cs
+++ b/Backend.Tests/Helper/Sanitization.cs
@@ -11,7 +11,7 @@ namespace Backend.Tests.Helper
         {
             "a",
             "1",
-            "a-5",
+            "a-5"
         };
 
         [TestCaseSource(nameof(_validIds))]

--- a/Backend.Tests/Mocks/UserEditRepositoryMock.cs
+++ b/Backend.Tests/Mocks/UserEditRepositoryMock.cs
@@ -22,10 +22,17 @@ namespace Backend.Tests.Mocks
             return Task.FromResult(cloneList.Where(userEdit => userEdit.ProjectId == projectId).ToList());
         }
 
-        public Task<UserEdit> GetUserEdit(string projectId, string userEditId)
+        public Task<UserEdit?> GetUserEdit(string projectId, string userEditId)
         {
-            var foundUserEdit = _userEdits.Single(ue => ue.Id == userEditId);
-            return Task.FromResult(foundUserEdit.Clone());
+            try
+            {
+                var foundUserEdit = _userEdits.Single(ue => ue.Id == userEditId);
+                return Task.FromResult<UserEdit?>(foundUserEdit.Clone());
+            }
+            catch (InvalidOperationException)
+            {
+                return Task.FromResult<UserEdit?>(null);
+            }
         }
 
         public Task<UserEdit> Create(UserEdit userEdit)

--- a/Backend.Tests/Mocks/UserRoleServiceMock.cs
+++ b/Backend.Tests/Mocks/UserRoleServiceMock.cs
@@ -23,10 +23,17 @@ namespace Backend.Tests.Mocks
             return Task.FromResult(cloneList.Where(userRole => userRole.ProjectId == projectId).ToList());
         }
 
-        public Task<UserRole> GetUserRole(string projectId, string userRoleId)
+        public Task<UserRole?> GetUserRole(string projectId, string userRoleId)
         {
-            var foundUserRole = _userRoles.Single(userRole => userRole.Id == userRoleId);
-            return Task.FromResult(foundUserRole.Clone());
+            try
+            {
+                var foundUserRole = _userRoles.Single(userRole => userRole.Id == userRoleId);
+                return Task.FromResult<UserRole?>(foundUserRole.Clone());
+            }
+            catch (InvalidOperationException)
+            {
+                return Task.FromResult<UserRole?>(null);
+            }
         }
 
         public Task<UserRole> Create(UserRole userRole)

--- a/Backend.Tests/Mocks/UserServiceMock.cs
+++ b/Backend.Tests/Mocks/UserServiceMock.cs
@@ -84,7 +84,7 @@ namespace Backend.Tests.Mocks
                 }
 
                 foundUser = MakeJwt(foundUser).Result;
-                return Task.FromResult<User?>(foundUser);
+                return Task.FromResult(foundUser);
             }
             catch (InvalidOperationException)
             {

--- a/Backend.Tests/Mocks/UserServiceMock.cs
+++ b/Backend.Tests/Mocks/UserServiceMock.cs
@@ -22,7 +22,7 @@ namespace Backend.Tests.Mocks
             return Task.FromResult(_users.Select(user => user.Clone()).ToList());
         }
 
-        public Task<User?> GetUser(string id)
+        public Task<User?> GetUser(string id, bool sanitize = true)
         {
             try
             {

--- a/Backend.Tests/Mocks/UserServiceMock.cs
+++ b/Backend.Tests/Mocks/UserServiceMock.cs
@@ -22,10 +22,17 @@ namespace Backend.Tests.Mocks
             return Task.FromResult(_users.Select(user => user.Clone()).ToList());
         }
 
-        public Task<User> GetUser(string id)
+        public Task<User?> GetUser(string id)
         {
-            var foundUser = _users.Single(user => user.Id == id);
-            return Task.FromResult(foundUser.Clone());
+            try
+            {
+                var foundUser = _users.Single(user => user.Id == id);
+                return Task.FromResult<User?>(foundUser.Clone());
+            }
+            catch (InvalidOperationException)
+            {
+                return Task.FromResult<User?>(null);
+            }
         }
 
         public Task<string?> GetUserAvatar(string id)

--- a/Backend.Tests/Mocks/WordRepositoryMock.cs
+++ b/Backend.Tests/Mocks/WordRepositoryMock.cs
@@ -24,10 +24,17 @@ namespace Backend.Tests.Mocks
             return Task.FromResult(_words.Select(word => word.Clone()).ToList());
         }
 
-        public Task<Word> GetWord(string projectId, string wordId)
+        public Task<Word?> GetWord(string projectId, string wordId)
         {
-            var foundWord = _words.Single(word => word.Id == wordId);
-            return Task.FromResult(foundWord.Clone());
+            try
+            {
+                var foundWord = _words.Single(word => word.Id == wordId);
+                return Task.FromResult<Word?>(foundWord.Clone());
+            }
+            catch (InvalidOperationException)
+            {
+                return Task.FromResult<Word?>(null);
+            }
         }
 
         public Task<Word> Create(Word word)

--- a/Backend.Tests/Models/ProjectTests.cs
+++ b/Backend.Tests/Models/ProjectTests.cs
@@ -123,8 +123,8 @@ namespace Backend.Tests.Models
         public void TestToString()
         {
             var system = new WritingSystem { Name = Name, Bcp47 = Bcp47 };
-            var systring = system.ToString();
-            Assert.IsTrue(systring.Contains(Name) && systring.Contains(Bcp47));
+            var sysString = system.ToString();
+            Assert.IsTrue(sysString.Contains(Name) && sysString.Contains(Bcp47));
         }
 
         [Test]

--- a/Backend.Tests/Services/PasswordResetServiceTests.cs
+++ b/Backend.Tests/Services/PasswordResetServiceTests.cs
@@ -25,7 +25,7 @@ namespace Backend.Tests.Services
         public void CreateRequest()
         {
             // test we can successfully create a request
-            var user = new User() { Email = "user@domain.com" };
+            var user = new User { Email = "user@domain.com" };
             _userService.Create(user);
 
             var res = _passwordResetService.CreatePasswordReset("user@domain.com").Result;
@@ -35,7 +35,7 @@ namespace Backend.Tests.Services
         [Test]
         public void ResetSuccess()
         {
-            var user = new User() { Email = "user@domain.com" };
+            var user = new User { Email = "user@domain.com" };
             _userService.Create(user);
 
             var request = _passwordResetService.CreatePasswordReset("user@domain.com").Result;
@@ -46,7 +46,7 @@ namespace Backend.Tests.Services
         [Test]
         public void ResetExpired()
         {
-            var user = new User() { Email = "user@domain.com" };
+            var user = new User { Email = "user@domain.com" };
             _userService.Create(user);
 
             var request = _passwordResetService.CreatePasswordReset("user@domain.com").Result;
@@ -59,7 +59,7 @@ namespace Backend.Tests.Services
         public void ResetBadToken()
         {
             const string email = "user@domain.com";
-            var user = new User() { Email = email };
+            var user = new User { Email = email };
             _userService.Create(user);
 
             var request = _passwordResetService.CreatePasswordReset("user@domain.com").Result;

--- a/Backend/Controllers/AudioController.cs
+++ b/Backend/Controllers/AudioController.cs
@@ -103,13 +103,17 @@ namespace BackendFramework.Controllers
             }
 
             // Add the relative path to the audio field
-            var gotWord = await _wordRepo.GetWord(projectId, wordId);
-            gotWord.Audio.Add(Path.GetFileName(fileUpload.FilePath));
+            var word = await _wordRepo.GetWord(projectId, wordId);
+            if (word is null)
+            {
+                return new NotFoundObjectResult(wordId);
+            }
+            word.Audio.Add(Path.GetFileName(fileUpload.FilePath));
 
             // Update the word with new audio file
-            await _wordService.Update(projectId, wordId, gotWord);
+            await _wordService.Update(projectId, wordId, word);
 
-            return new ObjectResult(gotWord.Id);
+            return new ObjectResult(word.Id);
         }
 
         /// <summary> Deletes audio in <see cref="Word"/> with specified ID </summary>

--- a/Backend/Controllers/AudioController.cs
+++ b/Backend/Controllers/AudioController.cs
@@ -129,7 +129,6 @@ namespace BackendFramework.Controllers
             }
 
             var newWord = await _wordService.Delete(projectId, wordId, fileName);
-
             if (newWord != null)
             {
                 return new OkObjectResult(newWord.Id);

--- a/Backend/Controllers/AvatarController.cs
+++ b/Backend/Controllers/AvatarController.cs
@@ -59,15 +59,15 @@ namespace BackendFramework.Controllers
                 return new BadRequestObjectResult("Null File");
             }
 
-            // Ensure file is not empty
+            // Ensure file is not empty.
             if (file.Length == 0)
             {
                 return new BadRequestObjectResult("Empty File");
             }
 
-            // Get user to apply avatar to
-            var gotUser = await _userService.GetUser(userId);
-            if (gotUser is null)
+            // Get user to apply avatar to.
+            var user = await _userService.GetUser(userId);
+            if (user is null)
             {
                 return new NotFoundObjectResult(userId);
             }
@@ -75,16 +75,16 @@ namespace BackendFramework.Controllers
             // Generate path to store avatar file.
             fileUpload.FilePath = FileStorage.GenerateAvatarFilePath(userId);
 
-            // Copy file data to a new local file
+            // Copy file data to a new local file.
             await using (var fs = new FileStream(fileUpload.FilePath, FileMode.OpenOrCreate))
             {
                 await file.CopyToAsync(fs);
             }
 
-            // Update the user's avatar file
-            gotUser.Avatar = fileUpload.FilePath;
-            gotUser.HasAvatar = true;
-            _ = await _userService.Update(userId, gotUser);
+            // Update the user's avatar file.
+            user.Avatar = fileUpload.FilePath;
+            user.HasAvatar = true;
+            _ = await _userService.Update(userId, user);
 
             return new OkResult();
         }

--- a/Backend/Controllers/LiftController.cs
+++ b/Backend/Controllers/LiftController.cs
@@ -98,7 +98,7 @@ namespace BackendFramework.Controllers
                 // If there was one directory, we're good
                 case 1:
                     {
-                        extractedDirPath = directoriesExtracted.FirstOrDefault();
+                        extractedDirPath = directoriesExtracted.First();
                         break;
                     }
                 // If there were two, and there was a __MACOSX directory, ignore it

--- a/Backend/Controllers/LiftController.cs
+++ b/Backend/Controllers/LiftController.cs
@@ -42,7 +42,7 @@ namespace BackendFramework.Controllers
         /// <returns> Number of words added </returns>
         [HttpPost("upload")]
         // Allow clients to POST large import files to the server (default limit is 28MB).
-        // Note: The HTTP Proxy in front, such as NGNIX, also needs to be configured
+        // Note: The HTTP Proxy in front, such as NGINX, also needs to be configured
         //     to allow large requests through as well.
         [RequestSizeLimit(250_000_000)]  // 250MB.
         public async Task<IActionResult> UploadLiftFile(string projectId, [FromForm] FileUpload fileUpload)

--- a/Backend/Controllers/ProjectController.cs
+++ b/Backend/Controllers/ProjectController.cs
@@ -128,8 +128,6 @@ namespace BackendFramework.Controllers
             userRole = await _userRoleService.Create(userRole);
 
             // Update user with userRole.
-            currentUser.ProjectRoles ??= new Dictionary<string, string>();
-
             // Generate the userRoles and update the user.
             currentUser.ProjectRoles.Add(project.Id, userRole.Id);
             await _userService.Update(currentUserId, currentUser);

--- a/Backend/Controllers/ProjectController.cs
+++ b/Backend/Controllers/ProjectController.cs
@@ -268,6 +268,11 @@ namespace BackendFramework.Controllers
                 await _userService.Update(changeUser.Id, changeUser);
             }
             var userRole = await _userRoleService.GetUserRole(projectId, userRoleId);
+            if (userRole is null)
+            {
+                return new NotFoundObjectResult(userRoleId);
+            }
+
             userRole.Permissions = new List<int>(permissions);
 
             var result = await _userRoleService.Update(userRoleId, userRole);

--- a/Backend/Controllers/ProjectController.cs
+++ b/Backend/Controllers/ProjectController.cs
@@ -104,11 +104,15 @@ namespace BackendFramework.Controllers
         {
             await _projectService.Create(project);
 
-            // Get user
+            // Get user.
             var currentUserId = _permissionService.GetUserId(HttpContext);
             var currentUser = await _userService.GetUser(currentUserId);
+            if (currentUser is null)
+            {
+                return new NotFoundObjectResult(currentUserId);
+            }
 
-            // Give Project admin privileges to user who creates a Project
+            // Give Project admin privileges to user who creates a Project.
             var userRole = new UserRole
             {
                 Permissions = new List<int>
@@ -123,13 +127,13 @@ namespace BackendFramework.Controllers
             };
             userRole = await _userRoleService.Create(userRole);
 
-            // Update user with userRole
+            // Update user with userRole.
             currentUser.ProjectRoles ??= new Dictionary<string, string>();
 
-            // Generate the userRoles and update the user
+            // Generate the userRoles and update the user.
             currentUser.ProjectRoles.Add(project.Id, userRole.Id);
             await _userService.Update(currentUserId, currentUser);
-            // Generate the JWT based on those new userRoles
+            // Generate the JWT based on those new userRoles.
             var currentUpdatedUser = await _userService.MakeJwt(currentUser);
             if (currentUpdatedUser is null)
             {
@@ -244,6 +248,11 @@ namespace BackendFramework.Controllers
 
             // Fetch the user -> fetch user role -> update user role
             var changeUser = await _userService.GetUser(userId);
+            if (changeUser is null)
+            {
+                return new NotFoundObjectResult(userId);
+            }
+
             string userRoleId;
             if (changeUser.ProjectRoles.ContainsKey(projectId))
             {
@@ -251,7 +260,6 @@ namespace BackendFramework.Controllers
             }
             else
             {
-
                 // Generate the userRole
                 var usersRole = new UserRole { ProjectId = projectId };
                 usersRole = await _userRoleService.Create(usersRole);

--- a/Backend/Controllers/UserController.cs
+++ b/Backend/Controllers/UserController.cs
@@ -142,7 +142,7 @@ namespace BackendFramework.Controllers
             var user = await _userService.GetUser(userId);
             if (user is null)
             {
-                return new NotFoundResult();
+                return new NotFoundObjectResult(userId);
             }
 
             return new ObjectResult(user);

--- a/Backend/Controllers/UserController.cs
+++ b/Backend/Controllers/UserController.cs
@@ -37,16 +37,16 @@ namespace BackendFramework.Controllers
         [HttpPost("forgot")]
         public async Task<IActionResult> ResetPasswordRequest([FromBody] PasswordResetData data)
         {
-            // find user attached to email or username
+            // Find user attached to email or username.
             var emailOrUsername = data.EmailOrUsername.ToLowerInvariant();
-            var user = (await _userService.GetAllUsers()).SingleOrDefault(user =>
-                user.Email.ToLowerInvariant().Equals(emailOrUsername) ||
-                user.Username.ToLowerInvariant().Equals(emailOrUsername));
+            var user = (await _userService.GetAllUsers()).SingleOrDefault(u =>
+                u.Email.ToLowerInvariant().Equals(emailOrUsername) ||
+                u.Username.ToLowerInvariant().Equals(emailOrUsername));
 
-            // create password reset
+            // Create password reset.
             var resetRequest = await _passwordResetService.CreatePasswordReset(user.Email);
 
-            // create email
+            // Create email.
             var message = new MimeMessage();
             message.To.Add(new MailboxAddress(user.Name, user.Email));
             message.Subject = "Combine password reset";

--- a/Backend/Controllers/UserEditController.cs
+++ b/Backend/Controllers/UserEditController.cs
@@ -120,6 +120,11 @@ namespace BackendFramework.Controllers
             // Update current user
             var currentUserId = _permissionService.GetUserId(HttpContext);
             var currentUser = await _userService.GetUser(currentUserId);
+            if (currentUser is null)
+            {
+                return new NotFoundObjectResult(currentUserId);
+            }
+
             currentUser.WorkedProjects.Add(projectId, userEdit.Id);
             await _userService.Update(currentUserId, currentUser);
 

--- a/Backend/Controllers/UserRoleController.cs
+++ b/Backend/Controllers/UserRoleController.cs
@@ -113,12 +113,7 @@ namespace BackendFramework.Controllers
                 return new NotFoundObjectResult(projectId);
             }
 
-            var returnUserRole = await _userRoleService.Create(userRole);
-            if (returnUserRole is null)
-            {
-                return BadRequest();
-            }
-
+            await _userRoleService.Create(userRole);
             return new OkObjectResult(userRole.Id);
         }
 

--- a/Backend/Controllers/WordController.cs
+++ b/Backend/Controllers/WordController.cs
@@ -202,12 +202,6 @@ namespace BackendFramework.Controllers
                 return new NotFoundObjectResult(projectId);
             }
 
-            // Ensure MergeWords is alright
-            if (mergeWords?.Parent is null)
-            {
-                return new BadRequestResult();
-            }
-
             try
             {
                 var newWordList = await _wordService.Merge(projectId, mergeWords);

--- a/Backend/Controllers/WordController.cs
+++ b/Backend/Controllers/WordController.cs
@@ -92,6 +92,7 @@ namespace BackendFramework.Controllers
             {
                 return new NotFoundObjectResult(wordId);
             }
+
             return new ObjectResult(word);
         }
 

--- a/Backend/Helper/FileStorage.cs
+++ b/Backend/Helper/FileStorage.cs
@@ -23,6 +23,7 @@ namespace BackendFramework.Helper
         }
 
         /// <summary> Indicates that an error occured locating the current user's home directory. </summary>
+        [Serializable]
         public class HomeFolderNotFoundException : Exception
         {
         }

--- a/Backend/Interfaces/IUserEditRepository.cs
+++ b/Backend/Interfaces/IUserEditRepository.cs
@@ -7,7 +7,7 @@ namespace BackendFramework.Interfaces
     public interface IUserEditRepository
     {
         Task<List<UserEdit>> GetAllUserEdits(string projectId);
-        Task<UserEdit> GetUserEdit(string projectId, string userEditId);
+        Task<UserEdit?> GetUserEdit(string projectId, string userEditId);
         Task<UserEdit> Create(UserEdit userEdit);
         Task<bool> Delete(string projectId, string userEditId);
         Task<bool> DeleteAllUserEdits(string projectId);

--- a/Backend/Interfaces/IUserRoleService.cs
+++ b/Backend/Interfaces/IUserRoleService.cs
@@ -8,7 +8,7 @@ namespace BackendFramework.Interfaces
     public interface IUserRoleService
     {
         Task<List<UserRole>> GetAllUserRoles(string projectId);
-        Task<UserRole> GetUserRole(string projectId, string userRoleId);
+        Task<UserRole?> GetUserRole(string projectId, string userRoleId);
         Task<UserRole> Create(UserRole userRole);
         Task<bool> Delete(string projectId, string userRoleId);
         Task<bool> DeleteAllUserRoles(string projectId);

--- a/Backend/Interfaces/IUserService.cs
+++ b/Backend/Interfaces/IUserService.cs
@@ -8,7 +8,7 @@ namespace BackendFramework.Interfaces
     public interface IUserService
     {
         Task<List<User>> GetAllUsers();
-        Task<User> GetUser(string userId);
+        Task<User?> GetUser(string userId);
         Task<string?> GetUserAvatar(string userId);
         Task<User?> Create(User user);
         Task<ResultOfUpdate> Update(string userId, User user, bool updateIsAdmin = false);

--- a/Backend/Interfaces/IUserService.cs
+++ b/Backend/Interfaces/IUserService.cs
@@ -8,7 +8,7 @@ namespace BackendFramework.Interfaces
     public interface IUserService
     {
         Task<List<User>> GetAllUsers();
-        Task<User?> GetUser(string userId);
+        Task<User?> GetUser(string userId, bool sanitize = false);
         Task<string?> GetUserAvatar(string userId);
         Task<User?> Create(User user);
         Task<ResultOfUpdate> Update(string userId, User user, bool updateIsAdmin = false);

--- a/Backend/Interfaces/IWordRepository.cs
+++ b/Backend/Interfaces/IWordRepository.cs
@@ -7,7 +7,7 @@ namespace BackendFramework.Interfaces
     public interface IWordRepository
     {
         Task<List<Word>> GetAllWords(string projectId);
-        Task<Word> GetWord(string projectId, string wordId);
+        Task<Word?> GetWord(string projectId, string wordId);
         Task<Word> Create(Word word);
         Task<Word> Add(Word word);
         Task<bool> DeleteAllWords(string projectId);

--- a/Backend/Interfaces/IWordService.cs
+++ b/Backend/Interfaces/IWordService.cs
@@ -10,7 +10,7 @@ namespace BackendFramework.Interfaces
         Task<bool> Delete(string projectId, string wordId);
         Task<List<Word>> Merge(string projectId, MergeWords mergeWords);
         Task<bool> WordIsUnique(Word word);
-        Task<Word> Delete(string projectId, string wordId, string fileName);
+        Task<Word?> Delete(string projectId, string wordId, string fileName);
         Task<string?> DeleteFrontierWord(string projectId, string wordId);
     }
 }

--- a/Backend/Services/LiftApiServices.cs
+++ b/Backend/Services/LiftApiServices.cs
@@ -75,6 +75,7 @@ namespace BackendFramework.Services
         }
     }
 
+    [Serializable]
     public class MissingProjectException : Exception
     {
         public MissingProjectException(string message)

--- a/Backend/Services/PermissionService.cs
+++ b/Backend/Services/PermissionService.cs
@@ -56,6 +56,10 @@ namespace BackendFramework.Services
         {
             var userId = GetUserId(request);
             var user = await _userService.GetUser(userId);
+            if (user is null)
+            {
+                return false;
+            }
 
             // Database administrators implicitly possess all permissions.
             if (user.IsAdmin)
@@ -95,8 +99,13 @@ namespace BackendFramework.Services
         public async Task<bool> IsViolationEdit(HttpContext request, string userEditId, string projectId)
         {
             var userId = GetUserId(request);
-            var userObj = await _userService.GetUser(userId);
-            return userObj.WorkedProjects[projectId] != userEditId;
+            var user = await _userService.GetUser(userId);
+            if (user is null)
+            {
+                return true;
+            }
+
+            return user.WorkedProjects[projectId] != userEditId;
         }
 
         /// <summary>Retrieve the User ID from the JWT in a request. </summary>

--- a/Backend/Services/UserApiServices.cs
+++ b/Backend/Services/UserApiServices.cs
@@ -136,8 +136,13 @@ namespace BackendFramework.Services
             foreach (var (projectRoleKey, projectRoleValue) in user.ProjectRoles)
             {
                 // Convert each userRoleId to its respective role and add to the mapping
-                var permissions = (await _userRole.GetUserRole(projectRoleKey, projectRoleValue)).Permissions;
-                var validEntry = new ProjectPermissions(projectRoleKey, permissions);
+                var userRole = await _userRole.GetUserRole(projectRoleKey, projectRoleValue);
+                if (userRole is null)
+                {
+                    return null;
+                }
+
+                var validEntry = new ProjectPermissions(projectRoleKey, userRole.Permissions);
                 projectPermissionMap.Add(validEntry);
             }
 

--- a/Backend/Services/UserApiServices.cs
+++ b/Backend/Services/UserApiServices.cs
@@ -192,7 +192,9 @@ namespace BackendFramework.Services
         }
 
         /// <summary> Finds <see cref="User"/> with specified userId </summary>
-        public async Task<User?> GetUser(string userId)
+        /// <param name="userId"> User ID to retrieve. </param>
+        /// <param name="sanitize"> Whether to sanitize (remove) sensitive information for the User instance. </param>
+        public async Task<User?> GetUser(string userId, bool sanitize = true)
         {
             var filterDef = new FilterDefinitionBuilder<User>();
             var filter = filterDef.Eq(x => x.Id, userId);
@@ -202,7 +204,10 @@ namespace BackendFramework.Services
             try
             {
                 var user = await userList.FirstAsync();
-                Sanitize(user);
+                if (sanitize)
+                {
+                    Sanitize(user);
+                }
                 return user;
             }
             catch (InvalidOperationException)
@@ -214,11 +219,7 @@ namespace BackendFramework.Services
         /// <summary> Finds <see cref="User"/> with specified userId and returns avatar filepath </summary>
         public async Task<string?> GetUserAvatar(string userId)
         {
-            var filterDef = new FilterDefinitionBuilder<User>();
-            var filter = filterDef.Eq(x => x.Id, userId);
-
-            var userList = await _userDatabase.Users.FindAsync(filter);
-            var user = userList.FirstOrDefault();
+            var user = await GetUser(userId, false);
             return string.IsNullOrEmpty(user?.Avatar) ? null : user.Avatar;
         }
 

--- a/Backend/Services/UserApiServices.cs
+++ b/Backend/Services/UserApiServices.cs
@@ -187,15 +187,23 @@ namespace BackendFramework.Services
         }
 
         /// <summary> Finds <see cref="User"/> with specified userId </summary>
-        public async Task<User> GetUser(string userId)
+        public async Task<User?> GetUser(string userId)
         {
             var filterDef = new FilterDefinitionBuilder<User>();
             var filter = filterDef.Eq(x => x.Id, userId);
 
             var userList = await _userDatabase.Users.FindAsync(filter);
-            var user = userList.FirstOrDefault();
-            Sanitize(user);
-            return user;
+
+            try
+            {
+                var user = await userList.FirstAsync();
+                Sanitize(user);
+                return user;
+            }
+            catch (InvalidOperationException)
+            {
+                return null;
+            }
         }
 
         /// <summary> Finds <see cref="User"/> with specified userId and returns avatar filepath </summary>

--- a/Backend/Services/UserEditApiServices.cs
+++ b/Backend/Services/UserEditApiServices.cs
@@ -16,11 +16,22 @@ namespace BackendFramework.Services
         }
 
         /// <summary> Adds an <see cref="Edit"/> to a specified <see cref="UserEdit"/> </summary>
-        /// <returns> Tuple of a bool: success of operation and int: index at which the new edit was placed </returns>
+        /// <returns>
+        /// Tuple of
+        ///     bool: success of operation
+        ///     int: index at which the new edit was placed or -1 on failure
+        /// </returns>
         public async Task<Tuple<bool, int>> AddGoalToUserEdit(string projectId, string userEditId, Edit edit)
         {
             // Get userEdit to change
             var userEntry = await _repo.GetUserEdit(projectId, userEditId);
+            const int invalidEditIndex = -1;
+            var failureResult = new Tuple<bool, int>(false, invalidEditIndex);
+            if (userEntry is null)
+            {
+                return failureResult;
+            }
+
             var newUserEdit = userEntry.Clone();
 
             // Add the new goal index to Edits list
@@ -28,10 +39,15 @@ namespace BackendFramework.Services
 
             // Replace the old UserEdit object with the new one that contains the new list entry
             var replaceSucceeded = await _repo.Replace(projectId, userEditId, newUserEdit);
-            var indexOfNewestEdit = -1;
+            var indexOfNewestEdit = invalidEditIndex;
             if (replaceSucceeded)
             {
                 var newestEdit = await _repo.GetUserEdit(projectId, userEditId);
+                if (newestEdit is null)
+                {
+                    return failureResult;
+                }
+
                 indexOfNewestEdit = newestEdit.Edits.Count - 1;
             }
 
@@ -43,6 +59,11 @@ namespace BackendFramework.Services
         public async Task<bool> AddStepToGoal(string projectId, string userEditId, int goalIndex, string userEdit)
         {
             var addUserEdit = await _repo.GetUserEdit(projectId, userEditId);
+            if (addUserEdit is null)
+            {
+                return false;
+            }
+
             var newUserEdit = addUserEdit.Clone();
             newUserEdit.Edits[goalIndex].StepData.Add(userEdit);
             var updateResult = await _repo.Replace(projectId, userEditId, newUserEdit);

--- a/Backend/Services/UserEditRepository.cs
+++ b/Backend/Services/UserEditRepository.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using BackendFramework.Interfaces;
@@ -31,7 +32,7 @@ namespace BackendFramework.Services
         }
 
         /// <summary> Finds <see cref="UserEdit"/> with specified userRoleId and projectId </summary>
-        public async Task<UserEdit> GetUserEdit(string projectId, string userEditId)
+        public async Task<UserEdit?> GetUserEdit(string projectId, string userEditId)
         {
             var filterDef = new FilterDefinitionBuilder<UserEdit>();
             var filter = filterDef.And(filterDef.Eq(
@@ -39,7 +40,14 @@ namespace BackendFramework.Services
 
             var userEditList = await _userEditDatabase.UserEdits.FindAsync(filter);
 
-            return userEditList.FirstOrDefault();
+            try
+            {
+                return await userEditList.FirstAsync();
+            }
+            catch (InvalidOperationException)
+            {
+                return null;
+            }
         }
 
         /// <summary> Adds a <see cref="UserEdit"/> </summary>

--- a/Backend/Services/UserRoleApiServices.cs
+++ b/Backend/Services/UserRoleApiServices.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using BackendFramework.Helper;
@@ -32,15 +33,21 @@ namespace BackendFramework.Services
         }
 
         /// <summary> Finds <see cref="UserRole"/> with specified userRoleId and projectId </summary>
-        public async Task<UserRole> GetUserRole(string projectId, string userRoleId)
+        public async Task<UserRole?> GetUserRole(string projectId, string userRoleId)
         {
             var filterDef = new FilterDefinitionBuilder<UserRole>();
             var filter = filterDef.And(filterDef.Eq(
                 x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, userRoleId));
 
             var userRoleList = await _userRoleDatabase.UserRoles.FindAsync(filter);
-
-            return userRoleList.FirstOrDefault();
+            try
+            {
+                return await userRoleList.FirstAsync();
+            }
+            catch (InvalidOperationException)
+            {
+                return null;
+            }
         }
 
         /// <summary> Adds a <see cref="UserRole"/> </summary>

--- a/Backend/Services/WordApiServices.cs
+++ b/Backend/Services/WordApiServices.cs
@@ -27,6 +27,11 @@ namespace BackendFramework.Services
             if (wordIsInFrontier)
             {
                 var wordToDelete = await _repo.GetWord(projectId, wordId);
+                if (wordToDelete is null)
+                {
+                    return false;
+                }
+
                 wordToDelete.Id = "";
                 wordToDelete.History = new List<string> { wordId };
                 wordToDelete.Accessibility = State.Deleted;
@@ -44,9 +49,14 @@ namespace BackendFramework.Services
 
         /// <summary> Removes audio with specified Id from a word </summary>
         /// <returns> New word </returns>
-        public async Task<Word> Delete(string projectId, string wordId, string fileName)
+        public async Task<Word?> Delete(string projectId, string wordId, string fileName)
         {
             var wordWithAudioToDelete = await _repo.GetWord(projectId, wordId);
+            if (wordWithAudioToDelete is null)
+            {
+                return null;
+            }
+
             var wordIsInFrontier = await _repo.DeleteFrontier(projectId, wordId);
 
             // We only want to update words that are in the frontier
@@ -78,13 +88,16 @@ namespace BackendFramework.Services
         public async Task<string?> DeleteFrontierWord(string projectId, string wordId)
         {
             var wordIsInFrontier = await _repo.DeleteFrontier(projectId, wordId);
-
             if (!wordIsInFrontier)
             {
                 return null;
             }
 
             var word = await _repo.GetWord(projectId, wordId);
+            if (word is null)
+            {
+                return null;
+            }
 
             word.Id = "";
             word.ProjectId = projectId;
@@ -149,6 +162,10 @@ namespace BackendFramework.Services
             {
                 // Get child word
                 var currentChildWord = await _repo.GetWord(projectId, newChildWordState.SrcWordId);
+                if (currentChildWord is null)
+                {
+                    throw new KeyNotFoundException($"Unable to locate word: ${newChildWordState.SrcWordId}");
+                }
 
                 // Copy over audio if child doesn't have own surviving entry
                 if (!newChildWordState.SenseStates.Exists(x => x == State.Separate))

--- a/Backend/Services/WordApiServices.cs
+++ b/Backend/Services/WordApiServices.cs
@@ -66,16 +66,8 @@ namespace BackendFramework.Services
                 wordWithAudioToDelete.Id = "";
                 wordWithAudioToDelete.ProjectId = projectId;
 
-                // Keep track of the old word
-                if (wordWithAudioToDelete.History is null)
-                {
-                    wordWithAudioToDelete.History = new List<string> { wordId };
-                }
-                // If we are updating the history, don't overwrite it, just add to the history
-                else
-                {
-                    wordWithAudioToDelete.History.Add(wordId);
-                }
+                // Keep track of the old word, adding it to the history.
+                wordWithAudioToDelete.History.Add(wordId);
 
                 wordWithAudioToDelete = await _repo.Create(wordWithAudioToDelete);
             }
@@ -103,16 +95,8 @@ namespace BackendFramework.Services
             word.ProjectId = projectId;
             word.Accessibility = State.Deleted;
 
-            // Keep track of the old word
-            if (word.History is null)
-            {
-                word.History = new List<string> { wordId };
-            }
-            // If we are updating the history, don't overwrite it, just add to the history
-            else
-            {
-                word.History.Add(wordId);
-            }
+            // Keep track of the old word, adding it to the history.
+            word.History.Add(wordId);
 
             var deletedWord = await _repo.Add(word);
             return deletedWord.Id;
@@ -130,16 +114,9 @@ namespace BackendFramework.Services
                 word.Id = "";
                 word.ProjectId = projectId;
                 word.Modified = DateTime.UtcNow.ToLongDateString();
-                // Keep track of the old word
-                if (word.History is null)
-                {
-                    word.History = new List<string> { wordId };
-                }
-                // If we are updating the history, don't overwrite it, just add to the history
-                else
-                {
-                    word.History.Add(wordId);
-                }
+
+                // Keep track of the old word, adding it to the history.
+                word.History.Add(wordId);
 
                 await _repo.Create(word);
             }

--- a/Backend/Services/WordRepository.cs
+++ b/Backend/Services/WordRepository.cs
@@ -24,15 +24,21 @@ namespace BackendFramework.Services
         }
 
         /// <summary> Finds <see cref="Word"/> with specified wordId and projectId </summary>
-        public async Task<Word> GetWord(string projectId, string wordId)
+        public async Task<Word?> GetWord(string projectId, string wordId)
         {
             var filterDef = new FilterDefinitionBuilder<Word>();
             var filter = filterDef.And(filterDef.Eq(
                 x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, wordId));
 
             var wordList = await _wordDatabase.Words.FindAsync(filter);
-
-            return wordList.FirstOrDefault();
+            try
+            {
+                return await wordList.FirstAsync();
+            }
+            catch (InvalidOperationException)
+            {
+                return null;
+            }
         }
 
         /// <summary> Removes all <see cref="Word"/>s from the WordsCollection and Frontier for specified

--- a/Backend/Startup.cs
+++ b/Backend/Startup.cs
@@ -54,6 +54,7 @@ namespace BackendFramework
             }
         }
 
+        [Serializable]
         private class EnvironmentNotConfiguredException : Exception
         {
         }
@@ -76,6 +77,7 @@ namespace BackendFramework
             return Environment.GetEnvironmentVariable("COMBINE_IS_IN_CONTAINER") != null;
         }
 
+        [Serializable]
         private class AdminUserCreationException : Exception
         {
         }


### PR DESCRIPTION
Closes #882 

Follow on to #892 

Cleanup:
- Force all Backend.Tests compile warnings into errors
- Fix `WordRepository.GetWord` and `WordService.Delete` type signatures to properly return `null` on failure
  - Includes fixing the type signatures and implementations of Mocks to correctly handle missing entries
- Fix implementation and signature of `UserEditRepository.GetUserEdit` & `UserEditApiServices` to properly handle missing IDs
- Fix type signature and implementation of `UserController.Get`
- Fix `UserRoleApiServices.GetUserRole` to properly handle missing IDs
- Update `UserApiServices.GetUserAvatar` to properly handle missing user IDs
- Remove redundant parentheses
- Fix typos
- Remove unused variables
- Remove `null` checks proven by the compiler to not be possible
- Make all custom `Exceptions` `Serializable`
- Use `Assert.IsInstanceOf<>()` to simplify tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/895)
<!-- Reviewable:end -->
