### PR TITLE
Configure logging for docker engine

### DIFF
--- a/deploy/roles/docker_install/tasks/main.yml
+++ b/deploy/roles/docker_install/tasks/main.yml
@@ -70,8 +70,8 @@
   notify: restart rsyslog
 
 - name: Configure Default Docker Logging
-  copy:
-    src: daemon.json
+  template:
+    src: daemon.json.j2
     dest: /etc/docker/daemon.json
     owner: root
     group: root

--- a/deploy/roles/docker_install/templates/daemon.json.j2
+++ b/deploy/roles/docker_install/templates/daemon.json.j2
@@ -1,4 +1,7 @@
 {
+{% if combine_use_syslog is defined and combine_use_syslog %}
+  "log-driver": "syslog"
+{% else %}
   "log-driver": "json-file",
   "log-opts": {
     "max-size": "10m",
@@ -6,4 +9,5 @@
     "labels": "production_status",
     "env": "os,customer"
   }
+{% endif %}
 }


### PR DESCRIPTION
Configure the docker engine to log using the syslog driver instead of the json driver.

This is residual work from #1055.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1088)
<!-- Reviewable:end -->
