### PR TITLE
Improve code quality for combine maintenance scripts

### DIFF
--- a/deploy/roles/combine_maintenance/files/add_user_to_proj.py
+++ b/deploy/roles/combine_maintenance/files/add_user_to_proj.py
@@ -88,17 +88,17 @@ def main():
         #      a. create a document in the UserRolesCollection,
         if args.admin:
             user_permissions = [
-                Permission.DeleteEditSettingsAndUsers,
-                Permission.ImportExport,
-                Permission.MergeAndCharSet,
-                Permission.Unused,
-                Permission.WordEntry,
+                int(Permission.DeleteEditSettingsAndUsers),
+                int(Permission.ImportExport),
+                int(Permission.MergeAndCharSet),
+                int(Permission.Unused),
+                int(Permission.WordEntry),
             ]
         else:
             user_permissions = [
-                Permission.MergeAndCharSet,
-                Permission.Unused,
-                Permission.WordEntry,
+                int(Permission.MergeAndCharSet),
+                int(Permission.Unused),
+                int(Permission.WordEntry),
             ]
         insert_doc = f'{{ "permissions" : {user_permissions}, "projectId" : "{proj_id}" }}'
         insert_result = db_cmd(f"db.UserRolesCollection.insertOne({insert_doc})")

--- a/deploy/roles/combine_maintenance/files/add_user_to_proj.py
+++ b/deploy/roles/combine_maintenance/files/add_user_to_proj.py
@@ -20,15 +20,14 @@ To add the user to the project, we need to:
 import argparse
 import sys
 
