### PR TITLE
Document use of LiftSense.Id for GUID

### DIFF
--- a/Backend/Services/LiftApiServices.cs
+++ b/Backend/Services/LiftApiServices.cs
@@ -590,6 +590,8 @@ namespace BackendFramework.Services
                     {
                         SemanticDomains = new List<SemanticDomain>(),
                         Glosses = new List<Gloss>(),
+                        // FieldWorks uses LiftSense.Id for the GUID field, rather than LiftSense.Guid,
+                        // so follow this convention.
                         Guid = new Guid(sense.Id)
                     };
 


### PR DESCRIPTION
Closes #1015 

`LiftSense` has a `.Guid` field. Document why The Combine imports the GUID for a `Sense` from from the `.Id` field rather than the `.Guid` field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1047)
<!-- Reviewable:end -->
