### PR TITLE
Fix frontend Word and Project data types to match the backend

### DIFF
--- a/src/types/project.tsx
+++ b/src/types/project.tsx
@@ -21,24 +21,22 @@ export interface Project {
   isActive: boolean;
   liftImported: boolean;
   semanticDomains: SemanticDomain[];
-  userRoles: string;
   vernacularWritingSystem: WritingSystem;
   analysisWritingSystems: WritingSystem[];
   validCharacters: string[];
   rejectedCharacters: string[];
+  autocompleteSetting: AutoComplete;
+  customFields: CustomField[];
   wordFields: string[];
   partsOfSpeech: string[];
-  customFields: CustomField[];
-  autocompleteSetting: AutoComplete;
 }
 
-export const defaultProject = {
+export const defaultProject: Project = {
   id: "",
   name: "",
   isActive: true,
   liftImported: false,
   semanticDomains: [],
-  userRoles: "",
   vernacularWritingSystem: { name: "", bcp47: "", font: "" },
   analysisWritingSystems: [{ name: "", bcp47: "", font: "" }],
   validCharacters: [],
@@ -47,7 +45,7 @@ export const defaultProject = {
   wordFields: [],
   partsOfSpeech: [],
   autocompleteSetting: AutoComplete.On,
-} as Project;
+};
 
 // Randomize properties as needed for tests.
 export function randomProject(): Project {

--- a/src/types/word.tsx
+++ b/src/types/word.tsx
@@ -16,8 +16,11 @@ export interface Gloss {
 export interface SemanticDomain {
   name: string;
   id: string;
+  // TODO: The backend also stores a description field. Should that be
+  //    exposed?
 }
 export class Sense {
+  guid?: string;
   glosses: Gloss[];
   semanticDomains: SemanticDomain[] = [];
   accessibility?: State;
@@ -31,8 +34,8 @@ export class Sense {
 }
 
 export class Note {
-  text: string;
   language: string; // bcp-47 code
+  text: string;
 
   constructor(text: string = "", lang: string = "") {
     this.text = text;
@@ -42,27 +45,25 @@ export class Note {
 
 export class Word {
   id: string = "";
+  guid: string = "";
   vernacular: string = "";
+  plural: string = "";
   senses: Sense[] = [];
   audio: string[] = [];
   created: string = "";
   modified: string = "";
+  accessibility: string = "";
   history: string[] = [];
   partOfSpeech: string = "";
   editedBy: string[] = [];
   otherField: string = "";
-  plural: string = "";
+  projectId: string = "";
   note: Note = new Note();
 }
 
 export interface MergeWord {
   wordID: string;
   senses: State[];
-}
-
-export interface MergeWords {
-  parent: Word;
-  children: MergeWord[];
 }
 
 //used in ExistingDataTable


### PR DESCRIPTION
Several type definitions in the frontend are not up to date with the backend. This is causing some data to flow through the frontend and back to the backend without it being apparent in the frontend that this is happening (JSON fields are being passed around that are persisted, but not reflected in the types).

- Also reorder the definitions to match the backend to make it easier to verify in the future


This syncing problem is something that OpenAPI solves.
- https://www.openapis.org/
- https://github.com/OpenAPITools/openapi-generator
- #309 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1019)
<!-- Reviewable:end -->
