### PR TITLE
MergeDups refactor (all at once, rather than one-by-one)

### DIFF
--- a/Backend.Tests/Controllers/WordControllerTests.cs
+++ b/Backend.Tests/Controllers/WordControllerTests.cs
@@ -194,7 +194,7 @@ namespace Backend.Tests.Controllers
                 }
             };
 
-            var newWords = _wordService.Merge(_projId, new List<MergeWords>() { mergeObject }).Result;
+            var newWords = _wordService.Merge(_projId, new List<MergeWords> { mergeObject }).Result;
 
             // There should only be 1 word added and it should be identical to what we passed in
             Assert.That(newWords, Has.Count.EqualTo(1));

--- a/Backend.Tests/Controllers/WordControllerTests.cs
+++ b/Backend.Tests/Controllers/WordControllerTests.cs
@@ -213,9 +213,6 @@ namespace Backend.Tests.Controllers
         [Test]
         public void MergeWordsMultiChild()
         {
-            // Each parent word is assumed correct as it is calculated in the frontend, except:
-            // The history and audio are built in the backend.
-
             // Build a mergeWords with a parent with 3 children.
             var mergeWords = new MergeWords { Parent = RandomWord() };
             const int numberOfChildren = 3;
@@ -238,6 +235,24 @@ namespace Backend.Tests.Controllers
             // Confirm that parent added to repo and children not in frontier.
             Assert.IsNotNull(_repo.GetWord(_projId, dbParent.Id).Result);
             Assert.AreEqual(_repo.GetFrontier(_projId).Result.Count, 1);
+        }
+
+        [Test]
+        public void MergeWordsMultiple()
+        {
+            var mergeWordsA = new MergeWords { Parent = RandomWord() };
+            var mergeWordsB = new MergeWords { Parent = RandomWord() };
+            var mergeWordsList = new List<MergeWords>() { mergeWordsA, mergeWordsB };
+            var newWords = _wordService.Merge(_projId, mergeWordsList).Result;
+
+            Assert.That(newWords, Has.Count.EqualTo(2));
+            Assert.AreNotEqual(newWords.First().Id, newWords.Last().Id);
+
+            var frontier = _repo.GetFrontier(_projId).Result;
+            Assert.That(frontier, Has.Count.EqualTo(2));
+            Assert.AreNotEqual(frontier.First().Id, frontier.Last().Id);
+            Assert.Contains(frontier.First(), newWords);
+            Assert.Contains(frontier.Last(), newWords);
         }
 
         [Test]

--- a/Backend.Tests/Controllers/WordControllerTests.cs
+++ b/Backend.Tests/Controllers/WordControllerTests.cs
@@ -190,15 +190,11 @@ namespace Backend.Tests.Controllers
                 Parent = thisWord,
                 Children = new List<MergeSourceWord>
                 {
-                    new MergeSourceWord
-                    {
-                        SrcWordId = thisWord.Id,
-                        SenseStates = new List<State> {State.Sense, State.Sense, State.Sense}
-                    }
+                    new MergeSourceWord { SrcWordId = thisWord.Id }
                 }
             };
 
-            var newWords = _wordService.Merge(_projId, mergeObject).Result;
+            var newWords = _wordService.Merge(_projId, new List<MergeWords>() { mergeObject }).Result;
 
             // There should only be 1 word added and it should be identical to what we passed in
             Assert.That(newWords, Has.Count.EqualTo(1));
@@ -211,54 +207,27 @@ namespace Backend.Tests.Controllers
 
             // Check that new word has the right history
             Assert.That(newWords.First().History, Has.Count.EqualTo(1));
-            var intermediateWord = _repo.GetWord(_projId, newWords.First().History.First()).Result;
-            if (intermediateWord is null)
-            {
-                Assert.Fail();
-                return;
-            }
-            Assert.That(intermediateWord.History, Has.Count.EqualTo(1));
-            Assert.AreEqual(intermediateWord.History.First(), thisWord.Id);
+            Assert.AreEqual(newWords.First().History.First(), thisWord.Id);
         }
 
         [Test]
         public void MergeWords()
         {
-            // The parent word is inherently correct as it is calculated by the frontend as the desired result of the
-            // merge
-            var parentChildMergeObject = new MergeWords
-            {
-                Parent = RandomWord(),
-                Children = new List<MergeSourceWord>()
-            };
+            // Each parent word is assumed correct as it is calculated in the frontend, except:
+            // The history and audio are built in the backend.
 
-            // Set the child info
-            var childWords = new List<Word> { RandomWord(), RandomWord(), RandomWord() };
-            foreach (var child in childWords)
-            {
-                // Generate mergeSourceWord with new child Id and desired child state list
-                var newGenChild = new MergeSourceWord
-                {
-                    SrcWordId = _repo.Add(child).Result.Id,
-                    SenseStates = new List<State> { State.Duplicate, State.Sense, State.Separate }
-                };
-                parentChildMergeObject.Children.Add(newGenChild);
-            }
+            // Build a mergeWords with a parent with 3 children.
+            var mergeWords = new MergeWords { Parent = RandomWord() };
+            var childIds = new List<string> { "child1", "child2", "child3" };
+            mergeWords.Children = childIds.Select(id => new MergeSourceWord { SrcWordId = id }).ToList();
 
-            var newWordList = _wordService.Merge(_projId, parentChildMergeObject).Result;
+            var mergeWordsList = new List<MergeWords>() { mergeWords };
+            var newWords = _wordService.Merge(_projId, mergeWordsList).Result;
 
-            // Check for parent is in the db
-            var dbParent = newWordList.First();
-            Assert.AreEqual(dbParent.Senses.Count, 3);
+            // Check for parent in the db.
+            var dbParent = newWords.First();
             Assert.AreEqual(dbParent.History.Count, 3);
-
-            // Check that separate words were made
-            Assert.AreEqual(newWordList.Count, 4);
-
-            foreach (var word in newWordList)
-            {
-                Assert.Contains(_repo.GetWord(_projId, word.Id).Result, _repo.GetAllWords(_projId).Result);
-            }
+            Assert.IsNotNull(_repo.GetWord(_projId, dbParent.Id).Result);
         }
 
         [Test]

