### PR TITLE
Disable pulling fonts from the Internet in the user guide

### DIFF
--- a/docs/user_guide/mkdocs.yml
+++ b/docs/user_guide/mkdocs.yml
@@ -13,7 +13,7 @@ theme:
   font: false
 repo_url: https://github.com/sillsdev/TheCombine
 repo_name: sillsdev/TheCombine
-copyright: © 2018-2021 SIL International
+copyright: © 2019-2021 SIL International
 extra:
   social:
     - icon: fontawesome/solid/globe

--- a/docs/user_guide/mkdocs.yml
+++ b/docs/user_guide/mkdocs.yml
@@ -9,9 +9,11 @@ theme:
     repo: fontawesome/brands/github
   favicon: images/favicon.ico
   language: en
+  # Disable pulling Google fonts from the Internet, to support offline networks.
+  font: false
 repo_url: https://github.com/sillsdev/TheCombine
 repo_name: sillsdev/TheCombine
-copyright: © 2020 SIL International
+copyright: © 2018-2021 SIL International
 extra:
   social:
     - icon: fontawesome/solid/globe


### PR DESCRIPTION
By default, [Material for MkDocs pulls fonts dynamically from the internet](https://squidfunk.github.io/mkdocs-material/setup/changing-the-fonts/#disabling-font-loading). To make the user experience better on offline networks, disable this feature and use built in system fonts instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1170)
<!-- Reviewable:end -->
