### PR TITLE
Use ts-key-enum to improve type safety of comparisons of KeyboardEvents

### DIFF
--- a/docs/style_guide/ts_style_guide.md
+++ b/docs/style_guide/ts_style_guide.md
@@ -18,6 +18,7 @@ Key Sections:
 - [`type` vs `interface`](#type-vs-interface)
 - [One-line `if` statements](#one-line-if-statements)
 - [imports](#imports)
+- [KeyBoardEvents](#keyboardevents)
 
 ## Variable and Function
 
@@ -380,3 +381,25 @@ import { Project } from "../../../../types/project";
 
 > Reason: Provides consistency for imports across all files and shortens imports of commonly used top level modules.
 > Developers don't have to count `../` to know where a module is, they can simply start from the root of `src/`.
+
+## KeyboardEvents
+
+Use `ts-key-enum` when comparing to `React.KeyboardEvent`s.
+
+**Good**
+
+```ts
+import { Key } from "ts-key-enum";
+
+if (event.key === Key.Enter) {
+}
+```
+
+**Bad**
+
+```ts
+if (event.key === "Enter") {
+}
+```
+
+> Reason: Avoid typos and increase the number of mistakes that can be caught at compile time.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16272,6 +16272,11 @@
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
     },
+    "ts-key-enum": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/ts-key-enum/-/ts-key-enum-2.0.7.tgz",
+      "integrity": "sha512-i5K1p6o5J2EMNS3DVpVdpsJnFMWNE01kBjnw5evS/XgBYiu/oo/mxamOOEVYn/uPbIaxl5iDVSbAcFCDY55tmw=="
+    },
     "ts-pnp": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "redux-persist": "^6.0.0",
     "redux-thunk": "^2.3.0",
     "source-map-explorer": "^2.5.2",
+    "ts-key-enum": "^2.0.7",
     "uuid": "^8.3.2",
     "validator": "^13.6.0",
     "xml2js": "^0.4.23"

--- a/src/components/Buttons/EditTextDialog.tsx
+++ b/src/components/Buttons/EditTextDialog.tsx
@@ -11,6 +11,7 @@ import {
 import { Clear } from "@material-ui/icons";
 import React, { useState } from "react";
 import { Translate } from "react-localize-redux";
+import { Key } from "ts-key-enum";
 
 import LoadingButton from "components/Buttons/LoadingButton";
 
@@ -50,7 +51,7 @@ export default function EditTextDialog(props: EditTextDialogProps) {
   }
 
   function confirmIfEnter(event: React.KeyboardEvent<any>) {
-    if (event.key === "Enter") {
+    if (event.key === Key.Enter) {
       onConfirm();
     }
   }

--- a/src/components/DataEntry/DataEntryHeader/DataEntryHeader.tsx
+++ b/src/components/DataEntry/DataEntryHeader/DataEntryHeader.tsx
@@ -6,6 +6,7 @@ import {
   withLocalize,
   LocalizeContextProps,
 } from "react-localize-redux";
+import { Key } from "ts-key-enum";
 
 import DomainTree from "types/SemanticDomain";
 import theme from "types/theme";
@@ -47,7 +48,7 @@ export class DataEntryHeader extends React.Component<
           style={{ paddingTop: "8px" }}
           disabled={!hasQuestions}
           onKeyPress={(e) => {
-            if (e.key === "Enter") {
+            if (e.key === Key.Enter) {
               this.props.setQuestionVisibility(!this.props.questionsVisible);
             }
           }}

--- a/src/components/DataEntry/DataEntryTable/EntryCellComponents/GlossWithSuggestions.tsx
+++ b/src/components/DataEntry/DataEntryTable/EntryCellComponents/GlossWithSuggestions.tsx
@@ -2,6 +2,7 @@ import { TextField } from "@material-ui/core";
 import { Autocomplete } from "@material-ui/lab";
 import React from "react";
 import { LocalizeContextProps, withLocalize } from "react-localize-redux";
+import { Key } from "ts-key-enum";
 
 import SpellChecker from "components/DataEntry/spellChecker";
 
@@ -65,7 +66,7 @@ export class GlossWithSuggestions extends React.Component<
           />
         )}
         onKeyPress={(e: React.KeyboardEvent) => {
-          if (e.key === "Enter" || e.key === "Tab")
+          if (e.key === Key.Enter || e.key === Key.Tab)
             this.props.handleEnterAndTab(e);
         }}
       />

--- a/src/components/DataEntry/DataEntryTable/EntryCellComponents/VernWithSuggestions.tsx
+++ b/src/components/DataEntry/DataEntryTable/EntryCellComponents/VernWithSuggestions.tsx
@@ -2,6 +2,7 @@ import { TextField } from "@material-ui/core";
 import { Autocomplete } from "@material-ui/lab";
 import React from "react";
 import { LocalizeContextProps, withLocalize } from "react-localize-redux";
+import { Key } from "ts-key-enum";
 
 interface VernWithSuggestionsProps {
   isNew?: boolean;
@@ -41,7 +42,7 @@ export class VernWithSuggestions extends React.Component<
             this.props.updateVernField(value);
           }}
           onKeyPress={(e: React.KeyboardEvent) => {
-            if (e.key === "Enter" || e.key === "Tab") {
+            if (e.key === Key.Enter || e.key === Key.Tab) {
               this.props.handleEnterAndTab(e);
             }
           }}

--- a/src/components/DataEntry/DataEntryTable/NewEntry/NewEntry.tsx
+++ b/src/components/DataEntry/DataEntryTable/NewEntry/NewEntry.tsx
@@ -1,6 +1,7 @@
 import { Grid, Typography } from "@material-ui/core";
 import React from "react";
 import { Translate } from "react-localize-redux";
+import { Key } from "ts-key-enum";
 
 import Pronunciations from "components/Pronunciations/PronunciationsComponent";
 import Recorder from "components/Pronunciations/Recorder";
@@ -205,7 +206,7 @@ export default class NewEntry extends React.Component<
   }
 
   handleEnter(e: React.KeyboardEvent, checkGloss: boolean) {
-    if (!this.state.vernOpen && e.key === "Enter") {
+    if (!this.state.vernOpen && e.key === Key.Enter) {
       // The user can never submit a new entry without a vernacular
       if (this.state.newEntry.vernacular) {
         // The user can conditionally submit a new entry without a gloss

--- a/src/components/TreeView/TreeViewHeader.tsx
+++ b/src/components/TreeView/TreeViewHeader.tsx
@@ -8,6 +8,7 @@ import {
 } from "@material-ui/core";
 import React, { useCallback, useEffect, useState } from "react";
 import Bounce from "react-reveal/Bounce";
+import { Key } from "ts-key-enum";
 
 import SemanticDomainWithSubdomains from "types/SemanticDomain";
 import DomainTile, { Direction } from "components/TreeView/DomainTile";
@@ -128,15 +129,15 @@ export function useTreeViewNavigation(props: TreeHeaderProps) {
   // Navigate tree via arrow keys
   const navigateDomainArrowKeys = useCallback(
     (event: KeyboardEvent) => {
-      if (event.key === "ArrowLeft") {
+      if (event.key === Key.ArrowLeft) {
         const domain = getBrotherDomain(-1, props);
         if (domain && domain.id !== props.currentDomain.id)
           props.animate(domain);
-      } else if (event.key === "ArrowRight") {
+      } else if (event.key === Key.ArrowRight) {
         const domain = getBrotherDomain(1, props);
         if (domain && domain.id !== props.currentDomain.id)
           props.animate(domain);
-      } else if (event.key === "ArrowUp") {
+      } else if (event.key === Key.ArrowUp) {
         if (props.currentDomain.parentDomain)
           props.animate(props.currentDomain.parentDomain);
       }
@@ -191,7 +192,7 @@ export function useTreeViewNavigation(props: TreeHeaderProps) {
     }
     event.bubbles = false;
 
-    if (event.key === "Enter") {
+    if (event.key === Key.Enter) {
       event.preventDefault();
       // Find parent domain
       let parent: SemanticDomainWithSubdomains | undefined =

--- a/src/components/TreeView/tests/TreeViewHeader.test.tsx
+++ b/src/components/TreeView/tests/TreeViewHeader.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { renderHook, act } from "@testing-library/react-hooks";
 import userEvent from "@testing-library/user-event";
 import React from "react";
+import { Key } from "ts-key-enum";
 
 import MockDomain from "components/TreeView/tests/MockSemanticDomain";
 import {
@@ -52,7 +53,7 @@ describe("TreeViewHeader", () => {
       // Simulate the user typing the enter key
       const simulatedEnterKey: Partial<React.KeyboardEvent> = {
         bubbles: true,
-        key: "Enter",
+        key: Key.Enter,
         preventDefault: jest.fn(),
         target: keyboardTarget,
         stopPropagation: MOCK_STOP_PROP,
@@ -255,7 +256,7 @@ describe("TreeViewHeader", () => {
     const keyDownHandler = eventListeners.get("keydown");
     expect(keyDownHandler).not.toBeUndefined();
     const simulatedArrowKey: Partial<KeyboardEvent> = {
-      key: "ArrowRight",
+      key: Key.ArrowRight,
     };
     keyDownHandler!.call(null, simulatedArrowKey as Event);
     // verify that we would switch to the domain requested
@@ -267,7 +268,7 @@ describe("TreeViewHeader", () => {
     const keyDownHandler = eventListeners.get("keydown");
     expect(keyDownHandler).not.toBeUndefined();
     const simulatedArrowKey: Partial<KeyboardEvent> = {
-      key: "ArrowLeft",
+      key: Key.ArrowLeft,
     };
     keyDownHandler!.call(null, simulatedArrowKey as Event);
     // verify that we would switch to the domain requested
@@ -279,7 +280,7 @@ describe("TreeViewHeader", () => {
     const keyDownHandler = eventListeners.get("keydown");
     expect(keyDownHandler).not.toBeUndefined();
     const simulatedArrowKey: Partial<KeyboardEvent> = {
-      key: "ArrowUp",
+      key: Key.ArrowUp,
     };
     keyDownHandler!.call(null, simulatedArrowKey as Event);
     // verify that we would switch to the domain requested


### PR DESCRIPTION
Use `ts-key-enum` to improve the compile-time checking of comparisons of `KeyboardEvent`s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1179)
<!-- Reviewable:end -->
