### PR TITLE
Enable Material for MkDocs 7.2 search features

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,12 +14,16 @@ black==21.7b0
     # via -r dev-requirements.in
 certifi==2021.5.30
     # via requests
-charset-normalizer==2.0.3
+charset-normalizer==2.0.4
     # via requests
 click==8.0.1
     # via
     #   black
     #   mkdocs
+colorama==0.4.4
+    # via
+    #   click
+    #   tox
 distlib==0.3.2
     # via virtualenv
 filelock==3.0.12
@@ -39,9 +43,9 @@ humanfriendly==9.2
     # via -r dev-requirements.in
 idna==3.2
     # via requests
-importlib-metadata==4.6.1
+importlib-metadata==4.6.3
     # via mkdocs
-isort==5.9.2
+isort==5.9.3
     # via -r dev-requirements.in
 jinja2==2.11.3
     # via
@@ -67,7 +71,7 @@ mkdocs==1.2.2
     #   mkdocs-material
 mkdocs-htmlproofer-plugin==0.4.0
     # via -r dev-requirements.in
-mkdocs-material==7.1.11
+mkdocs-material==7.2.2
     # via
     #   -r dev-requirements.in
     #   mkdocs-material-extensions
@@ -87,7 +91,7 @@ pathspec==0.9.0
     # via black
 pep8-naming==0.12.0
     # via -r dev-requirements.in
-platformdirs==2.0.2
+platformdirs==2.2.0
     # via virtualenv
 pluggy==0.13.1
     # via tox
@@ -103,6 +107,8 @@ pymdown-extensions==8.2
     # via mkdocs-material
 pyparsing==2.4.7
     # via packaging
+pyreadline==2.1
+    # via humanfriendly
 python-dateutil==2.8.2
     # via ghp-import
 pyyaml==5.4.1
@@ -126,17 +132,17 @@ toml==0.10.2
     # via
     #   mypy
     #   tox
-tomli==1.0.4
+tomli==1.2.0
     # via black
-tox==3.24.0
+tox==3.24.1
     # via -r dev-requirements.in
-types-requests==2.25.0
+types-requests==2.25.1
     # via -r dev-requirements.in
 typing-extensions==3.10.0.0
     # via mypy
 urllib3==1.26.6
     # via requests
-virtualenv==20.6.0
+virtualenv==20.7.0
     # via tox
 watchdog==2.1.3
     # via mkdocs

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -20,10 +20,6 @@ click==8.0.1
     # via
     #   black
     #   mkdocs
-colorama==0.4.4
-    # via
-    #   click
-    #   tox
 distlib==0.3.2
     # via virtualenv
 filelock==3.0.12
@@ -57,6 +53,7 @@ jinja2-base64-filters==0.1.4
 markdown==3.3.4
     # via
     #   mkdocs
+    #   mkdocs-htmlproofer-plugin
     #   mkdocs-material
     #   pymdown-extensions
 markupsafe==2.0.1
@@ -69,7 +66,7 @@ mkdocs==1.2.2
     # via
     #   mkdocs-htmlproofer-plugin
     #   mkdocs-material
-mkdocs-htmlproofer-plugin==0.4.0
+mkdocs-htmlproofer-plugin==0.5.0
     # via -r dev-requirements.in
 mkdocs-material==7.2.2
     # via
@@ -107,8 +104,6 @@ pymdown-extensions==8.2
     # via mkdocs-material
 pyparsing==2.4.7
     # via packaging
-pyreadline==2.1
-    # via humanfriendly
 python-dateutil==2.8.2
     # via ghp-import
 pyyaml==5.4.1

--- a/docs/user_guide/mkdocs.yml
+++ b/docs/user_guide/mkdocs.yml
@@ -10,6 +10,10 @@ theme:
   language: en
   # Disable pulling Google fonts from the Internet, to support offline networks.
   font: false
+  features:
+    - search.highlight
+    - search.share
+    - search.suggest
 site_name: The Combine
 site_url: ""
 use_directory_urls: false


### PR DESCRIPTION
Material for MkDocs 7.2 released with the following new useful search features. Enable them for the user guide:

- https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#search-highlighting
- https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#search-sharing
- https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#search-suggestions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1283)
<!-- Reviewable:end -->
