### PR TITLE
Fix docker install handler

### DIFF
--- a/deploy/roles/docker_install/handlers/main.yml
+++ b/deploy/roles/docker_install/handlers/main.yml
@@ -12,7 +12,7 @@
     name: rsyslog
     state: restarted
 
-- name: restart rotatelog
+- name: restart logrotate
   service:
-    name: rotatelog
+    name: logrotate
     state: restarted

--- a/deploy/roles/docker_install/handlers/main.yml
+++ b/deploy/roles/docker_install/handlers/main.yml
@@ -11,8 +11,3 @@
   service:
     name: rsyslog
     state: restarted
-
-- name: restart logrotate
-  service:
-    name: logrotate
-    state: restarted

--- a/deploy/roles/docker_install/tasks/main.yml
+++ b/deploy/roles/docker_install/tasks/main.yml
@@ -86,7 +86,6 @@
     group: root
     mode: 0644
   when: combine_use_syslog
-  notify: restart logrotate
 
 - name: check for docker-compose version
   command: docker-compose --version


### PR DESCRIPTION
The handlers for the `docker_install` role included a task to restart the `logrotate` service when the configuration to rotate the docker log files is created or modified.  This causes an error in Ubuntu 18.04 because `logrotate` is scheduled as a `cron` job instead of a `systemd` service.  In Ubuntu 20.04, it is ineffective since the `logrotate` service is a `oneshot` that is triggered by a `systemd` timer; restarting it is not necessary.

Note to reviewers: In addition to the issue above, the service name in the handler file is incorrectly named `rotatelog`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1070)
<!-- Reviewable:end -->
