### PR TITLE
Don't worry about project language when importing entries.

### DIFF
--- a/Backend.Tests/Controllers/LiftControllerTests.cs
+++ b/Backend.Tests/Controllers/LiftControllerTests.cs
@@ -309,7 +309,7 @@ namespace Backend.Tests.Controllers
 
                 // Make api call.
                 var result = _liftController.UploadLiftFile(proj1!.Id, fileUpload).Result;
-                Assert.That(result is OkObjectResult);
+                Assert.That(!(result is BadRequestObjectResult));
             }
 
             proj1 = _projServ.GetProject(proj1.Id).Result;
@@ -371,7 +371,7 @@ namespace Backend.Tests.Controllers
 
                 // Make api call.
                 var result2 = _liftController.UploadLiftFile(proj2!.Id, fileUpload).Result;
-                Assert.That(result2 is OkObjectResult);
+                Assert.That(!(result2 is BadRequestObjectResult));
             }
 
             proj2 = _projServ.GetProject(proj2.Id).Result;

--- a/Backend.Tests/Controllers/LiftControllerTests.cs
+++ b/Backend.Tests/Controllers/LiftControllerTests.cs
@@ -297,8 +297,9 @@ namespace Backend.Tests.Controllers
             // Roundtrip Part 1
 
             // Init the project the .zip info is added to.
-            var proj1 = _projServ.Create(RandomProject()).Result;
-            proj1!.VernacularWritingSystem.Bcp47 = roundTripObj.Language;
+            var proj1 = RandomProject();
+            proj1.VernacularWritingSystem.Bcp47 = roundTripObj.Language;
+            proj1 = _projServ.Create(proj1).Result;
 
             // Upload the zip file.
             // Generate api parameter with filestream.
@@ -358,8 +359,9 @@ namespace Backend.Tests.Controllers
             // Roundtrip Part 2
 
             // Init the project the .zip info is added to.
-            var proj2 = _projServ.Create(RandomProject()).Result;
-            proj2!.VernacularWritingSystem.Bcp47 = roundTripObj.Language;
+            var proj2 = RandomProject();
+            proj2.VernacularWritingSystem.Bcp47 = roundTripObj.Language;
+            proj2 = _projServ.Create(proj1).Result;
 
             // Upload the exported words again.
             // Generate api parameter with filestream.

--- a/Backend.Tests/Controllers/LiftControllerTests.cs
+++ b/Backend.Tests/Controllers/LiftControllerTests.cs
@@ -361,7 +361,7 @@ namespace Backend.Tests.Controllers
             // Init the project the .zip info is added to.
             var proj2 = RandomProject();
             proj2.VernacularWritingSystem.Bcp47 = roundTripObj.Language;
-            proj2 = _projServ.Create(proj1).Result;
+            proj2 = _projServ.Create(proj2).Result;
 
             // Upload the exported words again.
             // Generate api parameter with filestream.

--- a/Backend.Tests/Controllers/LiftControllerTests.cs
+++ b/Backend.Tests/Controllers/LiftControllerTests.cs
@@ -307,7 +307,7 @@ namespace Backend.Tests.Controllers
 
                 // Make api call.
                 var result = _liftController.UploadLiftFile(proj1!.Id, fileUpload).Result;
-                Assert.That(!(result is BadRequestObjectResult));
+                Assert.That(result is OkObjectResult);
             }
 
             proj1 = _projServ.GetProject(proj1.Id).Result;
@@ -367,7 +367,7 @@ namespace Backend.Tests.Controllers
 
                 // Make api call.
                 var result2 = _liftController.UploadLiftFile(proj2!.Id, fileUpload).Result;
-                Assert.That(!(result2 is BadRequestObjectResult));
+                Assert.That(result2 is OkObjectResult);
             }
 
             proj2 = _projServ.GetProject(proj2.Id).Result;

--- a/Backend.Tests/Controllers/LiftControllerTests.cs
+++ b/Backend.Tests/Controllers/LiftControllerTests.cs
@@ -317,7 +317,6 @@ namespace Backend.Tests.Controllers
                 return;
             }
 
-            Assert.AreEqual(proj1.VernacularWritingSystem.Bcp47, roundTripObj.Language);
             Assert.That(proj1.LiftImported);
 
             var allWords = _wordRepo.GetAllWords(proj1.Id).Result;
@@ -377,8 +376,6 @@ namespace Backend.Tests.Controllers
                 Assert.Fail();
                 return;
             }
-
-            Assert.AreEqual(proj2.VernacularWritingSystem.Bcp47, roundTripObj.Language);
 
             // Clean up zip file.
             File.Delete(exportedFilePath);

--- a/Backend.Tests/Controllers/LiftControllerTests.cs
+++ b/Backend.Tests/Controllers/LiftControllerTests.cs
@@ -298,6 +298,7 @@ namespace Backend.Tests.Controllers
 
             // Init the project the .zip info is added to.
             var proj1 = _projServ.Create(RandomProject()).Result;
+            proj1!.VernacularWritingSystem.Bcp47 = roundTripObj.Language;
 
             // Upload the zip file.
             // Generate api parameter with filestream.
@@ -358,6 +359,7 @@ namespace Backend.Tests.Controllers
 
             // Init the project the .zip info is added to.
             var proj2 = _projServ.Create(RandomProject()).Result;
+            proj2!.VernacularWritingSystem.Bcp47 = roundTripObj.Language;
 
             // Upload the exported words again.
             // Generate api parameter with filestream.

