### PR TITLE
Fix Sense.Clone() to clone Accessibility

### DIFF
--- a/Backend.Tests/Models/WordTests.cs
+++ b/Backend.Tests/Models/WordTests.cs
@@ -89,7 +89,7 @@ namespace Backend.Tests.Models
 
     public class SenseTests
     {
-        private const State Accessibility = State.Active;
+        private const State Accessibility = State.Duplicate;
 
         /// <summary> Words create a unique Guid by default. Use a common GUID to ensure equality in tests. </summary>
         private readonly Guid _commonGuid = Guid.NewGuid();
@@ -106,6 +106,13 @@ namespace Backend.Tests.Models
         {
             var sense = new Sense { Accessibility = Accessibility };
             Assert.IsFalse(sense.Equals(null));
+        }
+
+        [Test]
+        public void TestClone()
+        {
+            var sense = new Sense { Accessibility = State.Deleted };
+            Assert.AreEqual(sense, sense.Clone());
         }
 
         [Test]

--- a/Backend/Models/Word.cs
+++ b/Backend/Models/Word.cs
@@ -304,7 +304,7 @@ namespace BackendFramework.Models
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(Guid, Glosses, SemanticDomains);
+            return HashCode.Combine(Guid, Accessibility, Glosses, SemanticDomains);
         }
     }
 

--- a/Backend/Models/Word.cs
+++ b/Backend/Models/Word.cs
@@ -268,6 +268,7 @@ namespace BackendFramework.Models
             var clone = new Sense
             {
                 Guid = Guid,
+                Accessibility = Accessibility,
                 Glosses = new List<Gloss>(),
                 SemanticDomains = new List<SemanticDomain>()
             };
@@ -293,6 +294,7 @@ namespace BackendFramework.Models
 
             return
                 other.Guid == Guid &&
+                other.Accessibility == Accessibility &&
                 other.Glosses.Count == Glosses.Count &&
                 other.Glosses.All(Glosses.Contains) &&
 


### PR DESCRIPTION
Previously, `Sense.Clone()` would not clone the `Accessibility`, instead it would also put `State.Active` on any clone.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1045)
<!-- Reviewable:end -->
