### PR TITLE
Remove CORS headers from production

### DIFF
--- a/Backend/Startup.cs
+++ b/Backend/Startup.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using BackendFramework.Contexts;
 using BackendFramework.Helper;
@@ -86,18 +88,21 @@ namespace BackendFramework
         /// </summary>
         public void ConfigureServices(IServiceCollection services)
         {
-            // TODO: When moving to NGINX deployment, can remove this configure.
-            //    CORS isn't needed when a reverse proxy proxies all frontend and backend traffic.
-            var corsOrigin = Environment.GetEnvironmentVariable("COMBINE_CORS_ORIGIN") ?? "http://localhost:3000";
-            services.AddCors(options =>
+            // Only add CORS rules if running outside of Docker/NGINX environment. Rules are not needed in a
+            // true reverse proxy setup.
+            if (!IsInContainer())
             {
-                options.AddPolicy(AllowedOrigins,
-                    builder => builder
-                        .AllowAnyHeader()
-                        .AllowAnyMethod()
-                        .WithOrigins(corsOrigin)
-                        .AllowCredentials());
-            });
+                services.AddCors(options =>
+                {
+                    options.AddPolicy(AllowedOrigins,
+                        builder => builder
+                            .AllowAnyHeader()
+                            .AllowAnyMethod()
+                            // Add URL for React CLI using during development.
+                            .WithOrigins("http://localhost:3000")
+                            .AllowCredentials());
+                });
+            }
 
             // Configure JWT Authentication
             const string secretKeyEnvName = "COMBINE_JWT_SECRET_KEY";

--- a/Backend/Startup.cs
+++ b/Backend/Startup.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using BackendFramework.Contexts;
 using BackendFramework.Helper;


### PR DESCRIPTION
Closes #992 

- No longer read `COMBINE_CORS_ORIGIN` env variable
- Increase security slightly by no longer setting any CORS headers if running within Docker/production

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/996)
<!-- Reviewable:end -->
