### PR TITLE
Add Docker build GitHub Actions Jobs

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -36,6 +36,7 @@ jobs:
       # Fmt.
       - run: dotnet tool install -g dotnet-format
       - run: dotnet-format --check
+
   CodeQL_build:
     runs-on: ubuntu-latest
     steps:
@@ -58,6 +59,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: false
-          context: Backend
+          context: ./Backend
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -54,11 +54,15 @@ jobs:
   docker_build:
     runs-on: ubuntu-latest
     steps:
+      # For subfolders, currently a full checkout is required.
+      # See: https://github.com/marketplace/actions/build-and-push-docker-images#path-context
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Build
         id: docker_build
         uses: docker/build-push-action@v2
         with:
+          context: Backend
           push: false
-          context: ./Backend
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -49,3 +49,15 @@ jobs:
         uses: github/codeql-action/autobuild@v1
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1
+
+  docker_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          context: Backend
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -34,3 +34,14 @@ jobs:
 
       # Release build.
       - run: npm build
+
+  docker_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Closes #1160

This PR adds two new Gitlab Actions CI jobs. One builds the backend docker image and one builds the frontend docker image. Note these are purely done for testing purposes: to ensure that a PR did not make changes that broke the production Docker image builds. These CI jobs are not intended for any kind of automatic Docker push/deployment, though that could be done in the future if desired.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1216)
<!-- Reviewable:end -->
