### PR TITLE
Remove reference to missing index.htm file

### DIFF
--- a/nginx/templates/thecombine.conf.template
+++ b/nginx/templates/thecombine.conf.template
@@ -45,9 +45,9 @@ server {
 
     # User Guide static files.
     location /docs {
-        alias       /usr/share/nginx/user_guide;
-        index      index.html index.htm;
-        expires     12h;
+        alias      /usr/share/nginx/user_guide;
+        index      index.html;
+        expires    12h;
         add_header Cache-Control "public, no-transform";
     }
 


### PR DESCRIPTION
There is no `index.htm` file generated by the user guide.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/945)
<!-- Reviewable:end -->
