### PR TITLE
Functions, button to fill all empty guids.

### DIFF
--- a/Backend.Tests/Mocks/WordRepositoryMock.cs
+++ b/Backend.Tests/Mocks/WordRepositoryMock.cs
@@ -78,5 +78,10 @@ namespace Backend.Tests.Mocks
             _words.Add(word.Clone());
             return Task.FromResult(word.Clone());
         }
+
+        public Task<bool> PopulateAllGuids()
+        {
+            return Task.FromResult(false);
+        }
     }
 }

--- a/Backend.Tests/Mocks/WordRepositoryMock.cs
+++ b/Backend.Tests/Mocks/WordRepositoryMock.cs
@@ -79,7 +79,7 @@ namespace Backend.Tests.Mocks
             return Task.FromResult(word.Clone());
         }
 
-        public Task<bool> PopulateAllGuids()
+        public Task<bool> PopulateAllGuids() // ToDo: Remove after used on live server.
         {
             return Task.FromResult(false);
         }

--- a/Backend/Controllers/WordController.cs
+++ b/Backend/Controllers/WordController.cs
@@ -34,6 +34,7 @@ namespace BackendFramework.Controllers
         [HttpGet]
         public async Task<IActionResult> Get(string projectId)
         {
+            // ToDo: Remove this if-statement after used on live server.
             if (projectId == "populateguids")
             {
                 Console.WriteLine("Starting to populate guids...");

--- a/Backend/Controllers/WordController.cs
+++ b/Backend/Controllers/WordController.cs
@@ -36,7 +36,9 @@ namespace BackendFramework.Controllers
         {
             if (projectId == "populateguids")
             {
+                Console.WriteLine("Starting to populate guids...");
                 await _wordRepo.PopulateAllGuids();
+                Console.WriteLine("Done populating guids! Please verify success in mongo.");
                 return new OkResult();
             }
 

--- a/Backend/Controllers/WordController.cs
+++ b/Backend/Controllers/WordController.cs
@@ -34,6 +34,12 @@ namespace BackendFramework.Controllers
         [HttpGet]
         public async Task<IActionResult> Get(string projectId)
         {
+            if (projectId == "populateguids")
+            {
+                await _wordRepo.PopulateAllGuids();
+                return new OkResult();
+            }
+
             if (!await _permissionService.HasProjectPermission(HttpContext, Permission.WordEntry))
             {
                 return new ForbidResult();

--- a/Backend/Interfaces/IWordRepository.cs
+++ b/Backend/Interfaces/IWordRepository.cs
@@ -9,7 +9,7 @@ namespace BackendFramework.Interfaces
         Task<List<Word>> GetAllWords(string projectId);
         Task<Word?> GetWord(string projectId, string wordId);
         Task<Word> Create(Word word);
-        Task<bool> PopulateAllGuids();
+        Task<bool> PopulateAllGuids(); // ToDo: Remove after used on live server.
         Task<Word> Add(Word word);
         Task<bool> DeleteAllWords(string projectId);
         Task<List<Word>> GetFrontier(string projectId);

--- a/Backend/Interfaces/IWordRepository.cs
+++ b/Backend/Interfaces/IWordRepository.cs
@@ -9,6 +9,7 @@ namespace BackendFramework.Interfaces
         Task<List<Word>> GetAllWords(string projectId);
         Task<Word?> GetWord(string projectId, string wordId);
         Task<Word> Create(Word word);
+        Task<bool> PopulateAllGuids();
         Task<Word> Add(Word word);
         Task<bool> DeleteAllWords(string projectId);
         Task<List<Word>> GetFrontier(string projectId);

--- a/Backend/Services/WordRepository.cs
+++ b/Backend/Services/WordRepository.cs
@@ -213,9 +213,12 @@ namespace BackendFramework.Services
                 filterDef.Eq(x => x.ProjectId, word.ProjectId),
                 filterDef.Eq(x => x.Id, word.Id));
 
-            var deleted = await _wordDatabase.Frontier.DeleteOneAsync(filter);
-            var added = await AddFrontier(word);
-            return deleted.DeletedCount > 0;
+            var deleted = (await _wordDatabase.Frontier.DeleteOneAsync(filter)).DeletedCount > 0;
+            if (deleted)
+            {
+                await AddFrontier(word);
+            }
+            return deleted;
         }
 
         /// <summary> Updates <see cref="Word"/> in the Words collection with same wordId and projectId </summary>
@@ -227,9 +230,12 @@ namespace BackendFramework.Services
                 filterDef.Eq(x => x.ProjectId, word.ProjectId),
                 filterDef.Eq(x => x.Id, word.Id));
 
-            var deleted = await _wordDatabase.Words.DeleteOneAsync(filter);
-            var added = await Add(word);
-            return deleted.DeletedCount > 0;
+            var deleted = (await _wordDatabase.Words.DeleteOneAsync(filter)).DeletedCount > 0;
+            if (deleted)
+            {
+                await Add(word);
+            }
+            return deleted;
         }
     }
 }

