### PR TITLE
Docker 20.10

### DIFF
--- a/deploy/roles/docker_install/defaults/main.yml
+++ b/deploy/roles/docker_install/defaults/main.yml
@@ -10,11 +10,11 @@ docker_packages:
 
 docker_pinned_pkgs:
   - pkg: docker-ce
-    version: "5:19.03.*"
+    version: "5:20.10.*"
   - pkg: docker-ce-cli
-    version: "5:19.03.*"
+    version: "5:20.10.*"
   - pkg: docker-ce-rootless-extras
-    version: "5:19.03.*"
+    version: "5:20.10.*"
 
 combine_log_directory: /var/log/combine
 docker_log_file: docker.log

--- a/deploy/roles/docker_install/handlers/main.yml
+++ b/deploy/roles/docker_install/handlers/main.yml
@@ -11,3 +11,8 @@
   service:
     name: rsyslog
     state: restarted
+
+- name: update packages
+  apt:
+    update_cache: yes
+    upgrade: "yes"

--- a/deploy/roles/docker_install/tasks/main.yml
+++ b/deploy/roles/docker_install/tasks/main.yml
@@ -46,6 +46,7 @@
     group: root
     mode: 0644
   with_items: "{{ docker_pinned_pkgs }}"
+  notify: update packages
 
 - name: Install Docker Engine
   apt:


### PR DESCRIPTION
Pin Ubuntu Docker packages to version 5.20.10.*;  Kubernetes has now been validated with Docker 20.10. (see [Container Runtimes | Kubernetes](https://kubernetes.io/docs/setup/production-environment/container-runtimes/)

Closes #1256.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1263)
<!-- Reviewable:end -->
