### PR TITLE
Set ethernet as optional on NUCs

### DIFF
--- a/deploy/group_vars/nuc/main.yml
+++ b/deploy/group_vars/nuc/main.yml
@@ -50,6 +50,11 @@ config_captcha_sitekey: "none"
 config_email_enabled: "false"
 
 ################################################
+# Ethernet settings
+################################################
+eth_optional: yes
+
+################################################
 # WiFi access point settings
 ################################################
 has_wifi: yes

--- a/deploy/playbook_target_setup.yml
+++ b/deploy/playbook_target_setup.yml
@@ -25,39 +25,43 @@
     - "vars/{{ aws_credentials | default('aws.yml',true) }}"
 
   tasks:
-    - name: install required packages dependencies
+    - name: Install required packages dependencies
       import_role:
         name: package_install
 
-    - name: setup WiFi access point
+    - name: Setup WiFi access point
       import_role:
         name: wifi_ap
       when: has_wifi
 
-    - name: install docker subsystem
+    - name: Configure Ethernet connection
+      import_role:
+        name: ethernet_config
+
+    - name: Install Docker subsystem
       import_role:
         name: docker_install
 
-    - name: create combine user
+    - name: Create combine user
       import_role:
         name: combine_user
 
-    - name: install combine configuration files
+    - name: Install combine configuration files
       import_role:
         name: combine_config
 
-    - name: setup AWS access
+    - name: Setup AWS access
       import_role:
         name: aws_access
       tags:
         - aws
 
-    - name: setup certificate update from AWS S3
+    - name: Setup certificate update from AWS S3
       import_role:
         name: cert_update
       when: cert_mode == "cert-client"
 
-    - name: setup container maintenance scripts
+    - name: Setup container maintenance scripts
       import_role:
         name: combine_maintenance
       tags:

--- a/deploy/roles/ethernet_config/defaults/main.yaml
+++ b/deploy/roles/ethernet_config/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+eth_optional: no

--- a/deploy/roles/ethernet_config/handlers/main.yaml
+++ b/deploy/roles/ethernet_config/handlers/main.yaml
@@ -1,0 +1,3 @@
+---
+- name: Apply netplan
+  command: /usr/sbin/netplan apply

--- a/deploy/roles/ethernet_config/tasks/main.yml
+++ b/deploy/roles/ethernet_config/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name: List netplan configuration files
+  find:
+    paths: /etc/netplan
+    patterns: "*.yaml"
+  when: eth_optional
+  register: net_config
+
+- name: Set Ethernet I/F as optional
+  lineinfile:
+    path: "{{ item.path }}"
+    state: present
+    insertafter: "    en[a-z]\\d"
+    line: "      optional: true"
+  when: eth_optional
+  with_items: "{{ net_config.files }}"
+  notify: Apply netplan

--- a/deploy/roles/ethernet_config/tasks/main.yml
+++ b/deploy/roles/ethernet_config/tasks/main.yml
@@ -10,7 +10,7 @@
   lineinfile:
     path: "{{ item.path }}"
     state: present
-    insertafter: "    en[a-z]\\d"
+    insertafter: "^    en[a-z]\\d"
     line: "      optional: true"
   when: eth_optional
   with_items: "{{ net_config.files }}"


### PR DESCRIPTION
Update the default network configuration to specify that the Ethernet connection on the NUC is optional.  In the normal use of the NUC, the Ethernet cable is not connected and the NUC waits for the connection during startup.  With this change, the time from power on until The Combine is ready goes from 3 minutes to 30 seconds.

Note that this implementation iterates over all network connection configuration files and updates all ethernet connections.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1162)
<!-- Reviewable:end -->
