### PR TITLE
Major goal- and step-loading refactor.

### DIFF
--- a/Backend.Tests/Controllers/UserEditControllerTests.cs
+++ b/Backend.Tests/Controllers/UserEditControllerTests.cs
@@ -100,25 +100,25 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public void TestAddEditsToGoal()
+        public void TestAddGoalToUserEdit()
         {
             var userEdit = RandomUserEdit();
             _userEditRepo.Create(userEdit);
-            var newEditStep = new Edit();
-            newEditStep.StepData.Add("This is a new step");
-            var updateEdit = userEdit.Clone();
-            updateEdit.Edits.Add(newEditStep);
+            var newEdit = new Edit();
+            newEdit.StepData.Add("This is a new step");
+            var updatedUserEdit = userEdit.Clone();
+            updatedUserEdit.Edits.Add(newEdit);
 
-            _ = _userEditController.Post(_projId, userEdit.Id, newEditStep).Result;
+            _ = _userEditController.Post(_projId, userEdit.Id, newEdit).Result;
 
             var allUserEdits = _userEditRepo.GetAllUserEdits(_projId).Result;
-            Assert.Contains(updateEdit, allUserEdits);
+            Assert.Contains(updatedUserEdit, allUserEdits);
         }
 
         [Test]
-        public void TestGoalToUserEdit()
+        public void TestAddStepToGoal()
         {
-            // Generate db entry to test
+            // Generate db entry to test.
             var rnd = new Random();
             var count = rnd.Next(1, 13);
 
@@ -128,17 +128,17 @@ namespace Backend.Tests.Controllers
             }
             var origUserEdit = _userEditRepo.Create(RandomUserEdit()).Result;
 
-            // Generate correct result for comparison
+            // Generate correct result for comparison.
             var modUserEdit = origUserEdit.Clone();
-            const string stringUserEdit = "This is another step added";
-            modUserEdit.Edits[0].StepData.Add(stringUserEdit);
-
-            // Create wrapper object
+            const string stringStep = "This is another step added.";
             const int modGoalIndex = 0;
-            var wrapperObj = new UserEditStepWrapper(modGoalIndex, stringUserEdit);
+            modUserEdit.Edits[modGoalIndex].StepData.Add(stringStep);
 
-            _ = _userEditController.Put(_projId, origUserEdit.Id, wrapperObj);
+            // Create and put wrapper object.
+            var stepWrapperObj = new UserEditStepWrapper(modGoalIndex, stringStep);
+            _ = _userEditController.Put(_projId, origUserEdit.Id, stepWrapperObj);
 
+            // Step count should have increased by 1.
             Assert.That(_userEditRepo.GetAllUserEdits(_projId).Result, Has.Count.EqualTo(count + 1));
 
             var userEdit = _userEditRepo.GetUserEdit(_projId, origUserEdit.Id).Result;
@@ -147,7 +147,27 @@ namespace Backend.Tests.Controllers
                 Assert.Fail();
                 return;
             }
-            Assert.Contains(stringUserEdit, userEdit.Edits[modGoalIndex].StepData);
+            Assert.Contains(stringStep, userEdit.Edits[modGoalIndex].StepData);
+
+            // Now update a step within the goal.
+            const string modStringStep = "This is a replacement step.";
+            const int modStepIndex = 1;
+            modUserEdit.Edits[modGoalIndex].StepData[modStepIndex] = modStringStep;
+
+            // Create and put wrapper object.
+            stepWrapperObj = new UserEditStepWrapper(modGoalIndex, modStringStep, modStepIndex);
+            _ = _userEditController.Put(_projId, origUserEdit.Id, stepWrapperObj);
+
+            // Step count should not have further increased.
+            Assert.That(_userEditRepo.GetAllUserEdits(_projId).Result, Has.Count.EqualTo(count + 1));
+
+            userEdit = _userEditRepo.GetUserEdit(_projId, origUserEdit.Id).Result;
+            if (userEdit is null)
+            {
+                Assert.Fail();
+                return;
+            }
+            Assert.Contains(modStringStep, userEdit.Edits[modGoalIndex].StepData);
         }
 
         [Test]

--- a/Backend.Tests/Controllers/UserEditControllerTests.cs
+++ b/Backend.Tests/Controllers/UserEditControllerTests.cs
@@ -135,7 +135,7 @@ namespace Backend.Tests.Controllers
 
             // Create wrapper object
             const int modGoalIndex = 0;
-            var wrapperObj = new UserEditObjectWrapper(modGoalIndex, stringUserEdit);
+            var wrapperObj = new UserEditStepWrapper(modGoalIndex, stringUserEdit);
 
             _ = _userEditController.Put(_projId, origUserEdit.Id, wrapperObj);
 

