### PR TITLE
Cause npm run lint to fail if warnings are detected

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "import-sem-doms": "tsc scripts/importSemanticDomains.ts && node scripts/importSemanticDomains.js",
     "license-report": "npm install && license-checker --production",
     "license-summary": "npm install && license-checker --production --summary",
-    "lint": "eslint --ext js,ts,tsx,jsx src",
+    "lint": "eslint --max-warnings=0 --ext js,ts,tsx,jsx src",
     "predatabase": "tsc scripts/setupMongo.ts && node scripts/setupMongo.js",
     "set-admin-user": "tsc scripts/setAdminUser.ts && node scripts/setAdminUser.js",
     "start": "npm install && npm-run-all --parallel backend database frontend",


### PR DESCRIPTION
Currently if `npm run lint` is run and warnings are detected, the process does not fail. This means that when `npm run lint` is run on CI, it will not fail if ESLint warnings are pushed.

Fix this by failing if any warnings are detected by ESLint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/999)
<!-- Reviewable:end -->
