### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,15 +281,11 @@ To run all Python linting steps:
 (venv) $ tox
 ```
 
-To upgrade all pinned dependencies, run the following command under Python 3.6 so the requirements are
-backwards-compatible.
+To upgrade all pinned dependencies:
 
 ```bash
 (venv) $ python -m piptools compile --upgrade dev-requirements.in
 ```
-
-Then manually remove `dataclasses==` line from `dev-requirements.txt`. This is to work around a pinning issue with
-supporting Python 3.6 and 3.7+.
 
 ## Amazon Web Services
 

--- a/deploy/bin/clean_repo.py
+++ b/deploy/bin/clean_repo.py
@@ -56,7 +56,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def run_aws_cmd(aws_cmd: List[str], verbose: bool = False) -> subprocess.CompletedProcess:
+def run_aws_cmd(aws_cmd: List[str], verbose: bool = False) -> subprocess.CompletedProcess[str]:
     """Run an AWS command and print the command and results if verbose is set."""
     if verbose:
         print(aws_cmd)

--- a/deploy/roles/combine_maintenance/files/aws_backup.py
+++ b/deploy/roles/combine_maintenance/files/aws_backup.py
@@ -1,5 +1,7 @@
 """Wrappers to push/pull backups to/from AWS S3 bucket."""
 
+from __future__ import annotations
+
 from pathlib import Path
 import subprocess
 
@@ -14,17 +16,17 @@ class AwsBackup:
         self.profile = profile
         self.bucket = bucket
 
-    def push(self, src: Path, dest: str) -> subprocess.CompletedProcess:
+    def push(self, src: Path, dest: str) -> subprocess.CompletedProcess[str]:
         """Push a file to the AWS S3 bucket."""
         s3_uri = f"s3://{self.bucket}/{dest}"
         return run_cmd(["aws", "s3", "cp", str(src), s3_uri, "--profile", self.profile])
 
-    def pull(self, src: str, dest: Path) -> subprocess.CompletedProcess:
+    def pull(self, src: str, dest: Path) -> subprocess.CompletedProcess[str]:
         """Push a file to the AWS S3 bucket."""
         s3_uri = f"s3://{self.bucket}/{src}"
         return run_cmd(["aws", "s3", "cp", s3_uri, str(dest), "--profile", self.profile])
 
-    def list(self) -> subprocess.CompletedProcess:
+    def list(self) -> subprocess.CompletedProcess[str]:
         """List the objects in the S3 bucket."""
         return run_cmd(
             ["aws", "s3", "ls", f"s3://{self.bucket}", "--recursive", "--profile", self.profile]

--- a/deploy/roles/combine_maintenance/files/combine_app.py
+++ b/deploy/roles/combine_maintenance/files/combine_app.py
@@ -1,5 +1,7 @@
 """Run commands on the Combine services."""
 
+from __future__ import annotations
+
 import enum
 import json
 from pathlib import Path
@@ -43,7 +45,7 @@ class CombineApp:
         *,
         exec_opts: Optional[List[str]] = None,
         check_results: bool = True,
-    ) -> subprocess.CompletedProcess:
+    ) -> subprocess.CompletedProcess[str]:
         """
         Run a docker-compose 'exec' command in a Combine container.
 
@@ -103,15 +105,15 @@ class CombineApp:
         )
         result_str = self.object_id_to_str(db_results.stdout)
         if result_str:
-            result_dict = json.loads(result_str)
+            result_dict: Dict[str, Any] = json.loads(result_str)
             return result_dict
         return None
 
-    def start(self, services: List[str]) -> subprocess.CompletedProcess:
+    def start(self, services: List[str]) -> subprocess.CompletedProcess[str]:
         """Start the specified combine service(s)."""
         return run_cmd(["docker-compose"] + self.compose_opts + ["start"] + services)
 
-    def stop(self, services: List[str]) -> subprocess.CompletedProcess:
+    def stop(self, services: List[str]) -> subprocess.CompletedProcess[str]:
         """Stop the specified combine service(s)."""
         return run_cmd(
             ["docker-compose"] + self.compose_opts + ["stop", "--timeout", "0"] + services
@@ -127,7 +129,7 @@ class CombineApp:
             return None
 
         if len(results) == 1:
-            return results[0]["_id"]
+            return results[0]["_id"]  # type: ignore
         if len(results) > 1:
             print(f"More than one project is named {project_name}", file=sys.stderr)
             sys.exit(1)
@@ -139,10 +141,10 @@ class CombineApp:
             f'db.UsersCollection.findOne({{ username: "{user}"}}, {{ username: 1 }})'
         )
         if results is not None:
-            return results["_id"]
+            return results["_id"]  # type: ignore
         results = self.db_cmd(
             f'db.UsersCollection.findOne({{ email: "{user}"}}, {{ username: 1 }})'
         )
         if results is not None:
-            return results["_id"]
+            return results["_id"]  # type: ignore
         return None

--- a/deploy/roles/combine_maintenance/files/maint_utils.py
+++ b/deploy/roles/combine_maintenance/files/maint_utils.py
@@ -1,5 +1,7 @@
 """Collection of utility functions for the Combine maintenance scripts."""
 
+from __future__ import annotations
+
 import subprocess
 import sys
 from typing import List

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ extend-exclude =
 # tox-gh-actions configuration.
 [gh-actions]
 python =
-    3.6: lint
     3.7: lint
     3.8: lint, fmt-check, type-check, user-guide
     3.9: lint


### PR DESCRIPTION
- Drop support for Python 3.6
  - Python 3.6 support was kept solely because it is the default Python version on Ubuntu 18.04. We've since migrate to Ubuntu 20.04+
- Enable `mypy` strict mode to get additional type checking

Note that [`__from__ future import annotations`](https://www.python.org/dev/peps/pep-0563/) is needed in some cases for generics that are supported in Python 3.9+ but not in Python 3.7+. What this does is defer evaluation of the type annotations so that they aren't actually run at run time (which is not needed as Python does not do runtime type checking).
