### PR TITLE
Fix vscode default tab setting to 4 spaces for cs.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
   "editor.formatOnSaveMode": "file",
   "[csharp]": {
     "editor.defaultFormatter": "ms-dotnettools.csharp",
+    "editor.insertSpaces": true,
     "editor.tabSize": 4
   },
   "[javascript]": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,8 @@
   "editor.formatOnSave": true,
   "editor.formatOnSaveMode": "file",
   "[csharp]": {
-    "editor.defaultFormatter": "ms-dotnettools.csharp"
+    "editor.defaultFormatter": "ms-dotnettools.csharp",
+    "editor.tabSize": 4
   },
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"


### PR DESCRIPTION
In a new .cs file, this sets the default to tab = 4 spaces.
When editing an existing .cs file, the existing indentation will override this, unless we also set `"editor.detectIndentation": false`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1264)
<!-- Reviewable:end -->
