### PR TITLE
Bump Python dependencies

### DIFF
--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,6 +1,4 @@
 tox
-pytest
-pytest-cov
 mypy
 flake8
 pep8-naming

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,10 +8,6 @@ appdirs==1.4.4
     # via
     #   black
     #   virtualenv
-atomicwrites==1.4.0
-    # via pytest
-attrs==20.3.0
-    # via pytest
 black==20.8b1
     # via -r dev-requirements.in
 click==7.1.2
@@ -20,11 +16,7 @@ click==7.1.2
     #   mkdocs
     #   nltk
 colorama==0.4.4
-    # via
-    #   pytest
-    #   tox
-coverage==5.3.1
-    # via pytest-cov
+    # via tox
 distlib==0.3.1
     # via virtualenv
 filelock==3.0.12
@@ -39,21 +31,19 @@ flake8==3.8.4
     #   flake8-polyfill
 future==0.18.2
     # via lunr
-iniconfig==1.1.1
-    # via pytest
 isort==5.7.0
     # via -r dev-requirements.in
-jinja2==2.11.2
+jinja2==2.11.3
     # via
     #   -r dev-requirements.in
     #   mkdocs
-joblib==1.0.0
+joblib==1.0.1
     # via nltk
 livereload==2.6.3
     # via mkdocs
 lunr[languages]==0.5.8
     # via mkdocs
-markdown==3.3.3
+markdown==3.3.4
     # via
     #   mkdocs
     #   mkdocs-material
@@ -64,7 +54,7 @@ mccabe==0.6.1
     # via flake8
 mkdocs-material-extensions==1.0.1
     # via mkdocs-material
-mkdocs-material==6.2.5
+mkdocs-material==7.0.2
     # via
     #   -r dev-requirements.in
     #   mkdocs-material-extensions
@@ -74,42 +64,30 @@ mypy-extensions==0.4.3
     # via
     #   black
     #   mypy
-mypy==0.800
+mypy==0.812
     # via -r dev-requirements.in
 nltk==3.5
     # via lunr
-packaging==20.8
-    # via
-    #   pytest
-    #   tox
+packaging==20.9
+    # via tox
 pathspec==0.8.1
     # via black
 pep8-naming==0.11.1
     # via -r dev-requirements.in
 pluggy==0.13.1
-    # via
-    #   pytest
-    #   tox
+    # via tox
 py==1.10.0
-    # via
-    #   pytest
-    #   tox
+    # via tox
 pycodestyle==2.6.0
     # via flake8
 pyflakes==2.2.0
     # via flake8
-pygments==2.7.4
+pygments==2.8.0
     # via mkdocs-material
-pymdown-extensions==8.1
+pymdown-extensions==8.1.1
     # via mkdocs-material
 pyparsing==2.4.7
     # via packaging
-pytest-cov==2.11.1
-    # via -r dev-requirements.in
-pytest==6.2.1
-    # via
-    #   -r dev-requirements.in
-    #   pytest-cov
 pyyaml==5.4.1
     # via mkdocs
 regex==2020.11.13
@@ -125,15 +103,14 @@ six==1.15.0
 toml==0.10.2
     # via
     #   black
-    #   pytest
     #   tox
 tornado==6.1
     # via
     #   livereload
     #   mkdocs
-tox==3.21.2
+tox==3.22.0
     # via -r dev-requirements.in
-tqdm==4.56.0
+tqdm==4.58.0
     # via nltk
 typed-ast==1.4.2
     # via
@@ -143,5 +120,5 @@ typing-extensions==3.7.4.3
     # via
     #   black
     #   mypy
-virtualenv==20.4.0
+virtualenv==20.4.2
     # via tox


### PR DESCRIPTION
- Bump Python dependencies
- Remove unused `pytest` and `pytest-cov`. They were included accidently when using another Python project as an example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1038)
<!-- Reviewable:end -->
