### PR TITLE
Cleanup loadGoalData and blacklist building.

### DIFF
--- a/src/components/GoalTimeline/GoalsActions.tsx
+++ b/src/components/GoalTimeline/GoalsActions.tsx
@@ -8,7 +8,6 @@ import { CreateStrWordInv } from "../../goals/CreateStrWordInv/CreateStrWordInv"
 import { HandleFlags } from "../../goals/HandleFlags/HandleFlags";
 import DupFinder from "../../goals/MergeDupGoal/DuplicateFinder/DuplicateFinder";
 import { MergeDupData, MergeDups } from "../../goals/MergeDupGoal/MergeDups";
-import { Hash } from "../../goals/MergeDupGoal/MergeDupStep/MergeDupsTree";
 import {
   MergeTreeAction,
   refreshWords,
@@ -108,44 +107,39 @@ export function loadGoalData(goal: Goal) {
   return async (dispatch: ThunkDispatch<any, any, MergeTreeAction>) => {
     switch (goal.goalType) {
       case GoalType.MergeDups:
-        let finder = new DupFinder();
+        const finder = new DupFinder();
+        const groups = await finder.getNextDups();
 
-        //Used for testing duplicate finder. (See docs/bitmap_testing.md)
-        //let t0 = performance.now();
+        const usedIDs: string[] = [];
+        const newGroups = [];
+        const blacklist = LocalStorage.getMergeDupsBlacklist();
 
-        let groups = await finder.getNextDups();
-
-        //Used for testing duplicate finder. (See docs/bitmap_testing.md)
-        //console.log(performance.now() - t0);
-
-        let usedIDs: string[] = [];
-
-        let newGroups = [];
-
-        let blacklist: Hash<boolean> = LocalStorage.getMergeDupsBlacklist();
-
-        for (let group of groups) {
-          let newGroup = [];
-          for (let word of group) {
-            if (!usedIDs.includes(word.id)) {
-              usedIDs.push(word.id);
-              newGroup.push(word);
-            }
+        for (const group of groups) {
+          // Remove words that are already included/blacklisted.
+          const newGroup = group.filter((w) => !usedIDs.includes(w.id));
+          if (newGroup.length < 2) {
+            continue;
           }
-          // check blacklist
-          let groupIds = newGroup.map((a) => a.id).sort();
-          let groupHash = groupIds.reduce((val, acc) => `${acc}:${val}`, "");
-          if (!blacklist[groupHash] && newGroup.length > 1) {
+
+          // Add if not blacklisted.
+          const groupIds = newGroup.map((w) => w.id).sort();
+          const groupHash = groupIds.reduce((val, acc) => `${acc}:${val}`, "");
+          if (!blacklist[groupHash]) {
             newGroups.push(newGroup);
+            usedIDs.push(...groupIds);
+          }
+
+          // Stop the process once numSteps many groups found.
+          if (newGroups.length === goal.numSteps) {
+            break;
           }
         }
 
-        if (newGroups.length >= 8) {
-          newGroups = newGroups.slice(0, 8);
-        }
-
+        // Add data to goal.
         goal.data = { plannedWords: newGroups };
         goal.numSteps = newGroups.length;
+
+        // Reset goal steps.
         goal.currentStep = 0;
         goal.steps = [];
 

--- a/src/components/GoalTimeline/GoalsActions.tsx
+++ b/src/components/GoalTimeline/GoalsActions.tsx
@@ -9,6 +9,7 @@ import { HandleFlags } from "../../goals/HandleFlags/HandleFlags";
 import DupFinder from "../../goals/MergeDupGoal/DuplicateFinder/DuplicateFinder";
 import { MergeDupData, MergeDups } from "../../goals/MergeDupGoal/MergeDups";
 import {
+  generateBlacklistHash,
   MergeTreeAction,
   refreshWords,
 } from "../../goals/MergeDupGoal/MergeDupStep/MergeDupStepActions";
@@ -122,8 +123,8 @@ export function loadGoalData(goal: Goal) {
           }
 
           // Add if not blacklisted.
-          const groupIds = newGroup.map((w) => w.id).sort();
-          const groupHash = groupIds.reduce((val, acc) => `${acc}:${val}`, "");
+          const groupIds = newGroup.map((w) => w.id);
+          const groupHash = generateBlacklistHash(groupIds);
           if (!blacklist[groupHash]) {
             newGroups.push(newGroup);
             usedIDs.push(...groupIds);

--- a/src/components/GoalTimeline/GoalsActions.tsx
+++ b/src/components/GoalTimeline/GoalsActions.tsx
@@ -116,7 +116,7 @@ export function loadGoalData(goal: Goal) {
         const blacklist = LocalStorage.getMergeDupsBlacklist();
 
         for (const group of groups) {
-          // Remove words that are already included/blacklisted.
+          // Remove words that are already included.
           const newGroup = group.filter((w) => !usedIDs.includes(w.id));
           if (newGroup.length < 2) {
             continue;

--- a/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepActions.tsx
+++ b/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepActions.tsx
@@ -406,7 +406,7 @@ export function mergeAll() {
   };
 }
 
-function generateBlacklistEntry(wordIDs: string[]) {
+export function generateBlacklistHash(wordIDs: string[]) {
   return wordIDs.sort().reduce((val, acc) => `${acc}:${val}`, "");
 }
 
@@ -415,12 +415,12 @@ function blacklistSetAndAllSubsets(
   blacklist: Hash<boolean>,
   wordIDs: string[]
 ) {
-  let hash = generateBlacklistEntry(wordIDs);
+  let hash = generateBlacklistHash(wordIDs);
   blacklist[hash] = true;
   if (wordIDs.length > 2) {
     wordIDs.forEach((id) => {
       const subset = wordIDs.filter((i) => i !== id);
-      hash = generateBlacklistEntry(subset);
+      hash = generateBlacklistHash(subset);
       if (!blacklist[hash]) {
         blacklistSetAndAllSubsets(blacklist, subset);
       }

--- a/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepActions.tsx
+++ b/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepActions.tsx
@@ -391,21 +391,39 @@ export function mergeAll() {
     dispatch: ThunkDispatch<any, any, MergeTreeAction>,
     getState: () => StoreState
   ) => {
-    // generate blacklist
-    const wordIDs: string[] = Object.keys(
-      getState().mergeDuplicateGoal.data.words
-    );
-    const hash: string = wordIDs
-      .sort()
-      .reduce((val, acc) => `${acc}:${val}`, "");
-    const blacklist: Hash<boolean> = LocalStorage.getMergeDupsBlacklist();
-    blacklist[hash] = true;
+    // Generate blacklist.
+    const wordIDs = Object.keys(getState().mergeDuplicateGoal.data.words);
+    const blacklist = LocalStorage.getMergeDupsBlacklist();
+    blacklistSetAndAllSubsets(blacklist, wordIDs);
     LocalStorage.setMergeDupsBlacklist(blacklist);
-    // merge words
+
+    // Merge words.
     let mapping: Hash<{ srcWord: string; order: number }> = {};
     const words = Object.keys(getState().mergeDuplicateGoal.tree.words);
     for (const wordID of words) {
       mapping = await mergeWord(wordID, getState, mapping);
     }
   };
+}
+
+function generateBlacklistEntry(wordIDs: string[]) {
+  return wordIDs.sort().reduce((val, acc) => `${acc}:${val}`, "");
+}
+
+// Recursively blacklist all subsets of length at least 2.
+function blacklistSetAndAllSubsets(
+  blacklist: Hash<boolean>,
+  wordIDs: string[]
+) {
+  let hash = generateBlacklistEntry(wordIDs);
+  blacklist[hash] = true;
+  if (wordIDs.length > 2) {
+    wordIDs.forEach((id) => {
+      const subset = wordIDs.filter((i) => i !== id);
+      hash = generateBlacklistEntry(subset);
+      if (!blacklist[hash]) {
+        blacklistSetAndAllSubsets(blacklist, subset);
+      }
+    });
+  }
 }

--- a/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepActions.tsx
+++ b/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepActions.tsx
@@ -187,8 +187,8 @@ export function refreshWords() {
     dispatch: ThunkDispatch<any, any, MergeTreeAction>,
     getState: () => StoreState
   ) => {
-    let historyState: GoalHistoryState = getState().goalsState.historyState;
-    let goal: Goal = historyState.history[historyState.history.length - 1];
+    let historyState = getState().goalsState.historyState;
+    let goal = historyState.history[historyState.history.length - 1];
 
     // Push the current step into the history state and load the data.
     await updateStep(dispatch, goal, historyState).then(() => {

--- a/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepComponent.tsx
+++ b/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepComponent.tsx
@@ -20,11 +20,7 @@ import {
   Droppable,
   DropResult,
 } from "react-beautiful-dnd";
-import {
-  LocalizeContextProps,
-  Translate,
-  withLocalize,
-} from "react-localize-redux";
+import { LocalizeContextProps, withLocalize } from "react-localize-redux";
 
 import theme from "../../../types/theme";
 import { uuid } from "../../../utilities";
@@ -304,14 +300,14 @@ class MergeDupStep extends React.Component<
               ) as string
             }
           >
-            <Translate id="buttons.saveAndContinue" />
+            {this.props.translate("buttons.saveAndContinue")}
           </Button>
           <Button
             style={{ float: "right", marginRight: 30 }}
             onClick={(_) => this.next()}
             title={this.props.translate("mergeDups.helpText.skip") as string}
           >
-            <Translate id="buttons.skip" />
+            {this.props.translate("buttons.skip")}
           </Button>
         </Paper>
       </Box>


### PR DESCRIPTION
`loadGoalData()` blocks any use of words that are already in a suggested duplicate set, as it should. It also blocks words that were seen in a singleton set or a blacklist set, preventing them from being compared to other words. This pr removes those two restrictions.

The latter restriction was because `getNextDups()` has some sets that are strict subsets of previous sets. If you blacklisted a set, you shouldn't have to consider its subsets. To target that problem specifically, this pr updates the blacklisting function to blacklist not just a specified set but also its subsets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/902)
<!-- Reviewable:end -->
