### PR TITLE
Enable HTTP/2 support in production NGINX configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY . ./
 RUN npm run build
 
 # Production environment.
-FROM nginx:1.19
+FROM nginx:1.21
 
 WORKDIR /app
 

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -13,7 +13,7 @@ server {
 }
 
 server {
-    listen              443 ssl;
+    listen              443 ssl http2;
     server_name         ${SERVER_NAME};
     ssl_certificate     ${SSL_CERTIFICATE};
     ssl_certificate_key ${SSL_PRIVATE_KEY};
@@ -77,17 +77,17 @@ server {
     # Websocket proxy.
     # https://nginx.org/en/docs/http/websocket.html
     location /hub {
-        proxy_pass http://backend:5000;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_pass          http://backend:5000;
+        proxy_http_version  1.1;
+        proxy_set_header    Upgrade $http_upgrade;
+        proxy_set_header    Connection "upgrade";
     }
 
     # User Guide static files.
     location /docs {
-        alias       /usr/share/nginx/user_guide;
+        alias      /usr/share/nginx/user_guide;
         index      index.html index.htm;
-        expires     12h;
+        expires    12h;
         add_header Cache-Control "public, no-transform";
     }
 


### PR DESCRIPTION
Enable HTTP/2 support in NGINX. This should increase page loading performance, especially for mobile users and users running with high latency (e.g. a user in France running against the Combine within the U.S.).

Also update NGINX to the latest version (1.21).

HTTP/2 works by using a binary format that is more efficient to transmit as well as using a single TCP/TLS connection for multiple requests. This reduces round trip times to set up TCP + TLS connections. We already enabled TLS 1.3 in #779, which eliminated reduced 1 round trip time. Using HTTP/2 will further increase network performance of remote users.

HTTP/2 was released in 2015 and all major browsers support it: https://caniuse.com/http2. Somewhere around 60% of websites use HTTP/2 currently.

Because NGINX proxies connections to the backend, this change is transparent to the backend itself. It will continue to get HTTP/1.1 connections from NGINX over the fast, Docker virtual network.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1193)
<!-- Reviewable:end -->
