### PR TITLE
When merging senses, only show glosses from the keeper.

### DIFF
--- a/src/goals/MergeDupGoal/MergeDupStep/DragDropComponents/DragSense.tsx
+++ b/src/goals/MergeDupGoal/MergeDupStep/DragDropComponents/DragSense.tsx
@@ -87,14 +87,17 @@ export default function DragSense(props: DragSenseProps) {
     updateSidebar();
   }
 
-  let glosses: MergeGloss[] = [];
-  for (const entry of props.senses) {
-    for (const gloss of entry.glosses) {
-      glosses.push({ ...gloss, senseGuid: entry.guid });
-    }
-  }
+  // Only display the first sense; others will be deleted as duplicates.
+  // User can select a different one by reordering in the sidebar.
+  const firstSense = props.senses[0];
+  let glosses: MergeGloss[] = firstSense.glosses.map((g) => ({
+    ...g,
+    senseGuid: firstSense.guid,
+  }));
+  // Filter out duplicates.
   glosses = glosses.filter(
-    (v, i, a) => a.findIndex((o) => o.def === v.def) === i
+    (v, i, a) =>
+      a.findIndex((o) => o.def === v.def && o.language === v.language) === i
   );
 
   const semDoms = [


### PR DESCRIPTION
When combining senses (dropping a sense on another, triggering the sidebar to open), we show all the glosses, but during the actual merge, only the first sense and its glosses are preserved. This pr implements visual indication that only the first of merged senses is kept in the merge process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1151)
<!-- Reviewable:end -->
