### PR TITLE
Enable Gzip compression in NGINX

### DIFF
--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -25,6 +25,42 @@ server {
     # Allow clients to import large projects.
     client_max_body_size  250m;
 
+    # Gzip responses to decrease page loading time.
+    # https://www.digitalocean.com/community/tutorials/
+    #   how-to-increase-pagespeed-score-by-changing-your-nginx-configuration-on-ubuntu-16-04
+    gzip               on;
+    gzip_comp_level    5;
+    gzip_min_length    256;
+    gzip_proxied       any;
+    gzip_vary          on;
+
+    gzip_types
+    application/atom+xml
+    application/javascript
+    application/json
+    application/ld+json
+    application/manifest+json
+    application/rss+xml
+    application/vnd.geo+json
+    application/vnd.ms-fontobject
+    application/x-font-ttf
+    application/x-web-app-manifest+json
+    application/xhtml+xml
+    application/xml
+    font/opentype
+    image/bmp
+    image/svg+xml
+    image/x-icon
+    text/cache-manifest
+    text/css
+    text/plain
+    text/vcard
+    text/vnd.rim.location.xloc
+    text/vtt
+    text/x-component
+    text/x-cross-domain-policy;
+    # text/html is always compressed by gzip module
+
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;
     }


### PR DESCRIPTION
Enable Gzip compression on all common compressible response formats in NGINX.

This should increase page loading speeds, especially for users with slower network connection speeds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/997)
<!-- Reviewable:end -->