--- a/Backend/Controllers/UserEditController.cs
+++ b/Backend/Controllers/UserEditController.cs
@@ -220,10 +220,8 @@ namespace BackendFramework.Controllers
             {
                 return new BadRequestObjectResult("Goal index out of range.");
             }
-            Console.WriteLine(stepEdit.StepIndex);
             var maxStepIndex = document.Edits[stepEdit.GoalIndex].StepData.Count;
             var stepIndex = stepEdit.StepIndex ?? maxStepIndex;
-            Console.WriteLine(stepIndex);
             if (stepIndex < 0 || stepIndex > maxStepIndex)
             {
                 return new BadRequestObjectResult("Step index out of range.");

--- a/Backend/Interfaces/IUserEditService.cs
+++ b/Backend/Interfaces/IUserEditService.cs
@@ -6,7 +6,8 @@ namespace BackendFramework.Interfaces
 {
     public interface IUserEditService
     {
-        Task<bool> AddStepToGoal(string projectId, string userEditId, int goalIndex, string userEdit);
         Task<Tuple<bool, int>> AddGoalToUserEdit(string projectId, string userEditId, Edit edit);
+        Task<bool> AddStepToGoal(string projectId, string userEditId, int goalIndex, string stepString);
+        Task<bool> UpdateStepInGoal(string projectId, string userEditId, int goalIndex, string stepString, int stepIndex);
     }
 }

--- a/Backend/Models/UserEdit.cs
+++ b/Backend/Models/UserEdit.cs
@@ -76,6 +76,8 @@ namespace BackendFramework.Models
         public string StepString { get; set; }
 
         [BsonElement("stepIndex")]
+        /* A null StepIndex implies index equal to the length of the step list--
+         * i.e. the step is to be added to the end of the list. */
         public int? StepIndex { get; set; }
 
         public UserEditStepWrapper(int goalIndex, string stepString, int? stepIndex = null)

--- a/Backend/Models/UserEdit.cs
+++ b/Backend/Models/UserEdit.cs
@@ -67,33 +67,38 @@ namespace BackendFramework.Models
         }
     }
 
-    public class UserEditObjectWrapper
+    public class UserEditStepWrapper
     {
         [BsonElement("goalIndex")]
         public int GoalIndex { get; set; }
 
-        [BsonElement("newEdit")]
-        public string NewEdit { get; set; }
+        [BsonElement("stepString")]
+        public string StepString { get; set; }
 
-        public UserEditObjectWrapper(int goalIndex, string newEdit)
+        [BsonElement("stepIndex")]
+        public int? StepIndex { get; set; }
+
+        public UserEditStepWrapper(int goalIndex, string stepString, int? stepIndex = null)
         {
             GoalIndex = goalIndex;
-            NewEdit = newEdit;
+            StepString = stepString;
+            StepIndex = stepIndex;
         }
 
         public override bool Equals(object? obj)
         {
-            if (!(obj is UserEditObjectWrapper other) || GetType() != obj.GetType())
+            if (!(obj is UserEditStepWrapper other) || GetType() != obj.GetType())
             {
                 return false;
             }
 
-            return other.GoalIndex.Equals(GoalIndex) && other.NewEdit.Equals(NewEdit);
+            return other.GoalIndex.Equals(GoalIndex)
+                && other.StepString.Equals(StepString) && other.StepIndex.Equals(StepIndex);
         }
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(GoalIndex, NewEdit);
+            return HashCode.Combine(GoalIndex, StepString, StepIndex);
         }
     }
 

--- a/src/backend/index.tsx
+++ b/src/backend/index.tsx
@@ -2,7 +2,7 @@ import axios from "axios";
 
 import authHeader from "components/Login/AuthHeaders";
 import history, { Path } from "browserHistory";
-import { Goal } from "types/goals";
+import { Goal, GoalStep } from "types/goals";
 import { Project } from "types/project";
 import { RuntimeConfig } from "types/runtimeConfig";
 import SemanticDomainWithSubdomains from "types/SemanticDomain";
@@ -400,10 +400,11 @@ export async function avatarSrc(userId: string): Promise<string> {
   return `data:${resp.headers["content-type"].toLowerCase()};base64,${image}`;
 }
 