--- a/Backend.Tests/Controllers/WordControllerTests.cs
+++ b/Backend.Tests/Controllers/WordControllerTests.cs
@@ -225,7 +225,7 @@ namespace Backend.Tests.Controllers
             }
             Assert.AreEqual(_repo.GetFrontier(_projId).Result.Count, numberOfChildren);
 
-            var mergeWordsList = new List<MergeWords>() { mergeWords };
+            var mergeWordsList = new List<MergeWords> { mergeWords };
             var newWords = _wordService.Merge(_projId, mergeWordsList).Result;
 
             // Check for correct history length;
@@ -242,7 +242,7 @@ namespace Backend.Tests.Controllers
         {
             var mergeWordsA = new MergeWords { Parent = RandomWord() };
             var mergeWordsB = new MergeWords { Parent = RandomWord() };
-            var mergeWordsList = new List<MergeWords>() { mergeWordsA, mergeWordsB };
+            var mergeWordsList = new List<MergeWords> { mergeWordsA, mergeWordsB };
             var newWords = _wordService.Merge(_projId, mergeWordsList).Result;
 
             Assert.That(newWords, Has.Count.EqualTo(2));

--- a/Backend.Tests/Controllers/WordControllerTests.cs
+++ b/Backend.Tests/Controllers/WordControllerTests.cs
@@ -216,7 +216,7 @@ namespace Backend.Tests.Controllers
             // Build a mergeWords with a parent with 3 children.
             var mergeWords = new MergeWords { Parent = RandomWord() };
             const int numberOfChildren = 3;
-            for (int i = 0; i < numberOfChildren; i++)
+            foreach (var _ in Enumerable.Range(0, numberOfChildren))
             {
                 var child = RandomWord();
                 var id = _repo.Create(child).Result.Id;

--- a/Backend.Tests/Controllers/WordControllerTests.cs
+++ b/Backend.Tests/Controllers/WordControllerTests.cs
@@ -188,7 +188,7 @@ namespace Backend.Tests.Controllers
             var mergeObject = new MergeWords
             {
                 Parent = thisWord,
-                ChildrenWords = new List<MergeSourceWord>
+                Children = new List<MergeSourceWord>
                 {
                     new MergeSourceWord
                     {
@@ -229,7 +229,7 @@ namespace Backend.Tests.Controllers
             var parentChildMergeObject = new MergeWords
             {
                 Parent = RandomWord(),
-                ChildrenWords = new List<MergeSourceWord>()
+                Children = new List<MergeSourceWord>()
             };
 
             // Set the child info
@@ -242,7 +242,7 @@ namespace Backend.Tests.Controllers
                     SrcWordId = _repo.Add(child).Result.Id,
                     SenseStates = new List<State> { State.Duplicate, State.Sense, State.Separate }
                 };
-                parentChildMergeObject.ChildrenWords.Add(newGenChild);
+                parentChildMergeObject.Children.Add(newGenChild);
             }
 
             var newWordList = _wordService.Merge(_projId, parentChildMergeObject).Result;

--- a/Backend.Tests/Mocks/WordRepositoryMock.cs
+++ b/Backend.Tests/Mocks/WordRepositoryMock.cs
@@ -85,7 +85,14 @@ namespace Backend.Tests.Mocks
             var origLength = _frontier.Count;
             _frontier.RemoveAll(word => word.Id == wordId);
             return Task.FromResult(origLength != _frontier.Count);
+        }
 
+        public Task<long> DeleteFrontier(string projectId, List<string> wordIds)
+        {
+            var origLength = _frontier.Count;
+            long deletedCount = 0;
+            wordIds.ForEach(id => deletedCount += _frontier.RemoveAll(word => word.Id == id));
+            return Task.FromResult(deletedCount);
         }
 
         public Task<Word> Add(Word word)

--- a/Backend.Tests/Mocks/WordRepositoryMock.cs
+++ b/Backend.Tests/Mocks/WordRepositoryMock.cs
@@ -89,7 +89,6 @@ namespace Backend.Tests.Mocks
 
         public Task<long> DeleteFrontier(string projectId, List<string> wordIds)
         {
-            var origLength = _frontier.Count;
             long deletedCount = 0;
             wordIds.ForEach(id => deletedCount += _frontier.RemoveAll(word => word.Id == id));
             return Task.FromResult(deletedCount);

--- a/Backend.Tests/Models/UserEditTests.cs
+++ b/Backend.Tests/Models/UserEditTests.cs
@@ -29,7 +29,7 @@ namespace Backend.Tests.Models
     {
         private const int GoalType = 1;
         private Guid Guid = Guid.NewGuid();
-        private List<string> StepData = new List<string>() { "step" };
+        private List<string> StepData = new List<string> { "step" };
         private const string Changes = "{wordIds:[]}";
 
         [Test]

--- a/Backend/Controllers/WordController.cs
+++ b/Backend/Controllers/WordController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using BackendFramework.Interfaces;
@@ -189,7 +189,7 @@ namespace BackendFramework.Controllers
         /// <remarks> PUT: v1/projects/{projectId}/words </remarks>
         /// <returns> List of ids of new words </returns>
         [HttpPut]
-        public async Task<IActionResult> Put(string projectId, [FromBody] MergeWords mergeWords)
+        public async Task<IActionResult> Put(string projectId, [FromBody] List<MergeWords> mergeWordsList)
         {
             if (!await _permissionService.HasProjectPermission(HttpContext, Permission.MergeAndCharSet))
             {
@@ -205,8 +205,8 @@ namespace BackendFramework.Controllers
 
             try
             {
-                var newWordList = await _wordService.Merge(projectId, mergeWords);
-                return new OkObjectResult(newWordList.Select(w => w.Id).ToList());
+                var newWords = await _wordService.Merge(projectId, mergeWordsList);
+                return new OkObjectResult(newWords.Select(w => w.Id).ToList());
             }
             catch
             {

--- a/Backend/Controllers/WordController.cs
+++ b/Backend/Controllers/WordController.cs
@@ -206,9 +206,9 @@ namespace BackendFramework.Controllers
             try
             {
                 var newWordList = await _wordService.Merge(projectId, mergeWords);
-                return new ObjectResult(newWordList.Select(i => i.Id).ToList());
+                return new OkObjectResult(newWordList.Select(w => w.Id).ToList());
             }
-            catch (Exception)
+            catch
             {
                 return new BadRequestResult();
             }

--- a/Backend/Interfaces/IWordRepository.cs
+++ b/Backend/Interfaces/IWordRepository.cs
@@ -16,5 +16,6 @@ namespace BackendFramework.Interfaces
         Task<Word> AddFrontier(Word word);
         Task<List<Word>> AddFrontier(List<Word> word);
         Task<bool> DeleteFrontier(string projectId, string wordId);
+        Task<long> DeleteFrontier(string projectId, List<string> wordIds);
     }
 }

--- a/Backend/Interfaces/IWordService.cs
+++ b/Backend/Interfaces/IWordService.cs
@@ -8,7 +8,7 @@ namespace BackendFramework.Interfaces
     {
         Task<bool> Update(string projectId, string wordId, Word word);
         Task<bool> Delete(string projectId, string wordId);
-        Task<List<Word>> Merge(string projectId, MergeWords mergeWords);
+        Task<List<Word>> Merge(string projectId, List<MergeWords> mergeWordsList);
         Task<bool> WordIsUnique(Word word);
         Task<Word?> Delete(string projectId, string wordId, string fileName);
         Task<string?> DeleteFrontierWord(string projectId, string wordId);

--- a/Backend/Models/Word.cs
+++ b/Backend/Models/Word.cs
@@ -408,20 +408,26 @@ namespace BackendFramework.Models
     /// </summary>
     public class MergeWords
     {
+        [BsonElement("parent")]
         public Word Parent { get; set; }
-        public List<MergeSourceWord> ChildrenWords { get; set; }
+
+        [BsonElement("children")]
+        public List<MergeSourceWord> Children { get; set; }
 
         public MergeWords()
         {
             Parent = new Word();
-            ChildrenWords = new List<MergeSourceWord>();
+            Children = new List<MergeSourceWord>();
         }
     }
 
     /// <summary> Helper object that contains a wordId and the type of merge that should be performed </summary>
     public class MergeSourceWord
     {
+        [BsonElement("srcWordId")]
         public string SrcWordId;
+
+        [BsonElement("senseStates")]
         public List<State> SenseStates;
 
         public MergeSourceWord()

--- a/Backend/Models/Word.cs
+++ b/Backend/Models/Word.cs
@@ -408,10 +408,7 @@ namespace BackendFramework.Models
     /// </summary>
     public class MergeWords
     {
-        [BsonElement("parent")]
         public Word Parent { get; set; }
-
-        [BsonElement("children")]
         public List<MergeSourceWord> Children { get; set; }
 
         public MergeWords()
@@ -424,10 +421,7 @@ namespace BackendFramework.Models
     /// <summary> Helper object that contains a wordId and the type of merge that should be performed </summary>
     public class MergeSourceWord
     {
-        [BsonElement("srcWordId")]
         public string SrcWordId;
-
-        [BsonElement("getAudio")]
         public bool GetAudio;
 
         public MergeSourceWord()

--- a/Backend/Models/Word.cs
+++ b/Backend/Models/Word.cs
@@ -427,13 +427,13 @@ namespace BackendFramework.Models
         [BsonElement("srcWordId")]
         public string SrcWordId;
 
-        [BsonElement("senseStates")]
-        public List<State> SenseStates;
+        [BsonElement("getAudio")]
+        public bool GetAudio;
 
         public MergeSourceWord()
         {
             SrcWordId = "";
-            SenseStates = new List<State>();
+            GetAudio = false;
         }
     }
 

--- a/Backend/Services/LiftApiServices.cs
+++ b/Backend/Services/LiftApiServices.cs
@@ -755,7 +755,7 @@ namespace BackendFramework.Services
                 /*uncomment this if you want to import semantic domains from a lift-ranges file*/
                 //if (range == "semantic-domain-ddp4")
                 //{
-                //    _sdList.Add(new SemanticDomain() {
+                //    _sdList.Add(new SemanticDomain {
                 //        Name = label.ElementAt(0).Value.Text, Id = abbrev.First().Value.Text });
                 //}
             }

--- a/Backend/Services/WordApiServices.cs
+++ b/Backend/Services/WordApiServices.cs
@@ -128,8 +128,7 @@ namespace BackendFramework.Services
 
         /// <summary> Prepares a merge parent to be added to the database. </summary>
         /// <returns> Word to add. </returns>
-        private async Task<Word> MergePrepParent(
-            string projectId, MergeWords mergeWords)
+        private async Task<Word> MergePrepParent(string projectId, MergeWords mergeWords)
         {
             var parent = mergeWords.Parent.Clone();
             parent.ProjectId = projectId;

--- a/Backend/Services/WordApiServices.cs
+++ b/Backend/Services/WordApiServices.cs
@@ -129,7 +129,7 @@ namespace BackendFramework.Services
         /// <summary> Prepares a merge parent to be added to the database. </summary>
         /// <returns> Word to add. </returns>
         private async Task<Word> MergePrepParent(
-            string projectId, MergeWords mergeWords, List<Word>? wordsToAdd)
+            string projectId, MergeWords mergeWords)
         {
             var parent = mergeWords.Parent.Clone();
             parent.ProjectId = projectId;
@@ -158,10 +158,6 @@ namespace BackendFramework.Services
             parent.Id = "";
             parent.Modified = "";
 
-            if (wordsToAdd != null)
-            {
-                wordsToAdd.Add(parent);
-            }
             return parent;
         }
 
@@ -181,7 +177,8 @@ namespace BackendFramework.Services
         public async Task<List<Word>> Merge(string projectId, List<MergeWords> mergeWordsList)
         {
             var newWords = new List<Word>();
-            await Task.WhenAll(mergeWordsList.Select(m => MergePrepParent(projectId, m, newWords)));
+            await Task.WhenAll(mergeWordsList.Select(m => MergePrepParent(projectId, m)
+                                             .ContinueWith(Task => newWords.Add(Task.Result))));
             await Task.WhenAll(mergeWordsList.Select(m => MergeDeleteChildren(projectId, m)));
             return await _repo.Create(newWords);
         }

--- a/Backend/Services/WordApiServices.cs
+++ b/Backend/Services/WordApiServices.cs
@@ -130,8 +130,6 @@ namespace BackendFramework.Services
         /// <returns> Word to add. </returns>
         private async Task<Word> PrepMerge(string projectId, MergeWords mergeWords)
         {
-            var newWordsList = new List<Word>();
-
             var parent = mergeWords.Parent.Clone();
             parent.ProjectId = projectId;
             parent.History = new List<string>();

--- a/Backend/Services/WordApiServices.cs
+++ b/Backend/Services/WordApiServices.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using BackendFramework.Helper;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
 
@@ -128,101 +126,60 @@ namespace BackendFramework.Services
             return wordIsInFrontier;
         }
 
-        /// <summary> Makes a parent from merging other words and some number of separate words </summary>
-        /// <returns> List of words added: Parent first, followed by separate words in order added </returns>
-        public async Task<List<Word>> Merge(string projectId, MergeWords mergeWords)
+        /// <summary> Prepares a merge parent to be added to the database. </summary>
+        /// <returns> Word to add. </returns>
+        private async Task<Word> PrepMerge(string projectId, MergeWords mergeWords)
         {
             var newWordsList = new List<Word>();
 
-            var addParent = mergeWords.Parent.Clone();
-            addParent.History = new List<string>();
+            var parent = mergeWords.Parent.Clone();
+            parent.ProjectId = projectId;
+            parent.History = new List<string>();
 
-            // Generate new child words from Children.
+            // Add child to history.
             foreach (var childSource in mergeWords.Children)
             {
-                // Get child word.
-                var currentChildWord = await _repo.GetWord(projectId, childSource.SrcWordId);
-                if (currentChildWord is null)
+                parent.History.Add(childSource.SrcWordId);
+                if (childSource.GetAudio)
                 {
-                    throw new KeyNotFoundException($"Unable to locate word: ${childSource.SrcWordId}");
-                }
-
-                // Copy over audio if child doesn't have own surviving entry.
-                if (!childSource.SenseStates.Exists(x => x == State.Separate))
-                {
-                    addParent.Audio.AddRange(currentChildWord.Audio);
-                }
-
-                // Remove child from frontier.
-                await _repo.DeleteFrontier(projectId, currentChildWord.Id);
-
-                // Iterate through senses of that word and change to corresponding state in merged words.
-                if (currentChildWord.Senses.Count != childSource.SenseStates.Count)
-                {
-                    throw new FormatException("Sense counts don't match");
-                }
-                for (var i = 0; i < currentChildWord.Senses.Count; i++)
-                {
-                    currentChildWord.Senses[i].Accessibility = childSource.SenseStates[i];
-                }
-
-                // Change the child word's history to its previous self
-                currentChildWord.History = new List<string> { childSource.SrcWordId };
-
-                // Add child word to the database
-                currentChildWord.Id = "";
-                // Erase time old Modified date timestamp so the are recalculated.
-                currentChildWord.Modified = "";
-                await _repo.Add(currentChildWord);
-
-                // Handle different states.
-                var separateWord = currentChildWord.Clone();
-                separateWord.Senses = new List<Sense>();
-                separateWord.Id = "";
-                for (var i = 0; i < currentChildWord.Senses.Count; i++)
-                {
-                    switch (childSource.SenseStates[i])
+                    var child = await _repo.GetWord(projectId, childSource.SrcWordId);
+                    if (child is null)
                     {
-                        // Add the word to the parent's history.
-                        case State.Sense:
-                        case State.Duplicate:
-                            if (!addParent.History.Contains(currentChildWord.Id))
-                            {
-                                addParent.History.Add(currentChildWord.Id);
-                            }
-                            break;
-                        // Add the sense to a separate word and the word to its history.
-                        case State.Separate:
-                            currentChildWord.Senses[i].Accessibility = State.Active;
-                            separateWord.Senses.Add(currentChildWord.Senses[i]);
-                            if (!separateWord.History.Contains(currentChildWord.Id))
-                            {
-                                separateWord.History.Add(currentChildWord.Id);
-                            }
-                            break;
-                        default:
-                            throw new NotSupportedException();
+                        throw new KeyNotFoundException($"Unable to locate word: ${childSource.SrcWordId}");
                     }
-                }
-
-                // Add a new word to the database with all of the senses with separate tags from this word
-                if (separateWord.Senses.Count != 0)
-                {
-                    separateWord.ProjectId = projectId;
-                    separateWord.Modified = "";
-                    var newSeparate = await _repo.Create(separateWord);
-                    newWordsList.Add(newSeparate);
+                    parent.Audio.AddRange(child.Audio);
                 }
             }
 
-            // Add parent with child history to the database
-            addParent.Id = "";
-            addParent.ProjectId = projectId;
-            addParent.Modified = "";
-            addParent.Audio = addParent.Audio.Distinct().ToList();
-            addParent = await _repo.Create(addParent);
-            newWordsList.Insert(0, addParent);
-            return newWordsList;
+            // Remove duplicates.
+            parent.Audio = parent.Audio.Distinct().ToList();
+            parent.History = parent.History.Distinct().ToList();
+
+            // Clear fields to be automatically regenerated.
+            parent.Id = "";
+            parent.Modified = "";
+
+            return parent;
+        }
+
+        /// <summary>
+        /// Given a list of MergeWords, preps the words to be added, removes the children
+        /// from the frontier, and adds the new words to the database.
+        /// </summary>
+        /// <returns> List of new words added. </returns>
+        public async Task<List<Word>> Merge(string projectId, List<MergeWords> mergeWordsList)
+        {
+            var newWords = new List<Word>();
+            foreach (var mergeWords in mergeWordsList)
+            {
+                newWords.Add(await PrepMerge(projectId, mergeWords));
+            }
+            foreach (var mergeWords in mergeWordsList)
+            {
+                List<string> childIds = mergeWords.Children.Select(c => c.SrcWordId).ToList();
+                await _repo.DeleteFrontier(projectId, childIds);
+            }
+            return await _repo.Create(newWords);
         }
 
         /// <summary> Checks if a word being added is an exact duplicate of a preexisting word </summary>

--- a/Backend/Services/WordApiServices.cs
+++ b/Backend/Services/WordApiServices.cs
@@ -177,7 +177,7 @@ namespace BackendFramework.Services
         {
             var newWords = new List<Word>();
             await Task.WhenAll(mergeWordsList.Select(m => MergePrepParent(projectId, m)
-                                             .ContinueWith(Task => newWords.Add(Task.Result))));
+                                             .ContinueWith(task => newWords.Add(task.Result))));
             await Task.WhenAll(mergeWordsList.Select(m => MergeDeleteChildren(projectId, m)));
             return await _repo.Create(newWords);
         }

--- a/Backend/Services/WordRepository.cs
+++ b/Backend/Services/WordRepository.cs
@@ -154,7 +154,7 @@ namespace BackendFramework.Services
         }
 
         /// <summary> Removes <see cref="Word"/>s from the Frontier with specified wordIds and projectId </summary>
-        /// <returns> A long: number of words deleted </returns>
+        /// <returns> Number of words deleted </returns>
         public async Task<long> DeleteFrontier(string projectId, List<string> wordIds)
         {
             var filterDef = new FilterDefinitionBuilder<Word>();

--- a/Backend/Services/WordRepository.cs
+++ b/Backend/Services/WordRepository.cs
@@ -153,6 +153,18 @@ namespace BackendFramework.Services
             return deleted.DeletedCount > 0;
         }
 
+        /// <summary> Removes <see cref="Word"/>s from the Frontier with specified wordIds and projectId </summary>
+        /// <returns> A long: number of words deleted </returns>
+        public async Task<long> DeleteFrontier(string projectId, List<string> wordIds)
+        {
+            var filterDef = new FilterDefinitionBuilder<Word>();
+            var filter = filterDef.And(
+                filterDef.Eq(x => x.ProjectId, projectId),
+                filterDef.In(x => x.Id, wordIds));
+            var deleted = await _wordDatabase.Frontier.DeleteManyAsync(filter);
+            return deleted.DeletedCount;
+        }
+
         /// <summary> Updates <see cref="Word"/> in the Frontier collection with same wordId and projectId </summary>
         /// <returns> A bool: success of operation </returns>
         public async Task<bool> UpdateFrontier(Word word)

--- a/src/backend/index.tsx
+++ b/src/backend/index.tsx
@@ -11,7 +11,7 @@ import SemanticDomainWithSubdomains from "types/SemanticDomain";
 import { User } from "types/user";
 import { UserEdit } from "types/userEdit";
 import { UserRole } from "types/userRole";
-import { MergeSourceWord, MergeWords, Word } from "types/word";
+import { MergeWords, Word } from "types/word";
 
 export const baseURL = `${RuntimeConfig.getInstance().baseUrl()}`;
 const apiBaseURL = `${baseURL}/v1`;
@@ -88,14 +88,11 @@ export async function getAllWords(): Promise<Word[]> {
 
 /** Returns array of ids of the post-merge words. */
 export async function mergeWords(
-  parent: Word,
-  children: MergeSourceWord[]
+  mergeWordsArray: MergeWords[]
 ): Promise<string[]> {
-  parent = JSON.parse(JSON.stringify(parent));
-  const mergeWords: MergeWords = { parent, children };
-  let resp = await backendServer.put(
+  const resp = await backendServer.put(
     `projects/${LocalStorage.getProjectId()}/words`,
-    mergeWords,
+    mergeWordsArray,
     { headers: authHeader() }
   );
   return resp.data;

--- a/src/backend/index.tsx
+++ b/src/backend/index.tsx
@@ -11,7 +11,7 @@ import SemanticDomainWithSubdomains from "types/SemanticDomain";
 import { User } from "types/user";
 import { UserEdit } from "types/userEdit";
 import { UserRole } from "types/userRole";
-import { MergeWord, Word } from "types/word";
+import { MergeSourceWord, MergeWords, Word } from "types/word";
 
 export const baseURL = `${RuntimeConfig.getInstance().baseUrl()}`;
 const apiBaseURL = `${baseURL}/v1`;
@@ -86,20 +86,13 @@ export async function getAllWords(): Promise<Word[]> {
   return resp.data;
 }
 
+/** Returns array of ids of the post-merge words. */
 export async function mergeWords(
   parent: Word,
-  children: MergeWord[]
+  children: MergeSourceWord[]
 ): Promise<string[]> {
   parent = JSON.parse(JSON.stringify(parent));
-  parent.id = "";
-  let childrenWords = children.map((child) => ({
-    SrcWordId: child.wordId,
-    SenseStates: child.senses,
-  }));
-  let mergeWords = {
-    Parent: parent,
-    ChildrenWords: childrenWords,
-  };
+  const mergeWords: MergeWords = { parent, children };
   let resp = await backendServer.put(
     `projects/${LocalStorage.getProjectId()}/words`,
     mergeWords,

--- a/src/components/Login/LoginPage/LoginComponent.tsx
+++ b/src/components/Login/LoginPage/LoginComponent.tsx
@@ -212,7 +212,7 @@ export default class Login extends React.Component<
                       type: "submit",
                       color: "primary",
                     }}
-                    //disabled={!this.state.isVerified}
+                    disabled={!this.state.isVerified}
                     loading={this.props.loginAttempt}
                   >
                     <Translate id="login.login" />

--- a/src/components/Login/LoginPage/LoginComponent.tsx
+++ b/src/components/Login/LoginPage/LoginComponent.tsx
@@ -212,7 +212,7 @@ export default class Login extends React.Component<
                       type: "submit",
                       color: "primary",
                     }}
-                    disabled={!this.state.isVerified}
+                    //disabled={!this.state.isVerified}
                     loading={this.props.loginAttempt}
                   >
                     <Translate id="login.login" />

--- a/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepActions.tsx
+++ b/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepActions.tsx
@@ -218,27 +218,28 @@ function getMergeWords(
     });
 
     // Clean order of senses in each src word to reflect backend order.
-    const childSources = Object.values(senses);
-    childSources.forEach((wordSenses) => {
+    Object.values(senses).forEach((wordSenses) => {
       wordSenses = wordSenses.sort((a, b) => a.order - b.order);
       senses[wordSenses[0].srcWordId] = wordSenses;
     });
 
     // Don't return empty merges: when the only child is the parent word
     // and has the same number of senses as parent (all with State.Sense).
-    if (
-      childSources.length === 1 &&
-      childSources[0][0].srcWordId === wordId &&
-      childSources[0].length === data.words[wordId].senses.length &&
-      !childSources[0].find((s) => s.state !== State.Sense)
-    ) {
-      return undefined;
+    if (Object.values(senses).length === 1) {
+      const onlyChild = Object.values(senses)[0];
+      if (
+        onlyChild[0].srcWordId === wordId &&
+        onlyChild.length === data.words[wordId].senses.length &&
+        !onlyChild.find((s) => s.state !== State.Sense)
+      ) {
+        return undefined;
+      }
     }
 
     // Construct parent and children.
     const parent: Word = { ...data.words[wordId], senses: [] };
-    const children: MergeSourceWord[] = childSources.map((wordSenses) => {
-      wordSenses.forEach((sense) => {
+    const children: MergeSourceWord[] = Object.values(senses).map((sList) => {
+      sList.forEach((sense) => {
         if (sense.state === State.Sense || sense.state === State.Active) {
           parent.senses.push({
             guid: sense.guid,
@@ -248,8 +249,8 @@ function getMergeWords(
         }
       });
       return {
-        srcWordId: wordSenses[0].srcWordId,
-        getAudio: !wordSenses.find((s) => s.state === State.Separate),
+        srcWordId: sList[0].srcWordId,
+        getAudio: !sList.find((sense) => sense.state === State.Separate),
       };
     });
 

--- a/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepActions.tsx
+++ b/src/goals/MergeDupGoal/MergeDupStep/MergeDupStepActions.tsx
@@ -155,6 +155,8 @@ export function mergeSense() {
 
 type SenseWithState = TreeDataSense & { state: State };
 
+// Given a wordId, constructs from the state the corresponing MergeWords.
+// Returns the MergeWords, or undefined if the parent and child are identical.
 function getMergeWords(
   wordId: string,
   getState: () => StoreState

--- a/src/goals/MergeDupGoal/MergeDupStep/tests/MergeDupStepActions.test.tsx
+++ b/src/goals/MergeDupGoal/MergeDupStep/tests/MergeDupStepActions.test.tsx
@@ -15,7 +15,8 @@ import {
 } from "goals/MergeDupGoal/MergeDupStep/MergeDupsTree";
 import { goalDataMock } from "goals/MergeDupGoal/MergeDupStep/tests/MockMergeDupData";
 import {
-  MergeWord,
+  MergeSourceWord,
+  MergeWords,
   multiGlossWord,
   multiGlossWordAnyGuid,
   Sense,
@@ -56,36 +57,32 @@ const mockWordList: { [key in mockWordListIndex]: Word } = {
 };
 
 // mockMergeN is for test treeN below
-interface parentWithMergeChildren {
-  parent: Word;
-  children: MergeWord[];
-}
-const mockMerge2a: parentWithMergeChildren = {
+const mockMerge2a: MergeWords = {
   parent: { ...mockWordList["WA2"], id: "WA", history: [] },
   children: [
-    { wordId: "WA", senses: [State.Sense, State.Sense] },
-    { wordId: "WB", senses: [State.Duplicate, State.Separate] },
+    { srcWordId: "WA", senseStates: [State.Sense, State.Sense] },
+    { srcWordId: "WB", senseStates: [State.Duplicate, State.Separate] },
   ],
 };
-const mockMerge2b: parentWithMergeChildren = {
+const mockMerge2b: MergeWords = {
   parent: { ...mockWordList["WB2"], id: "WB", history: [] },
-  children: [{ wordId: "WB2", senses: [State.Sense] }],
+  children: [{ srcWordId: "WB2", senseStates: [State.Sense] }],
 };
-const mockMerge3a: parentWithMergeChildren = {
+const mockMerge3a: MergeWords = {
   parent: { ...mockWordList["WA3"], id: "WA", history: [] },
   children: [
-    { wordId: "WA", senses: [State.Sense, State.Sense] },
-    { wordId: "WB", senses: [State.Sense, State.Separate] },
+    { srcWordId: "WA", senseStates: [State.Sense, State.Sense] },
+    { srcWordId: "WB", senseStates: [State.Sense, State.Separate] },
   ],
 };
 const mockMerge3b = mockMerge2b;
-const mockMerge4a: parentWithMergeChildren = {
+const mockMerge4a: MergeWords = {
   parent: { ...mockWordList["WA4"], id: "WA", history: [] },
-  children: [{ wordId: "WA", senses: [State.Sense, State.Duplicate] }],
+  children: [{ srcWordId: "WA", senseStates: [State.Sense, State.Duplicate] }],
 };
 
 // These tests were written before guids were implemented, so guids can obstruct.
-function stripGuid(merge: parentWithMergeChildren): parentWithMergeChildren {
+function stripGuid(merge: MergeWords): MergeWords {
   return {
     parent: {
       ...merge.parent,
@@ -95,7 +92,7 @@ function stripGuid(merge: parentWithMergeChildren): parentWithMergeChildren {
     children: merge.children,
   };
 }
-function hashMerge(merge: parentWithMergeChildren) {
+function hashMerge(merge: MergeWords) {
   return JSON.stringify(stripGuid(merge));
 }
 
@@ -112,17 +109,19 @@ function setMockFunctions() {
   mockGetWords.mockImplementation((id: mockWordListIndex) =>
     Promise.resolve(mockWordList[id])
   );
-  mockMergeWords.mockImplementation((parent: Word, children: MergeWord[]) => {
-    expect(mockMerges).toContainEqual({ parent, children });
-    const args = hashMerge({ parent, children });
-    return Promise.resolve(mergeList[args]);
-  });
+  mockMergeWords.mockImplementation(
+    (parent: Word, children: MergeSourceWord[]) => {
+      expect(mockMerges).toContainEqual({ parent, children });
+      const args = hashMerge({ parent, children });
+      return Promise.resolve(mergeList[args]);
+    }
+  );
 }
 
 jest.mock("backend", () => {
   return {
     getWord: (id: mockWordListIndex) => mockGetWords(id),
-    mergeWords: (parent: Word, children: MergeWord[]) =>
+    mergeWords: (parent: Word, children: MergeSourceWord[]) =>
       mockMergeWords(parent, children),
   };
 });

--- a/src/types/word.tsx
+++ b/src/types/word.tsx
@@ -70,9 +70,13 @@ export class Word {
   }
 }
 
-export interface MergeWord {
-  wordId: string;
-  senses: State[];
+export interface MergeSourceWord {
+  srcWordId: string;
+  senseStates: State[];
+}
+export interface MergeWords {
+  parent: Word;
+  children: MergeSourceWord[];
 }
 
 //used in ExistingDataTable

--- a/src/types/word.tsx
+++ b/src/types/word.tsx
@@ -72,7 +72,7 @@ export class Word {
 
 export interface MergeSourceWord {
   srcWordId: string;
-  senseStates: State[];
+  getAudio: boolean;
 }
 export interface MergeWords {
   parent: Word;
@@ -114,15 +114,16 @@ export function multiGlossWord(vern: string, glosses: string[]): Word {
 
 // Used for unit testing, as the expected result, when the guids don't matter.
 export function multiGlossWordAnyGuid(vern: string, glosses: string[]): Word {
+  const senses = glosses.map((g) => ({
+    ...new Sense(g),
+    guid: expect.any(String),
+  }));
   return {
     ...new Word(),
     id: randomIntString(),
     guid: expect.any(String),
     vernacular: vern,
-    senses: glosses.map((gloss) => ({
-      ...new Sense(gloss),
-      guid: expect.any(String),
-    })),
+    senses,
   };
 }
 

--- a/src/types/word.tsx
+++ b/src/types/word.tsx
@@ -114,16 +114,15 @@ export function multiGlossWord(vern: string, glosses: string[]): Word {
 
 // Used for unit testing, as the expected result, when the guids don't matter.
 export function multiGlossWordAnyGuid(vern: string, glosses: string[]): Word {
-  const senses = glosses.map((g) => ({
-    ...new Sense(g),
-    guid: expect.any(String),
-  }));
   return {
     ...new Word(),
     id: randomIntString(),
     guid: expect.any(String),
     vernacular: vern,
-    senses,
+    senses: glosses.map((gloss) => ({
+      ...new Sense(gloss),
+      guid: expect.any(String),
+    })),
   };
 }
 


### PR DESCRIPTION
Rather than updating all remaining mergeWords after each is merged, prepare them all at once, then merge all, then delete all children from the frontier.

Resolves #1072
Resolves #1078

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1081)
<!-- Reviewable:end -->
