### PR TITLE
Make FinishEntry sync to fix Lift import

### DIFF
--- a/Backend/Services/LiftApiServices.cs
+++ b/Backend/Services/LiftApiServices.cs
@@ -543,7 +543,7 @@ namespace BackendFramework.Services
             /// to <see cref="_importEntries"/> to be saved to the database.
             /// </summary>
             /// <param name="entry"></param>
-            public async void FinishEntry(LiftEntry entry)
+            public void FinishEntry(LiftEntry entry)
             {
                 var newWord = new Word
                 {
@@ -551,7 +551,7 @@ namespace BackendFramework.Services
                     Created = Time.ToUtcIso8601(entry.DateCreated),
                     Modified = Time.ToUtcIso8601(entry.DateModified)
                 };
-                var proj = await _projectService.GetProject(_projectId);
+                var proj = _projectService.GetProject(_projectId).Result;
                 if (proj is null)
                 {
                     throw new MissingProjectException($"Project does not exist: {_projectId}");
@@ -573,7 +573,7 @@ namespace BackendFramework.Services
                     if (proj.VernacularWritingSystem.Bcp47 == "")
                     {
                         proj.VernacularWritingSystem.Bcp47 = entry.CitationForm.FirstValue.Key;
-                        await _projectService.Update(_projectId, proj);
+                        _projectService.Update(_projectId, proj);
                     }
                 }
                 else if (!entry.LexicalForm.IsEmpty) // lexeme form for backup
@@ -582,7 +582,7 @@ namespace BackendFramework.Services
                     if (proj.VernacularWritingSystem.Bcp47 == "")
                     {
                         proj.VernacularWritingSystem.Bcp47 = entry.LexicalForm.FirstValue.Key;
-                        await _projectService.Update(_projectId, proj);
+                        _projectService.Update(_projectId, proj);
                     }
                 }
                 else // this is not a word if there is no vernacular


### PR DESCRIPTION
Closes #1061 

Fix for issue exposed in #1054

`FinishEntry` is not expected to be `async` by parent class, so do not define as `async`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1064)
<!-- Reviewable:end -->
