### PR TITLE
Remove reference to backend running on port 5001

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,9 +341,6 @@ Installs the necessary packages and runs the app in the development mode.<br> Op
 
 The page will reload if you make edits.<br> You will also see any lint errors in the console.
 
-> Note: You may need to first browse to https://localhost:5001 and accept the certificate warning in your browser if you
-> get Network Errors the first time you try to run the application locally.
-
 #### `npm run frontend`
 
 Runs only the front end of the app in the development mode.


### PR DESCRIPTION
Since moving to Docker/NGINX, we no longer run SSL outside of a reverse proxy directly from the backend. Remove an outdated reference to this from from the README.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1137)
<!-- Reviewable:end -->
