### PR TITLE
Remove host_vars files

### DIFF
--- a/deploy/group_vars/nuc/main.yml
+++ b/deploy/group_vars/nuc/main.yml
@@ -5,19 +5,20 @@
 # Group: nuc
 #################################################
 
-# TheCombine is installed on the QA Server by TeamCity.  It will set the
-# IMAGE_TAG environment variable to major.minor.build_no and launch
-# Docker compose
+# TheCombine is installed using Ansible and the playbook_install.yml
+# playbook.  It will set the IMAGE_TAG environment variable to
+# value provided by the user and launch docker-compose
 image_tag: "${IMAGE_TAG}"
 
 combine_image_backend: "{{ aws_ecr }}/combine/backend:{{ image_tag }}"
 combine_image_frontend: "{{ aws_ecr }}/combine/frontend:{{ image_tag }}"
 combine_image_certmgr: "{{ aws_ecr }}/combine/certmgr:{{ image_tag }}"
 
-# SSL cert variables specific to QA targets
+# SSL cert variables specific to NUC targets
 cert_mode: "cert-client"
 cert_email: ""
 cert_self_renewal: 60
+combine_alias_domain_list: []
 combine_cert_proxy_list: []
 
 # setup variables for roles/aws_access
@@ -35,6 +36,13 @@ aws_ecr_profile: ecr_read_only
 my_aws_profiles:
   - "{{ aws_s3_profile }}"
   - "{{ aws_ecr_profile }}"
+
+################################################
+# Disable Google reCAPTCHA for the NUC
+# (expected to work with no internet connection)
+################################################
+config_captcha_required: "false"
+config_captcha_sitekey: "none"
 
 ################################################
 # WiFi access point settings

--- a/deploy/host_vars/qa-thecombine.psonet.yml
+++ b/deploy/host_vars/qa-thecombine.psonet.yml
@@ -1,5 +1,0 @@
----
-combine_server_name: qa-thecombine.psonet
-combine_addl_domain_list: []
-config_captcha_required: "true"
-config_captcha_sitekey: "6LeG1LYZAAAAAPELEO16SkI6eY3gom8PoNJen35a"

--- a/deploy/host_vars/thecombine.app.yml
+++ b/deploy/host_vars/thecombine.app.yml
@@ -1,6 +1,0 @@
----
-combine_server_name: thecombine.app
-combine_addl_domain_list:
-  - thecombine.languagetechnology.org
-config_captcha_required: "true"
-config_captcha_sitekey: "6LdZIlkaAAAAAES4FZ5d01Shj5G4X0e2CHYg0D5t"

--- a/deploy/host_vars/thecombine.yml
+++ b/deploy/host_vars/thecombine.yml
@@ -1,4 +1,0 @@
----
-combine_server_name: thecombine.languagetechnology.org
-config_captcha_required: "true"
-config_captcha_sitekey: "6LemQNgUAAAAAAwJ6dps-Uncg5xsNuDdMxehfW8d"

--- a/deploy/hosts.yml
+++ b/deploy/hosts.yml
@@ -21,7 +21,7 @@ all:
           combine_server_name: thecombine.app
           cert_mode: cert-server
           combine_addl_domain_list:
-            - www.thecombine.app
+            - thecombine.languagetechnology.org
           combine_cert_proxy_list:
             - nuc2.thecombine.app
             - nuc1.thecombine.app

--- a/deploy/hosts.yml
+++ b/deploy/hosts.yml
@@ -4,10 +4,26 @@ all:
   children:
     nuc:
       hosts:
+        nuc1:
+          combine_server_name: nuc1.thecombine.app
         nuc2:
-    server:
-      hosts:
-        thecombine.app:
+          combine_server_name: nuc2.thecombine.app
     qa:
       hosts:
         qa-thecombine.psonet:
+          combine_server_name: qa-thecombine.psonet
+          combine_addl_domain_list: []
+          config_captcha_required: "true"
+          config_captcha_sitekey: "6LeG1LYZAAAAAPELEO16SkI6eY3gom8PoNJen35a"
+    server:
+      hosts:
+        thecombine.app:
+          combine_server_name: thecombine.app
+          cert_mode: cert-server
+          combine_addl_domain_list:
+            - www.thecombine.app
+          combine_cert_proxy_list:
+            - nuc2.thecombine.app
+            - nuc1.thecombine.app
+          config_captcha_required: "true"
+          config_captcha_sitekey: "6LdZIlkaAAAAAES4FZ5d01Shj5G4X0e2CHYg0D5t"


### PR DESCRIPTION
Move host specific configuration items to the hosts.yml inventory file.  This is a step to enable easier configuration for other sites to run their own instance of _TheCombine_.

Also update NUC configuration items.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1082)
<!-- Reviewable:end -->
