### PR TITLE
Highlight that export of large projects will take a long time

### DIFF
--- a/user_guide/docs/project.md
+++ b/user_guide/docs/project.md
@@ -47,8 +47,11 @@ and associated with new data entries.
     Currently, only one LIFT file can be imported per project.
 
 After clicking the Export button, you can navigate to other parts of the website. A download icon will appear in the App
-Bar when the export is ready for download. A project that has reached hundreds of MB in size may take tens of minutes to
-export.
+Bar when the export is ready for download.
+
+!!! important
+
+    A project that has reached hundreds of MB in size may take multiple minutes to export.
 
 ### Autocomplete
 


### PR DESCRIPTION
Users have reported thinking that exports have stalled when in fact they just take a long time to export. Specifically highlight long export times in the user guide.

Related #937

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/952)
<!-- Reviewable:end -->
