### PR TITLE
Fix maintenance scripts

### DIFF
--- a/deploy/bin/clean_repo.py
+++ b/deploy/bin/clean_repo.py
@@ -56,7 +56,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def run_aws_cmd(aws_cmd: List[str], verbose: bool = False) -> subprocess.CompletedProcess[str]:
+def run_aws_cmd(aws_cmd: List[str], verbose: bool = False) -> subprocess.CompletedProcess:
     """Run an AWS command and print the command and results if verbose is set."""
     if verbose:
         print(aws_cmd)

--- a/deploy/roles/combine_maintenance/files/aws_backup.py
+++ b/deploy/roles/combine_maintenance/files/aws_backup.py
@@ -16,17 +16,17 @@ class AwsBackup:
         self.profile = profile
         self.bucket = bucket
 
-    def push(self, src: Path, dest: str) -> subprocess.CompletedProcess[str]:
+    def push(self, src: Path, dest: str) -> subprocess.CompletedProcess:
         """Push a file to the AWS S3 bucket."""
         s3_uri = f"s3://{self.bucket}/{dest}"
         return run_cmd(["aws", "s3", "cp", str(src), s3_uri, "--profile", self.profile])
 
-    def pull(self, src: str, dest: Path) -> subprocess.CompletedProcess[str]:
+    def pull(self, src: str, dest: Path) -> subprocess.CompletedProcess:
         """Push a file to the AWS S3 bucket."""
         s3_uri = f"s3://{self.bucket}/{src}"
         return run_cmd(["aws", "s3", "cp", s3_uri, str(dest), "--profile", self.profile])
 
-    def list(self) -> subprocess.CompletedProcess[str]:
+    def list(self) -> subprocess.CompletedProcess:
         """List the objects in the S3 bucket."""
         return run_cmd(
             ["aws", "s3", "ls", f"s3://{self.bucket}", "--recursive", "--profile", self.profile]

--- a/deploy/roles/combine_maintenance/files/combine_app.py
+++ b/deploy/roles/combine_maintenance/files/combine_app.py
@@ -45,7 +45,7 @@ class CombineApp:
         *,
         exec_opts: Optional[List[str]] = None,
         check_results: bool = True,
-    ) -> subprocess.CompletedProcess[str]:
+    ) -> subprocess.CompletedProcess:
         """
         Run a docker-compose 'exec' command in a Combine container.
 
@@ -109,11 +109,11 @@ class CombineApp:
             return result_dict
         return None
 
-    def start(self, services: List[str]) -> subprocess.CompletedProcess[str]:
+    def start(self, services: List[str]) -> subprocess.CompletedProcess:
         """Start the specified combine service(s)."""
         return run_cmd(["docker-compose"] + self.compose_opts + ["start"] + services)
 
-    def stop(self, services: List[str]) -> subprocess.CompletedProcess[str]:
+    def stop(self, services: List[str]) -> subprocess.CompletedProcess:
         """Stop the specified combine service(s)."""
         return run_cmd(
             ["docker-compose"] + self.compose_opts + ["stop", "--timeout", "0"] + services
@@ -129,7 +129,7 @@ class CombineApp:
             return None
 
         if len(results) == 1:
-            return results[0]["_id"]  # type: ignore
+            return results[0]["_id"]
         if len(results) > 1:
             print(f"More than one project is named {project_name}", file=sys.stderr)
             sys.exit(1)
@@ -141,10 +141,10 @@ class CombineApp:
             f'db.UsersCollection.findOne({{ username: "{user}"}}, {{ username: 1 }})'
         )
         if results is not None:
-            return results["_id"]  # type: ignore
+            return results["_id"]
         results = self.db_cmd(
             f'db.UsersCollection.findOne({{ email: "{user}"}}, {{ username: 1 }})'
         )
         if results is not None:
-            return results["_id"]  # type: ignore
+            return results["_id"]
         return None

--- a/deploy/roles/combine_maintenance/tasks/main.yml
+++ b/deploy/roles/combine_maintenance/tasks/main.yml
@@ -50,20 +50,24 @@
     group: "{{ combine_group }}"
     mode: "{{ item.mode }}"
   with_items:
-    - name: rm_project.py
-      mode: "0755"
     - name: add_user_to_proj.py
       mode: "0755"
-    - name: make_user_admin.py
-      mode: "0755"
-    - name: maint_utils.py
+    - name: aws_backup.py
       mode: "0644"
-    - name: script_step.py
+    - name: combine_app.py
       mode: "0644"
     - name: combine_backup.py
       mode: "0755"
     - name: combine_restore.py
       mode: "0755"
+    - name: maint_utils.py
+      mode: "0644"
+    - name: make_user_admin.py
+      mode: "0755"
+    - name: rm_project.py
+      mode: "0755"
+    - name: script_step.py
+      mode: "0644"
 
 - name: set environment variables for backup job
   cron:


### PR DESCRIPTION
Addresses the following problems with the maintenance scripts for The Combine:
- PR #1114, Drop Python 3.6 Support, introduces type problems with calls to subprocess.run.
- Ansible role `combine_maintenance` does not install all the required Python modules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1152)
<!-- Reviewable:end -->
