### PR TITLE
Fix Storage/Import of Word Creation and Modified Fields

### DIFF
--- a/Backend/Helper/Time.cs
+++ b/Backend/Helper/Time.cs
@@ -4,6 +4,9 @@ namespace BackendFramework.Helper
 {
     public static class Time
     {
+        // https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#Roundtrip
+        private const string RoadTripIso8601Format = "o";
+
         /// <summary>
         /// Construct a string for the current DateTime in the UTC timezone formatted in ISO 8601 format.
         /// </summary>
@@ -13,7 +16,15 @@ namespace BackendFramework.Helper
         /// </remarks>
         public static string UtcNowIso8601()
         {
-            return DateTime.UtcNow.ToString("o");
+            return DateTime.UtcNow.ToString(RoadTripIso8601Format);
+        }
+
+        /// <summary>
+        /// Convert a DateTime into a UTC timezone ISO 8601 formatted string.
+        /// </summary>
+        public static string ToUtcIso8601(DateTime dateTime)
+        {
+            return dateTime.ToString(RoadTripIso8601Format);
         }
     }
 }

--- a/Backend/Helper/Time.cs
+++ b/Backend/Helper/Time.cs
@@ -5,7 +5,7 @@ namespace BackendFramework.Helper
     public static class Time
     {
         // https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#Roundtrip
-        private const string RoadTripIso8601Format = "o";
+        private const string RoundTripIso8601Format = "o";
 
         /// <summary>
         /// Construct a string for the current DateTime in the UTC timezone formatted in ISO 8601 format.
@@ -16,7 +16,7 @@ namespace BackendFramework.Helper
         /// </remarks>
         public static string UtcNowIso8601()
         {
-            return DateTime.UtcNow.ToString(RoadTripIso8601Format);
+            return DateTime.UtcNow.ToString(RoundTripIso8601Format);
         }
 
         /// <summary>
@@ -24,7 +24,7 @@ namespace BackendFramework.Helper
         /// </summary>
         public static string ToUtcIso8601(DateTime dateTime)
         {
-            return dateTime.ToString(RoadTripIso8601Format);
+            return dateTime.ToString(RoundTripIso8601Format);
         }
     }
 }

--- a/Backend/Helper/Time.cs
+++ b/Backend/Helper/Time.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace BackendFramework.Helper
+{
+    public static class Time
+    {
+        /// <summary>
+        /// Construct a string for the current DateTime in the UTC timezone formatted in ISO 8601 format.
+        /// </summary>
+        /// <remarks>
+        /// This format is suitable for storage into the database because it is possible to round trip the strings
+        /// because they retain timezone information.
+        /// </remarks>
+        public static string UtcNowIso8601()
+        {
+            return DateTime.UtcNow.ToString("o");
+        }
+    }
+}
+

--- a/Backend/Models/Word.cs
+++ b/Backend/Models/Word.cs
@@ -16,7 +16,8 @@ namespace BackendFramework.Models
         public string Id { get; set; }
 
         /// <summary>
-        /// This Guid is important for Lift round-tripping with other applications and must remain stable through Word edits.
+        /// This Guid is important for Lift round-tripping with other applications and must remain stable through
+        /// Word edits.
         /// </summary>
         /// <remarks>Only nullable for legacy, can be removed once all projects are updated.</remarks>
         [BsonElement("guid")]

--- a/Backend/Services/LiftApiServices.cs
+++ b/Backend/Services/LiftApiServices.cs
@@ -530,7 +530,12 @@ namespace BackendFramework.Services
             /// </summary>
             public async void FinishEntry(LiftEntry entry)
             {
-                var newWord = new Word { Guid = entry.Guid };
+                var newWord = new Word
+                {
+                    Guid = entry.Guid,
+                    Created = Time.ToUtcIso8601(entry.DateCreated),
+                    Modified = Time.ToUtcIso8601(entry.DateModified)
+                };
                 var proj = await _projectService.GetProject(_projectId);
                 if (proj is null)
                 {

--- a/Backend/Services/WordApiServices.cs
+++ b/Backend/Services/WordApiServices.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using BackendFramework.Helper;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
 
@@ -113,7 +114,7 @@ namespace BackendFramework.Services
             {
                 word.Id = "";
                 word.ProjectId = projectId;
-                word.Modified = DateTime.UtcNow.ToLongDateString();
+                word.Modified = Time.UtcNowIso8601();
 
                 // Keep track of the old word, adding it to the history.
                 word.History.Add(wordId);

--- a/Backend/Services/WordRepository.cs
+++ b/Backend/Services/WordRepository.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using BackendFramework.Helper;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
 using MongoDB.Driver;
@@ -59,7 +60,10 @@ namespace BackendFramework.Services
         public async Task<Word> Create(Word word)
         {
             PopulateWordGuids(word);
-            word.Created = DateTime.UtcNow.ToLongTimeString();
+            // Use Roundtrip-suitable ISO 8601 format.
+            // https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#Roundtrip
+            word.Created = Time.UtcNowIso8601();
+            word.Modified = Time.UtcNowIso8601();
             await _wordDatabase.Words.InsertOneAsync(word);
             await AddFrontier(word);
             return word;

--- a/Backend/Services/WordRepository.cs
+++ b/Backend/Services/WordRepository.cs
@@ -60,15 +60,25 @@ namespace BackendFramework.Services
         public async Task<Word> Create(Word word)
         {
             PopulateWordGuids(word);
-            // Use Roundtrip-suitable ISO 8601 format.
-            // https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#Roundtrip
-            word.Created = Time.UtcNowIso8601();
-            word.Modified = Time.UtcNowIso8601();
+
+            // Only update date time stamps if they are blank to allow services such as LiftApiService to set before
+            // creation.
+            if (word.Created.Length == 0)
+            {
+                // Use Roundtrip-suitable ISO 8601 format.
+                word.Created = Time.UtcNowIso8601();
+            }
+            if (word.Modified.Length == 0)
+            {
+                word.Modified = Time.UtcNowIso8601();
+            }
+
             await _wordDatabase.Words.InsertOneAsync(word);
             await AddFrontier(word);
             return word;
         }
 
+        /// <remarks> This method should be removed once all legacy data has been converted. </remarks>
         internal static void PopulateWordGuids(Word word)
         {
             if (word.Guid is null || Guid.Empty.Equals(word.Guid))


### PR DESCRIPTION
Subtask of #960

- Use ISO 8601 date time format to allow for reliable round tripping of date times through database
- Set `Word.Modified` to creation time when `Word` is created
- Properly import `Creation` and `Modified` date times during Lift import

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/962)
<!-- Reviewable:end -->
