### PR TITLE
Unpin isort

### DIFF
--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -10,8 +10,7 @@ pep8-naming
 
 # Formatting.
 black
-# Pin until this issue is fixed: https://github.com/PyCQA/isort/issues/1762
-isort==5.8.0
+isort
 
 # Documentation.
 mkdocs-material

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -36,7 +36,7 @@ humanfriendly==9.2
     # via -r dev-requirements.in
 importlib-metadata==4.6.0
     # via mkdocs
-isort==5.8.0
+isort==5.9.2
     # via -r dev-requirements.in
 jinja2==2.11.3
     # via

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ commands =
 deps =
     -r{toxinidir}/dev-requirements.txt
 commands =
-    isort --check-only .
+    isort --check .
     black --check .
 
 [testenv:user-guide]


### PR DESCRIPTION
Unpin `isort` now that upstream https://github.com/PyCQA/isort/issues/1762 has been resolved.

Also use `--check` alias in `tox` config so that `isort` CLI matches similar `black` CLI arguments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1243)
<!-- Reviewable:end -->