--- a/Backend/Controllers/LiftController.cs
+++ b/Backend/Controllers/LiftController.cs
@@ -163,16 +163,9 @@ namespace BackendFramework.Controllers
             {
                 return new NotFoundObjectResult(projectId);
             }
-            try
-            {
-                _liftService.LdmlImport(
-                    Path.Combine(liftStoragePath, "WritingSystems"),
-                    proj.VernacularWritingSystem.Bcp47, _projectService, proj);
-            }
-            catch (Exception)
-            {
-                Console.WriteLine("There appears to be a problem with LdmlImport.");
-            }
+            _liftService.LdmlImport(
+                Path.Combine(liftStoragePath, "WritingSystems"),
+                proj.VernacularWritingSystem.Bcp47, _projectService, proj);
 
             // Store that we have imported Lift data already for this project to signal the frontend
             // not to attempt to import again.

--- a/Backend/Controllers/LiftController.cs
+++ b/Backend/Controllers/LiftController.cs
@@ -149,35 +149,45 @@ namespace BackendFramework.Controllers
                 return new BadRequestObjectResult("No lift files detected");
             }
 
-            // Sets the projectId of our parser to add words to that project
-            var liftMerger = _liftService.GetLiftImporterExporter(projectId, _projectService, _wordRepo);
-            var parser = new LiftParser<LiftObject, LiftEntry, LiftSense, LiftExample>(liftMerger);
-
-            // Import words from lift file
-            var resp = parser.ReadLiftFile(extractedLiftPath.FirstOrDefault());
-            await liftMerger.SaveImportEntries();
-
-            // Add character set to project from ldml file
-            var proj = await _projectService.GetProject(projectId);
-            if (proj is null)
+            try
             {
-                return new NotFoundObjectResult(projectId);
-            }
-            _liftService.LdmlImport(
-                Path.Combine(liftStoragePath, "WritingSystems"),
-                proj.VernacularWritingSystem.Bcp47, _projectService, proj);
+                // Sets the projectId of our parser to add words to that project
+                var liftMerger = _liftService.GetLiftImporterExporter(projectId, _projectService, _wordRepo);
+                var parser = new LiftParser<LiftObject, LiftEntry, LiftSense, LiftExample>(liftMerger);
 
-            // Store that we have imported Lift data already for this project to signal the frontend
-            // not to attempt to import again.
-            var project = await _projectService.GetProject(projectId);
-            if (project is null)
+                // Import words from lift file
+                var resp = parser.ReadLiftFile(extractedLiftPath.FirstOrDefault());
+                await liftMerger.SaveImportEntries();
+
+                // Add character set to project from ldml file
+                var proj = await _projectService.GetProject(projectId);
+                if (proj is null)
+                {
+                    return new NotFoundObjectResult(projectId);
+                }
+
+                _liftService.LdmlImport(
+                    Path.Combine(liftStoragePath, "WritingSystems"),
+                    proj.VernacularWritingSystem.Bcp47, _projectService, proj);
+
+                // Store that we have imported Lift data already for this project to signal the frontend
+                // not to attempt to import again.
+                var project = await _projectService.GetProject(projectId);
+                if (project is null)
+                {
+                    return new NotFoundObjectResult(projectId);
+                }
+
+                project.LiftImported = true;
+                await _projectService.Update(projectId, project);
+
+                return new ObjectResult(resp);
+            }
+            // If anything wrong happened, it's probably something wrong with the file itself
+            catch (Exception)
             {
-                return new NotFoundObjectResult(projectId);
+                return new UnsupportedMediaTypeResult();
             }
-            project.LiftImported = true;
-            await _projectService.Update(projectId, project);
-
-            return new OkObjectResult(resp);
         }
 
         /// <summary> Packages project data into zip file </summary>

--- a/Backend/Services/LiftApiServices.cs
+++ b/Backend/Services/LiftApiServices.cs
@@ -551,11 +551,6 @@ namespace BackendFramework.Services
                     Created = Time.ToUtcIso8601(entry.DateCreated),
                     Modified = Time.ToUtcIso8601(entry.DateModified)
                 };
-                var proj = _projectService.GetProject(_projectId).Result;
-                if (proj is null)
-                {
-                    throw new MissingProjectException($"Project does not exist: {_projectId}");
-                }
 
                 // Add Note if one exists.
                 // Note: Currently only support for a single note is included.
@@ -570,20 +565,10 @@ namespace BackendFramework.Services
                 if (!entry.CitationForm.IsEmpty) // Prefer citation form for vernacular
                 {
                     newWord.Vernacular = entry.CitationForm.FirstValue.Value.Text;
-                    if (proj.VernacularWritingSystem.Bcp47 == "")
-                    {
-                        proj.VernacularWritingSystem.Bcp47 = entry.CitationForm.FirstValue.Key;
-                        _projectService.Update(_projectId, proj);
-                    }
                 }
                 else if (!entry.LexicalForm.IsEmpty) // lexeme form for backup
                 {
                     newWord.Vernacular = entry.LexicalForm.FirstValue.Value.Text;
-                    if (proj.VernacularWritingSystem.Bcp47 == "")
-                    {
-                        proj.VernacularWritingSystem.Bcp47 = entry.LexicalForm.FirstValue.Key;
-                        _projectService.Update(_projectId, proj);
-                    }
                 }
                 else // this is not a word if there is no vernacular
                 {


### PR DESCRIPTION
Removing an unused part of our import process. If we decide to automatically extract `VernacularWritingSystem` for the project from the lift file in the future, we'll probably want something that is run once, not with every imported entry.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1065)
<!-- Reviewable:end -->
