### PR TITLE
Add .well-known folder to ssl configuration

### DIFF
--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -25,6 +25,10 @@ server {
     # Allow clients to import large projects.
     client_max_body_size  250m;
 
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
     location /v1 {
         proxy_pass         http://backend:5000;
         proxy_http_version 1.1;


### PR DESCRIPTION
Update the nginx configuration templates to add the location for `/.well-known/acme-challenge` to the ssl server configuration.  This is required when an external service provides the redirection of http traffic to an https site.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/969)
<!-- Reviewable:end -->
