### PR TITLE
Fully qualify pip-tools command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,7 +569,7 @@ With an active virtual environment, install Python development requirements for 
 
 ```bash
 (venv) $ python -m pip install --upgrade pip pip-tools
-(venv) $ pip-sync dev-requirements.txt
+(venv) $ python -m piptools sync dev-requirements.txt
 ```
 
 Note, you can also now perform automated code formatting of Python code:
@@ -588,7 +588,7 @@ To upgrade all pinned dependencies, run the following command under Python 3.6 s
 backwards-compatible.
 
 ```bash
-(venv) $ pip-compile --upgrade dev-requirements.in
+(venv) $ python -m piptools compile --upgrade dev-requirements.in
 ```
 
 Then manually remove `dataclasses==` line from `dev-requirements.txt`. This is to work around a pinning issue with


### PR DESCRIPTION
Use `python -m piptools ...` rather than `pip-compile` / `pip-sync` commands to ensure the correct Python virtual environment is in use.

`python -m ...` will always use `python` from the currently activated virtual environment.

This fixes an issue observed on macOS where `pip-tools` was installed globally and being used rather than the version in the current `venv`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1056)
<!-- Reviewable:end -->
