### PR TITLE
Install set_proj_owner.py script on target

### DIFF
--- a/deploy/roles/combine_maintenance/tasks/main.yml
+++ b/deploy/roles/combine_maintenance/tasks/main.yml
@@ -68,6 +68,8 @@
       mode: "0755"
     - name: script_step.py
       mode: "0644"
+    - name: set_proj_owner.py
+      mode: "0755"
 
 - name: set environment variables for backup job
   cron:


### PR DESCRIPTION
The maintenance script, `set_proj_owner.py` was approved with PR #1259.  This PR updates the Ansible playbooks to install the script on target machines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1262)
<!-- Reviewable:end -->
