### PR TITLE
Retire asyncRegisterForEmailInvite

### DIFF
--- a/src/components/Login/Redux/LoginActions.ts
+++ b/src/components/Login/Redux/LoginActions.ts
@@ -86,33 +86,6 @@ export function asyncRegister(
   };
 }
 
-export function asyncRegisterForEmailInvite(
-  name: string,
-  username: string,
-  email: string,
-  password: string
-) {
-  return async (dispatch: StoreStateDispatch) => {
-    dispatch(registerAttempt(username));
-    // Create new user
-    const user = newUser(name, username, password);
-    user.email = email;
-    await backend
-      .addUser(user)
-      .then((_res) => {
-        dispatch(registerSuccess(username));
-        setTimeout(() => {
-          dispatch(reset());
-        }, 1000);
-      })
-      .catch((err) => {
-        dispatch(
-          registerFailure((err.response && err.response.status) || err.message)
-        );
-      });
-  };
-}
-
 export function registerAttempt(username: string): UserAction {
   return {
     type: LoginActionTypes.REGISTER_ATTEMPT,

--- a/src/components/ProjectInvite/index.ts
+++ b/src/components/ProjectInvite/index.ts
@@ -1,6 +1,6 @@
 import { connect } from "react-redux";
 
-import { asyncRegisterForEmailInvite } from "components/Login/Redux/LoginActions";
+import { asyncRegister } from "components/Login/Redux/LoginActions";
 import ProjectInvite, {
   ProjectInviteStateProps,
 } from "components/ProjectInvite/ProjectInviteComponent";
@@ -19,7 +19,7 @@ function mapStateToProps(state: StoreState): ProjectInviteStateProps {
 function mapDispatchToProps(dispatch: StoreStateDispatch) {
   return {
     register: (name: string, user: string, email: string, password: string) => {
-      dispatch(asyncRegisterForEmailInvite(name, user, email, password));
+      dispatch(asyncRegister(name, user, email, password));
     },
     reset: () => {
       dispatch(reset());


### PR DESCRIPTION
Fixes #1218 

Applying what #1187 did to `asyncRegister` to `asyncRegisterForEmailInvite` nullifies the subtle distinction between the two functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1219)
<!-- Reviewable:end -->