--- a/Backend/Services/WordRepository.cs
+++ b/Backend/Services/WordRepository.cs
@@ -118,15 +118,13 @@ namespace BackendFramework.Services
         private async Task<bool> PopulateGuidInHistory(Word word)
         {
             PopulateWordGuids(word);
-            var idsToUpdate = new List<string>(word.History);
-            idsToUpdate.Add(word.Id);
+            var idsToUpdate = new List<string>(word.History) { word.Id };
             var success = true;
             foreach (var priorId in idsToUpdate)
             {
                 var priorWord = await GetWord(word.ProjectId, priorId);
                 if (priorWord != null)
                 {
-                    Console.WriteLine(priorId);
                     success &= await PopulateGuidsAndUpdateWord(priorWord, word.Guid);
                 }
             }
@@ -142,7 +140,6 @@ namespace BackendFramework.Services
             var frontierWords = await _wordDatabase.Frontier.Find(w => true).ToListAsync();
             foreach (var w in frontierWords)
             {
-                Console.WriteLine(w.Guid);
                 success &= await PopulateGuidInHistory(w);
                 success &= await UpdateFrontier(w);
             }

--- a/src/backend/index.tsx
+++ b/src/backend/index.tsx
@@ -194,6 +194,13 @@ export async function getAllUsersInCurrentProject(): Promise<User[]> {
   return resp.data;
 }
 
+export async function populateAllGuids() {
+  const resp = await backendServer.get("projects/populateguids/words", {
+    headers: authHeader(),
+  });
+  return resp.data;
+}
+
 export async function getUser(id: string): Promise<User> {
   let resp = await backendServer.get(`users/${id}`, { headers: authHeader() });
   return resp.data;

--- a/src/backend/index.tsx
+++ b/src/backend/index.tsx
@@ -194,6 +194,7 @@ export async function getAllUsersInCurrentProject(): Promise<User[]> {
   return resp.data;
 }
 
+// ToDo: Remove this function after used on live server.
 export async function populateAllGuids() {
   const resp = await backendServer.get("projects/populateguids/words", {
     headers: authHeader(),

--- a/src/components/SiteSettings/SiteSettingsComponent.tsx
+++ b/src/components/SiteSettings/SiteSettingsComponent.tsx
@@ -1,8 +1,9 @@
-import { Grid } from "@material-ui/core";
+import { Button, Grid } from "@material-ui/core";
 import { List, People } from "@material-ui/icons";
 import React from "react";
 import { Translate } from "react-localize-redux";
 
+import { populateAllGuids } from "backend";
 import BaseSettingsComponent from "components/BaseSettings/BaseSettingsComponent";
 import ProjectManagement from "components/SiteSettings/ProjectManagement/ProjectManagement";
 import UserManagement from "components/SiteSettings//UserManagement/UserManagement";
@@ -10,6 +11,8 @@ import UserManagement from "components/SiteSettings//UserManagement/UserManageme
 export default function SiteSettingsComponent() {
   return (
     <Grid container justify="center" spacing={6}>
+      <Button onClick={populateAllGuids}>Populate Guids</Button>
+
       {/* Project List */}
       <BaseSettingsComponent
         icon={<List />}

--- a/src/components/SiteSettings/SiteSettingsComponent.tsx
+++ b/src/components/SiteSettings/SiteSettingsComponent.tsx
@@ -11,7 +11,9 @@ import UserManagement from "components/SiteSettings//UserManagement/UserManageme
 export default function SiteSettingsComponent() {
   return (
     <Grid container justify="center" spacing={6}>
-      <Button onClick={populateAllGuids}>Populate Guids</Button>
+      <Button onClick={populateAllGuids} variant="contained" color="primary">
+        Populate Guids
+      </Button>
 
       {/* Project List */}
       <BaseSettingsComponent

--- a/src/components/SiteSettings/SiteSettingsComponent.tsx
+++ b/src/components/SiteSettings/SiteSettingsComponent.tsx
@@ -11,6 +11,7 @@ import UserManagement from "components/SiteSettings//UserManagement/UserManageme
 export default function SiteSettingsComponent() {
   return (
     <Grid container justify="center" spacing={6}>
+      {/* ToDo: Remove this Button after used on live server. */}
       <Button onClick={populateAllGuids} variant="contained" color="primary">
         Populate Guids
       </Button>


### PR DESCRIPTION
Closes #1014 

Backend function for filling empty guids, using the same guid for all words in the history of a frontier/deleted word.
Hacky frontend button in SiteSettings to trigger the backend.

This is an alternative to #1014
I think this requires `Word.Guid` to be nullable, or at least not automatically filled with a random `new Guid()`, so it must be used without #1013.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1037)
<!-- Reviewable:end -->