+/** Returns index of added goal */
 export async function addGoalToUserEdit(
   userEditId: string,
   goal: Goal
-): Promise<Goal> {
+): Promise<number> {
   const stepData = JSON.stringify(goal.steps);
   const userEditTuple = {
     goalType: goal.goalType.toString(),
@@ -420,17 +421,19 @@ export async function addGoalToUserEdit(
   return resp.data;
 }
 
+/** Returns index of step within specified goal */
 export async function addStepToGoal(
   userEditId: string,
   goalIndex: number,
-  goal: Goal
-): Promise<Goal> {
-  const newEdit = JSON.stringify(goal.steps);
-  const userEditTuple = { goalIndex, newEdit };
+  step: GoalStep,
+  stepIndex?: number // If undefined, step will be added to end.
+): Promise<number> {
+  const stepString = JSON.stringify(step);
+  const stepEditTuple = { goalIndex, stepString, stepIndex };
   return await backendServer
     .put(
       `projects/${LocalStorage.getProjectId()}/useredits/${userEditId}`,
-      userEditTuple,
+      stepEditTuple,
       {
         headers: { ...authHeader() },
       }

--- a/src/backend/index.tsx
+++ b/src/backend/index.tsx
@@ -400,16 +400,20 @@ export async function avatarSrc(userId: string): Promise<string> {
   return `data:${resp.headers["content-type"].toLowerCase()};base64,${image}`;
 }
 
+function convertGoalToBackendEdit(goal: Goal) {
+  const stepData = goal.steps.map((s) => JSON.stringify(s));
+  return {
+    goalType: goal.goalType.toString(),
+    stepData,
+  };
+}
+
 /** Returns index of added goal */
 export async function addGoalToUserEdit(
   userEditId: string,
   goal: Goal
 ): Promise<number> {
-  const stepData = JSON.stringify(goal.steps);
-  const userEditTuple = {
-    goalType: goal.goalType.toString(),
-    stepData: [stepData],
-  };
+  const userEditTuple = convertGoalToBackendEdit(goal);
   const projectId = LocalStorage.getProjectId();
   const resp = await backendServer.post(
     `projects/${projectId}/useredits/${userEditId}`,

--- a/src/components/DataEntry/DataEntryTable/tests/DataEntryTable.test.tsx
+++ b/src/components/DataEntry/DataEntryTable/tests/DataEntryTable.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Provider } from "react-redux";
 import renderer, {
   ReactTestInstance,

--- a/src/components/GoalTimeline/GoalDisplay/HorizontalDisplay.tsx
+++ b/src/components/GoalTimeline/GoalDisplay/HorizontalDisplay.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Translate } from "react-localize-redux";
 import { Typography, GridList, GridListTile, Button } from "@material-ui/core";
 
-import { Goal } from "types/goals";
+import { Goal, GoalType } from "types/goals";
 
 const style = {
   container: {
@@ -23,7 +23,7 @@ interface HorizontalDisplayProps {
   width: number;
   numPanes: number;
   scrollToEnd: boolean;
-  handleChange: (name: string) => void;
+  handleChange: (goalType: GoalType) => void;
 }
 
 export default class HorizontalDisplay extends React.Component<HorizontalDisplayProps> {
@@ -47,8 +47,9 @@ export default class HorizontalDisplay extends React.Component<HorizontalDisplay
             { ...style.buttonStyle, width: this.optionWidth + "vw" } as any
           }
           onClick={() => {
-            this.props.handleChange(goal.name);
+            this.props.handleChange(goal.goalType);
           }}
+          disabled={goal.completed}
         >
           <Typography variant={"h6"}>
             <Translate id={goal.name + ".title"} />

--- a/src/components/GoalTimeline/GoalDisplay/VerticalDisplay.tsx
+++ b/src/components/GoalTimeline/GoalDisplay/VerticalDisplay.tsx
@@ -2,7 +2,7 @@ import { Typography, GridList, GridListTile, Button } from "@material-ui/core";
 import React from "react";
 import { Translate } from "react-localize-redux";
 
-import { Goal } from "types/goals";
+import { Goal, GoalType } from "types/goals";
 
 const style = {
   container: {
@@ -23,7 +23,7 @@ interface VerticalDisplayProps {
   height: number;
   numPanes: number;
   scrollToEnd: boolean;
-  handleChange: (name: string) => void;
+  handleChange: (goalType: GoalType) => void;
 }
 
 interface VerticalDisplayStates {
@@ -54,9 +54,10 @@ export default class VerticalDisplay extends React.Component<
             { ...style.buttonStyle, height: this.optionHeight + "vw" } as any
           }
           onClick={() => {
-            this.props.handleChange(goal.name);
+            this.props.handleChange(goal.goalType);
           }}
           fullWidth
+          disabled={goal.completed}
         >
           <Typography variant={"h6"}>
             <Translate id={goal.name + ".title"} />

--- a/src/components/GoalTimeline/GoalsActions.tsx
+++ b/src/components/GoalTimeline/GoalsActions.tsx
@@ -185,7 +185,7 @@ export function getUserEditId(): string | undefined {
   }
 }
 
-function convertEditToGoal(edit: Edit): Goal {
+export function convertEditToGoal(edit: Edit): Goal {
   const goal = goalTypeToGoal(edit.goalType);
   goal.steps = edit.stepData.map((stepString) => JSON.parse(stepString));
   goal.completed = true;

--- a/src/components/GoalTimeline/GoalsActions.tsx
+++ b/src/components/GoalTimeline/GoalsActions.tsx
@@ -1,8 +1,8 @@
 import * as Backend from "backend";
 import * as LocalStorage from "backend/localStorage";
-import { MergeDupData } from "goals/MergeDupGoal/MergeDups";
+import { MergeDupData, MergeDups } from "goals/MergeDupGoal/MergeDups";
 import {
-  getMergeStepData,
+  dispatchMergeStepData,
   loadMergeDupsData,
 } from "goals/MergeDupGoal/MergeDupStep/MergeDupStepActions";
 import history, { Path } from "browserHistory";
@@ -67,7 +67,7 @@ export function asyncLoadExistingUserEdits(
 ) {
   return async (dispatch: StoreStateDispatch) => {
     const userEdit = await Backend.getUserEditById(projectId, userEditId);
-    const history = convertEditsToGoals(userEdit.edits);
+    const history = userEdit.edits.map((e) => convertEditToGoal(e));
     dispatch(loadUserEdits(history));
   };
 }
@@ -91,62 +91,74 @@ export function asyncAddGoalToHistory(goal: Goal) {
   return async (dispatch: StoreStateDispatch) => {
     const userEditId = getUserEditId();
     if (userEditId) {
-      goal = await dispatch(asyncLoadGoalData(goal));
-      const goalIndex = await Backend.addGoalToUserEdit(userEditId, goal);
+      // Load data.
+      goal = await loadGoalData(goal);
+      goal = updateStepFromData(goal);
+
+      // Dispatch to state.
+      dispatch(dispatchStepData(goal));
       dispatch(addGoalToHistory(goal));
+
+      // Save to database.
+      const goalIndex = await Backend.addGoalToUserEdit(userEditId, goal);
+      await saveCurrentStep(goal, goalIndex);
+
+      // Serve goal.
       history.push(`${Path.Goals}/${goalIndex}`);
     }
-  };
-}
-
-export function asyncLoadGoalData(goal: Goal) {
-  return async (dispatch: StoreStateDispatch) => {
-    switch (goal.goalType) {
-      case GoalType.MergeDups:
-        goal = await loadMergeDupsData(goal);
-        await dispatch(asyncRefreshWords());
-        break;
-
-      default:
-        break;
-    }
-    return goal;
   };
 }
 
 export function asyncAdvanceStep() {
   return async (dispatch: StoreStateDispatch, getState: () => StoreState) => {
     const goalHistory = getState().goalsState.historyState.history;
-    const goal = goalHistory[goalHistory.length - 1];
+    const goalIndex = goalHistory.length - 1;
+    let goal = goalHistory[goalIndex];
     goal.currentStep++;
-    // Push the current step into the history state and load the data.
-    await dispatch(asyncRefreshWords());
+    if (goal.currentStep < goal.numSteps) {
+      // Update data.
+      goal = updateStepFromData(goal);
+
+      // Dispatch to state.
+      dispatch(dispatchStepData(goal));
+      dispatch(updateGoal(goal));
+
+      // Save to database.
+      await saveCurrentStep(goal, goalIndex);
+    } else {
+      goal.completed = true;
+      dispatch(updateGoal(goal));
+      history.push(Path.Goals);
+    }
   };
 }
 
-export function asyncRefreshWords() {
-  return async (dispatch: StoreStateDispatch, getState: () => StoreState) => {
-    let goalHistory = getState().goalsState.historyState.history;
-    let goal = goalHistory[goalHistory.length - 1];
-
-    // Push the current step into the history state and load the data.
-    await updateStep(dispatch, goal, goalHistory).then(() => {
-      goalHistory = getState().goalsState.historyState.history;
-      goal = goalHistory[goalHistory.length - 1];
-      if (goal.currentStep < goal.numSteps) {
-        if (goal.goalType === GoalType.MergeDups) {
-          getMergeStepData(goal, dispatch);
-        }
-      } else {
-        history.push(Path.Goals);
-      }
-    });
+export function dispatchStepData(goal: Goal) {
+  return (dispatch: StoreStateDispatch) => {
+    switch (goal.goalType) {
+      case GoalType.MergeDups:
+        dispatchMergeStepData(goal, dispatch);
+        break;
+      default:
+        break;
+    }
   };
 }
 
 // Helper Funtions
 
-export function updateStepData(goal: Goal): Goal {
+export async function loadGoalData(goal: Goal) {
+  switch (goal.goalType) {
+    case GoalType.MergeDups:
+      goal = await loadMergeDupsData(goal);
+      break;
+    default:
+      break;
+  }
+  return goal;
+}
+
+export function updateStepFromData(goal: Goal): Goal {
   switch (goal.goalType) {
     case GoalType.MergeDups: {
       const currentGoalData = goal.data as MergeDupData;
@@ -173,24 +185,17 @@ export function getUserEditId(): string | undefined {
   }
 }
 
-function convertEditsToGoals(edits: Edit[]): Goal[] {
-  return edits.map((edit) => goalTypeToGoal(edit.goalType));
+function convertEditToGoal(edit: Edit): Goal {
+  const goal = goalTypeToGoal(edit.goalType);
+  goal.steps = edit.stepData.map((stepString) => JSON.parse(stepString));
+  goal.completed = true;
+  return goal;
 }
 
-async function updateStep(
-  dispatch: StoreStateDispatch,
-  goal: Goal,
-  goalHistory: Goal[]
-): Promise<void> {
-  const goalIndex = goalHistory.findIndex((g) => g.hash === goal.hash);
-  const updatedGoal = updateStepData(goal);
-  dispatch(updateGoal(updatedGoal));
-  await addStepToGoal(goalHistory[goalIndex], goalIndex);
-}
-
-async function addStepToGoal(goal: Goal, goalIndex: number) {
+async function saveCurrentStep(goal: Goal, goalIndex: number) {
   const userEditId = getUserEditId();
   if (userEditId) {
-    await Backend.addStepToGoal(userEditId, goalIndex, goal);
+    const step = goal.steps[goal.currentStep] ?? {};
+    await Backend.addStepToGoal(userEditId, goalIndex, step, goal.currentStep);
   }
 }

--- a/src/components/GoalTimeline/GoalsActions.tsx
+++ b/src/components/GoalTimeline/GoalsActions.tsx
@@ -137,7 +137,7 @@ export function dispatchStepData(goal: Goal) {
   return (dispatch: StoreStateDispatch) => {
     switch (goal.goalType) {
       case GoalType.MergeDups:
-        dispatchMergeStepData(goal, dispatch);
+        dispatch(dispatchMergeStepData(goal));
         break;
       default:
         break;
@@ -188,6 +188,7 @@ export function getUserEditId(): string | undefined {
 export function convertEditToGoal(edit: Edit): Goal {
   const goal = goalTypeToGoal(edit.goalType);
   goal.steps = edit.stepData.map((stepString) => JSON.parse(stepString));
+  goal.numSteps = goal.steps.length;
   goal.completed = true;
   return goal;
 }

--- a/src/components/GoalTimeline/GoalsActions.tsx
+++ b/src/components/GoalTimeline/GoalsActions.tsx
@@ -1,6 +1,6 @@
 import * as Backend from "backend";
 import * as LocalStorage from "backend/localStorage";
-import { MergeDupData, MergeDups } from "goals/MergeDupGoal/MergeDups";
+import { MergeDupData } from "goals/MergeDupGoal/MergeDups";
 import {
   dispatchMergeStepData,
   loadMergeDupsData,

--- a/src/components/GoalTimeline/tests/GoalTimelineActions.test.tsx
+++ b/src/components/GoalTimeline/tests/GoalTimelineActions.test.tsx
@@ -262,6 +262,11 @@ describe("GoalsActions", () => {
         expectedUpdatedGoal
       );
     });
+
+    it("should not load data for an unimplemented goal", async () => {
+      const goal = new HandleFlags();
+      expect(await actions.loadGoalData(goal)).toEqual(goal);
+    });
   });
 
   describe("updateStepFromData", () => {
@@ -280,12 +285,7 @@ describe("GoalsActions", () => {
 
     it("should not update the step data of an unimplemented goal", () => {
       const goal = new HandleFlags();
-      expect(goal.steps).toEqual([{}]);
-      expect(goal.currentStep).toEqual(0);
-
-      const updatedGoal: HandleFlags = actions.updateStepFromData(goal);
-      expect(updatedGoal.steps).toEqual([{}]);
-      expect(updatedGoal.currentStep).toEqual(0);
+      expect(actions.updateStepFromData(goal)).toEqual(goal);
     });
   });
 

--- a/src/components/GoalTimeline/tests/GoalTimelineActions.test.tsx
+++ b/src/components/GoalTimeline/tests/GoalTimelineActions.test.tsx
@@ -210,7 +210,7 @@ describe("GoalsActions", () => {
       expect(mockStore.getActions()).toEqual([addGoalToHistory]);
     });
 
-    it("should create another action to add a MergeDups to history", async () => {
+    it("should create another action to add MergeDups data", async () => {
       const goal: Goal = new MergeDups();
       goal.numSteps = maxNumSteps(goal.goalType);
       goal.steps = [
@@ -230,6 +230,30 @@ describe("GoalsActions", () => {
       const goal: Goal = new MergeDups();
       await mockStore.dispatch<any>(actions.asyncAddGoalToHistory(goal));
       expect(mockLoadMergeDupsData).toBeCalled();
+    });
+  });
+
+  describe("dispatchStepData", () => {
+    it("should not create any action for an unimplemented goal", async () => {
+      const goal: Goal = new HandleFlags();
+      await mockStore.dispatch<any>(actions.dispatchStepData(goal));
+      expect(mockStore.getActions()).toEqual([]);
+    });
+
+    it("should create an action to add MergeDups data", async () => {
+      const goal: Goal = new MergeDups();
+      goal.numSteps = maxNumSteps(goal.goalType);
+      goal.steps = [
+        {
+          words: [...goalDataMock.plannedWords[0]],
+        },
+      ];
+      await mockStore.dispatch<any>(actions.dispatchStepData(goal));
+      const setWordData: MergeTreeAction = {
+        type: MergeTreeActions.SET_DATA,
+        payload: [...goalDataMock.plannedWords[0]],
+      };
+      expect(mockStore.getActions()).toEqual([setWordData]);
     });
   });
 

--- a/src/components/GoalTimeline/tests/GoalTimelineActions.test.tsx
+++ b/src/components/GoalTimeline/tests/GoalTimelineActions.test.tsx
@@ -85,7 +85,6 @@ const mockUserId = "789";
 let mockUser = new User("", "", "");
 mockUser.id = mockUserId;
 mockUser.workedProjects[mockProjectId] = mockUserEditId;
-const mockGoal: Goal = new CreateCharInv();
 
 beforeAll(() => {
   // Save things in localStorage to restore once tests are done

--- a/src/components/GoalTimeline/tests/GoalTimelineActions.test.tsx
+++ b/src/components/GoalTimeline/tests/GoalTimelineActions.test.tsx
@@ -200,7 +200,7 @@ describe("GoalsActions", () => {
       expect(mockStore.getActions()).toEqual([addGoalToHistory]);
     });
 
-    it("should create multiple actions to add a MergeDups to history", async () => {
+    it("should create another action to add a MergeDups to history", async () => {
       const goal: Goal = new MergeDups();
       goal.numSteps = maxNumSteps(goal.goalType);
       goal.steps = [
@@ -208,18 +208,6 @@ describe("GoalsActions", () => {
           words: [...goalDataMock.plannedWords[0]],
         },
       ];
-      const mockStoreState = {
-        goalsState: {
-          historyState: {
-            history: [goal],
-          },
-          allPossibleGoals: [...defaultState.allPossibleGoals],
-          suggestionsState: {
-            suggestions: [...defaultState.suggestionsState.suggestions],
-          },
-        },
-      };
-      mockStore = createMockStore(mockStoreState);
       await mockStore.dispatch<any>(actions.asyncAddGoalToHistory(goal));
       const setWordData: MergeTreeAction = {
         type: MergeTreeActions.SET_DATA,

--- a/src/components/GoalTimeline/tests/GoalTimelineComponent.test.tsx
+++ b/src/components/GoalTimeline/tests/GoalTimelineComponent.test.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import { ReactElement } from "react";
 import { Provider } from "react-redux";
 import renderer, { ReactTestRenderer } from "react-test-renderer";
 import configureMockStore from "redux-mock-store";
@@ -41,14 +41,16 @@ beforeEach(() => {
 
 describe("GoalTimelineVertical", () => {
   describe("handleChange", () => {
-    it("Selects a goal from suggestions based on name", () => {
-      timeHandle.handleChange(goals[2].name);
-      expect(CHOOSE_GOAL).toHaveBeenCalledWith(goals[2]);
+    it("Selects a goal from suggestions", () => {
+      timeHandle.handleChange(goals[2].goalType);
+      expect(CHOOSE_GOAL).toBeCalled();
+      expect(CHOOSE_GOAL.mock.calls[0][0].goalType).toEqual(goals[2].goalType);
     });
 
-    it("Doesn't select a non-existent goal by name", () => {
-      timeHandle.handleChange("The goal is a lie");
-      expect(CHOOSE_GOAL).toHaveBeenCalledTimes(0);
+    it("Goes default for a non-existent goalType", () => {
+      timeHandle.handleChange(-2);
+      expect(CHOOSE_GOAL).toBeCalled();
+      expect(CHOOSE_GOAL.mock.calls[0][0].goalType).toEqual(-1);
     });
   });
 

--- a/src/components/GoalTimeline/tests/GoalTimelineComponent.test.tsx
+++ b/src/components/GoalTimeline/tests/GoalTimelineComponent.test.tsx
@@ -47,7 +47,7 @@ describe("GoalTimelineVertical", () => {
       expect(CHOOSE_GOAL.mock.calls[0][0].goalType).toEqual(goals[2].goalType);
     });
 
-    it("Goes default for a non-existent goalType", () => {
+    it("Defaults to generic GoalType.Default=-1 for a non-existent goalType", () => {
       timeHandle.handleChange(-2);
       expect(CHOOSE_GOAL).toBeCalled();
       expect(CHOOSE_GOAL.mock.calls[0][0].goalType).toEqual(-1);

--- a/src/goals/CreateCharInv/CreateCharInv.tsx
+++ b/src/goals/CreateCharInv/CreateCharInv.tsx
@@ -10,7 +10,7 @@ export interface CreateCharInvStepData {
 
 export class CreateCharInv extends Goal {
   constructor(
-    steps: CreateCharInvStepData[] = [],
+    steps: CreateCharInvStepData[] = [{ inventory: [] }],
     data: CreateCharInvData = { inventory: [[]] }
   ) {
     super(GoalType.CreateCharInv, GoalName.CreateCharInv, steps, data);

--- a/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepActions.tsx
+++ b/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepActions.tsx
@@ -360,15 +360,14 @@ function blacklistSetAndAllSubsets(
 
 // Used in MergeDups cases of GoalActions functions
 
-export function dispatchMergeStepData(
-  goal: MergeDups,
-  dispatch: StoreStateDispatch
-) {
-  const stepData = goal.steps[goal.currentStep] as MergeStepData;
-  if (stepData) {
-    const stepWords = stepData.words ?? [];
-    dispatch(setWordData(stepWords));
-  }
+export function dispatchMergeStepData(goal: MergeDups) {
+  return (dispatch: StoreStateDispatch) => {
+    const stepData = goal.steps[goal.currentStep] as MergeStepData;
+    if (stepData) {
+      const stepWords = stepData.words ?? [];
+      dispatch(setWordData(stepWords));
+    }
+  };
 }
 
 export async function loadMergeDupsData(goal: MergeDups) {

--- a/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepActions.tsx
+++ b/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepActions.tsx
@@ -360,13 +360,14 @@ function blacklistSetAndAllSubsets(
 
 // Used in MergeDups cases of GoalActions functions
 
-export function getMergeStepData(
+export function dispatchMergeStepData(
   goal: MergeDups,
   dispatch: StoreStateDispatch
 ) {
   const stepData = goal.steps[goal.currentStep] as MergeStepData;
   if (stepData) {
-    dispatch(setWordData(stepData.words));
+    const stepWords = stepData.words ?? [];
+    dispatch(setWordData(stepWords));
   }
 }
 

--- a/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepComponent.tsx
+++ b/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepComponent.tsx
@@ -296,6 +296,7 @@ class MergeDupStep extends React.Component<
         </Grid>
       </React.Fragment>
     ) : (
+      // ToDo: create component with translated text and button back to goals.
       "Nothing to merge."
     );
   }

--- a/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepComponent.tsx
+++ b/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepComponent.tsx
@@ -41,8 +41,6 @@ interface MergeDupStepProps {
   orderSense: (wordID: string, senseID: string, order: number) => void;
   orderDuplicate: (ref: MergeTreeReference, order: number) => void;
   mergeAll?: () => Promise<void>;
-  // Should update the words content in this GoalStep
-  refreshWords?: () => void;
   // Will advance to the next goal step and update the words content
   advanceStep?: () => void;
 }
@@ -62,9 +60,6 @@ class MergeDupStep extends React.Component<
       portrait: true,
       sideBar: { senses: [], wordID: "WORD", senseID: "SENSE" },
     };
-    if (this.props.refreshWords) {
-      this.props.refreshWords();
-    }
   }
 
   clearSideBar() {
@@ -74,9 +69,6 @@ class MergeDupStep extends React.Component<
     this.clearSideBar();
     if (this.props.advanceStep) {
       this.props.advanceStep();
-    }
-    if (this.props.refreshWords) {
-      this.props.refreshWords();
     }
   }
   saveContinue() {
@@ -236,7 +228,7 @@ class MergeDupStep extends React.Component<
   render() {
     let newId = uuid();
     //visual definition
-    return (
+    return Object.keys(this.props.words).length ? (
       <React.Fragment>
         {/* Merging pane */}
         <div
@@ -303,6 +295,8 @@ class MergeDupStep extends React.Component<
           </Grid>
         </Grid>
       </React.Fragment>
+    ) : (
+      "Nothing to merge."
     );
   }
 }

--- a/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepReducer.tsx
+++ b/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepReducer.tsx
@@ -154,6 +154,9 @@ export const mergeDupStepReducer = (
     }
 
     case MergeTreeActions.SET_DATA: {
+      if (action.payload.length === 0) {
+        return defaultState;
+      }
       let words: Hash<Word> = {};
       let senses: Hash<TreeDataSense> = {};
       let wordsTree: Hash<MergeTreeWord> = {};

--- a/src/goals/MergeDupGoal/MergeDupStep/index.tsx
+++ b/src/goals/MergeDupGoal/MergeDupStep/index.tsx
@@ -1,9 +1,6 @@
 import { connect } from "react-redux";
 
-import {
-  asyncAdvanceStep,
-  asyncRefreshWords,
-} from "components/GoalTimeline/GoalsActions";
+import { asyncAdvanceStep } from "components/GoalTimeline/GoalsActions";
 import {
   moveSenses,
   mergeAll,
@@ -25,9 +22,6 @@ function mapDispatchToProps(dispatch: StoreStateDispatch) {
   return {
     advanceStep: () => {
       dispatch(asyncAdvanceStep());
-    },
-    refreshWords: () => {
-      dispatch(asyncRefreshWords());
     },
     moveSenses: (src: MergeTreeReference[], dest: MergeTreeReference[]) => {
       dispatch(moveSenses(src, dest));

--- a/src/goals/MergeDupGoal/MergeDupStep/tests/MergeDupStepActions.test.tsx
+++ b/src/goals/MergeDupGoal/MergeDupStep/tests/MergeDupStepActions.test.tsx
@@ -2,7 +2,12 @@ import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 
 import { MergeDups } from "goals/MergeDupGoal/MergeDups";
-import { mergeAll } from "goals/MergeDupGoal/MergeDupStep/MergeDupStepActions";
+import {
+  dispatchMergeStepData,
+  mergeAll,
+  MergeTreeAction,
+  MergeTreeActions,
+} from "goals/MergeDupGoal/MergeDupStep/MergeDupStepActions";
 import {
   Hash,
   MergeData,
@@ -250,4 +255,23 @@ test("merge senses within a word", async () => {
     mockMerge4a.parent,
     mockMerge4a.children
   );
+});
+
+describe("dispatchMergeStepData", () => {
+  it("should create an action to add MergeDups data", async () => {
+    const goal = new MergeDups();
+    goal.steps = [
+      {
+        words: [...goalDataMock.plannedWords[0]],
+      },
+    ];
+
+    const mockStore = createMockStore();
+    await mockStore.dispatch<any>(dispatchMergeStepData(goal));
+    const setWordData: MergeTreeAction = {
+      type: MergeTreeActions.SET_DATA,
+      payload: [...goalDataMock.plannedWords[0]],
+    };
+    expect(mockStore.getActions()).toEqual([setWordData]);
+  });
 });

--- a/src/types/goals.tsx
+++ b/src/types/goals.tsx
@@ -1,4 +1,4 @@
-import { v1 } from "uuid";
+import { v4 } from "uuid";
 
 import {
   CreateCharInvData,
@@ -15,7 +15,7 @@ enum GoalOption {
 
 type GoalData = CreateCharInvData | MergeDupData | {}; // | OtherTypes
 
-type GoalStep = CreateCharInvStepData | MergeStepData; // | OtherTypes
+export type GoalStep = CreateCharInvStepData | MergeStepData | {}; // | OtherTypes
 
 export interface GoalProps {
   goal?: Goal;
@@ -77,7 +77,7 @@ export class Goal {
   constructor(
     type = GoalType.Default,
     name = GoalName.Default,
-    steps: GoalStep[] = [],
+    steps: GoalStep[] = [{}],
     data: GoalData = {}
   ) {
     this.goalType = type;
@@ -89,6 +89,6 @@ export class Goal {
     this.data = data;
     this.completed = false;
     this.result = GoalOption.Current;
-    this.hash = v1();
+    this.hash = v4();
   }
 }


### PR DESCRIPTION
Backend:
* update functions that handle UserEdit goals and goal steps.

Frontend:
* update `backend.tsx` function correspondingly;
* make `GoalTimeline/GoalDisplay/` create new goals to avoid mutating suggestion list, disable buttons to completed goals;
* cleanup `GoalTimeline/GoalsActions.tsx`, especially goal loading and step advancing functions;
* in `MergeDupStepComponent.tsx`, don't refresh words (leave that to general goal actions), load filler text if nothing to merge (will need a proper page);
* in `types/goals.tsx`,  give empty first step by default, replace v1 (time-based) with v4 (random) to prevent duplicate hashes when goal history loaded

Closes #186 *
Closes #588 
Closes #990 
First 1.5 boxes of #931
Related to #393, #458 , #725 (*more needed to handle in-progress multi-step goals)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1004)
<!-- Reviewable:end -->
