### PR TITLE
Remove dependency on deprecated WebApiCompatShim

### DIFF
--- a/Backend/BackendFramework.csproj
+++ b/Backend/BackendFramework.csproj
@@ -13,7 +13,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.11.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.11.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />

--- a/Backend/Controllers/UserController.cs
+++ b/Backend/Controllers/UserController.cs
@@ -2,7 +2,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Web.Http;
 using BackendFramework.Helper;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
@@ -69,7 +68,8 @@ namespace BackendFramework.Controllers
             {
                 return Ok();
             }
-            return new InternalServerErrorResult();
+
+            return StatusCode(StatusCodes.Status500InternalServerError);
         }
 
         /// <summary> Resets a password using a token </summary>


### PR DESCRIPTION
Closes #1214 

This is a follow on of the work that has proceeded to eliminate remaining usages of deprecated ASP.NET 2.2 features from the code base.

- #1198 
- #1215

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1220)
<!-- Reviewable:end -->
