### PR TITLE
Ignore formatting large dictionary TS files to speed up formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+﻿# These files are very large and slow to format.
+src/resources/dictionaries


### PR DESCRIPTION
Closes #932 

This shaves almost a minute off the time to run `npm run fmt-frontend`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/944)
<!-- Reviewable:end -->
