### PR TITLE
Explicitly enable the docker service when docker is installed

### DIFF
--- a/deploy/roles/docker_install/tasks/main.yml
+++ b/deploy/roles/docker_install/tasks/main.yml
@@ -43,6 +43,12 @@
     name: "{{ docker_packages }}"
   notify: reboot target
 
+- name: Enable Docker service
+  service:
+    name: docker
+    enabled: yes
+    state: started
+
 - name: Create directory for TheCombine logs
   file:
     path: "{{ combine_log_directory }}"


### PR DESCRIPTION
Add a task to the `docker_install` role to explicitly enable the docker service (that is, start automatically) after docker has been installed.  This is required for _The Combine_ to start when the NUC is powered on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1156)
<!-- Reviewable:end -->