-from maint_utils import db_cmd, get_project_id, get_user_id
+from maint_utils import Permission, db_cmd, get_project_id, get_user_id
 
 
 def parse_args() -> argparse.Namespace:
     """Parse the command line arguments."""
     parser = argparse.ArgumentParser(
         description="Add a user to a project on TheCombine. "
-        "The user can be specified by his/her username or "
-        "by his/her e-mail address.",
+        "The user can be specified by username or e-mail address.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
@@ -88,9 +87,19 @@ def main():
         #  3. The user is not in the project:
         #      a. create a document in the UserRolesCollection,
         if args.admin:
-            user_permissions = [5, 4, 3, 2, 1]
+            user_permissions = [
+                Permission.DeleteEditSettingsAndUsers,
+                Permission.ImportExport,
+                Permission.MergeAndCharSet,
+                Permission.Unused,
+                Permission.WordEntry,
+            ]
         else:
-            user_permissions = [3, 2, 1]
+            user_permissions = [
+                Permission.MergeAndCharSet,
+                Permission.Unused,
+                Permission.WordEntry,
+            ]
         insert_doc = f'{{ "permissions" : {user_permissions}, "projectId" : "{proj_id}" }}'
         insert_result = db_cmd(f"db.UserRolesCollection.insertOne({insert_doc})")
         if insert_result is not None:

--- a/deploy/roles/combine_maintenance/files/add_user_to_proj.py
+++ b/deploy/roles/combine_maintenance/files/add_user_to_proj.py
@@ -26,9 +26,9 @@ from maint_utils import db_cmd, get_project_id, get_user_id
 def parse_args() -> argparse.Namespace:
     """Parse the command line arguments."""
     parser = argparse.ArgumentParser(
-        description="""Add a user to a project on TheCombine. """
-        """The user can be specified by his/her username or """
-        """by his/her e-mail address.""",
+        description="Add a user to a project on TheCombine. "
+        "The user can be specified by his/her username or "
+        "by his/her e-mail address.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
@@ -61,7 +61,7 @@ def main():
     proj_id = get_project_id(args.project)
     if proj_id is None:
         print(f"Cannot find project {args.project}")
-        sys.exit(2)
+        sys.exit(1)
     if args.verbose:
         print(f"Project ID: {proj_id}")
 
@@ -101,12 +101,12 @@ def main():
             add_role_result = db_cmd(f"db.UsersCollection.updateOne({select_user}, {update_user})")
             if add_role_result is None:
                 print(f"Could not add new role to {args.user}.", file=sys.stderr)
-                sys.exit(3)
+                sys.exit(1)
             elif args.verbose:
                 print(f"{args.user} added to {args.project} with permissions {user_permissions}")
         else:
             print(f"Could not create role for {args.user} in {args.project}.", file=sys.stderr)
-            sys.exit(4)
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/deploy/roles/combine_maintenance/files/add_user_to_proj.py
+++ b/deploy/roles/combine_maintenance/files/add_user_to_proj.py
@@ -48,6 +48,22 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     """Add a user to a project."""
     args = parse_args()
+    # 0. Define user permission sets
+    if args.admin:
+        user_permissions = [
+            int(Permission.DeleteEditSettingsAndUsers),
+            int(Permission.ImportExport),
+            int(Permission.MergeAndCharSet),
+            int(Permission.Unused),
+            int(Permission.WordEntry),
+        ]
+    else:
+        user_permissions = [
+            int(Permission.MergeAndCharSet),
+            int(Permission.Unused),
+            int(Permission.WordEntry),
+        ]
+
     # 1. Lookup the user id
     user_id = get_user_id(args.user)
     if user_id is None:
@@ -79,10 +95,10 @@ def main() -> None:
         if args.verbose:
             print(f"UserRole ID: {user_role_id}")
         select_role = f'{{ _id: ObjectId("{user_role_id}")}}'
-        update_role = '{ $set: { "permissions" : [5,4,3,2,1]} }'
+        update_role = f'{{ $set: {{"permissions" : {user_permissions}}} }}'
         db_cmd(f"db.UserRolesCollection.findOneAndUpdate({select_role}, {update_role})")
         if args.verbose:
-            print(f"Updated Role {user_role_id} with permissions [5,4,3,2,1]")
+            print(f"Updated Role {user_role_id} with permissions {user_permissions}")
     else:
         #  3. The user is not in the project:
         #      a. create a document in the UserRolesCollection,

--- a/deploy/roles/combine_maintenance/files/maint_utils.py
+++ b/deploy/roles/combine_maintenance/files/maint_utils.py
@@ -1,11 +1,23 @@
 #!/usr/bin/env python3
 """Run a command in a docker container and return a subprocess.CompletedProcess."""
 
+import enum
 import json
 import re
 import subprocess
 import sys
 from typing import Any, Dict, List, Optional
+
+
+@enum.unique
+class Permission(enum.Enum):
+    """Define enumerated type for Combine user permissions."""
+
+    WordEntry = 1
+    Unused = 2
+    MergeAndCharSet = 3
+    ImportExport = 4
+    DeleteEditSettingsAndUsers = 5
 
 
 def run_docker_cmd(service: str, cmd: List[str]) -> subprocess.CompletedProcess:

--- a/deploy/roles/combine_maintenance/files/maint_utils.py
+++ b/deploy/roles/combine_maintenance/files/maint_utils.py
@@ -78,7 +78,7 @@ def get_project_id(project_name: str) -> Optional[str]:
 
     if len(results) == 1:
         return results[0]["_id"]
-    elif len(results) > 1:
+    if len(results) > 1:
         print(f"More than one project is named {project_name}", file=sys.stderr)
         sys.exit(1)
     return None
@@ -89,8 +89,7 @@ def get_user_id(user: str) -> Optional[str]:
     results = db_cmd(f'db.UsersCollection.findOne({{ username: "{user}"}}, {{ username: 1 }})')
     if results is not None:
         return results["_id"]
-    else:
-        results = db_cmd(f'db.UsersCollection.findOne({{ email: "{user}"}}, {{ username: 1 }})')
-        if results is not None:
-            return results["_id"]
+    results = db_cmd(f'db.UsersCollection.findOne({{ email: "{user}"}}, {{ username: 1 }})')
+    if results is not None:
+        return results["_id"]
     return None

--- a/deploy/roles/combine_maintenance/files/maint_utils.py
+++ b/deploy/roles/combine_maintenance/files/maint_utils.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional
 
 
 @enum.unique
-class Permission(enum.Enum):
+class Permission(enum.IntEnum):
     """Define enumerated type for Combine user permissions."""
 
     WordEntry = 1

--- a/deploy/roles/combine_maintenance/files/make_user_admin.py
+++ b/deploy/roles/combine_maintenance/files/make_user_admin.py
@@ -9,10 +9,9 @@ from maint_utils import db_cmd, get_user_id
 def parse_args() -> argparse.Namespace:
     """Parse the command line arguments."""
     parser = argparse.ArgumentParser(
-        description="""Make an existing user a site administrator """
-        """for TheCombine.  """
-        """The user can be specified by his/her username or """
-        """by his/her e-mail address.""",
+        description="Make an existing user a site administrator "
+        "for TheCombine.  "
+        "The user can be specified by username or e-mail address.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(

--- a/deploy/roles/combine_maintenance/files/rm_project.py
+++ b/deploy/roles/combine_maintenance/files/rm_project.py
@@ -27,11 +27,10 @@ from maint_utils import db_cmd, get_project_id, run_docker_cmd
 
 def parse_args() -> argparse.Namespace:
     """Define command line arguments for parser."""
-    # Parse user command line arguments
     parser = argparse.ArgumentParser(
-        description="""Remove a project from the Combine server. """
-        """Project data are deleted from the database and """
-        """the backend containers.""",
+        description="Remove a project from the Combine server. "
+        "Project data are deleted from the database and "
+        "the backend containers.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument("projects", nargs="*", help="Project(s) to be removed from TheCombine.")


### PR DESCRIPTION
Improve the code quality of the maintenance scripts added with PR #1031.

- Use single exit code for failure
- Specify user permissions using an enumerated type
- Consistent quoting of string literals
- Improve help wording

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1041)
<!-- Reviewable:end -->
