### PR TITLE
Remove residual backend HTTPS setting

### DIFF
--- a/Backend/Startup.cs
+++ b/Backend/Startup.cs
@@ -246,12 +246,6 @@ namespace BackendFramework
                 app.UseHsts();
             }
 
-            // In container deployment, NGINX acts as reverse proxy and handles HTTPS connections.
-            if (!IsInContainer())
-            {
-                app.UseHttpsRedirection();
-            }
-
             app.UseRouting();
             app.UseCors(AllowedOrigins);
 


### PR DESCRIPTION
Fix the following backend warning that is shown on startup:

```
warn: Microsoft.AspNetCore.HttpsPolicy.HttpsRedirectionMiddleware[3]
      Failed to determine the https port for redirect.
```

The backend no longer runs HTTPS itself, that is delegated to NGINX