### PR TITLE
Enable ESLint exhaustive switch linting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16347,9 +16347,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     },
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
-      "ecmaVersion": 2018,
       "project": "./tsconfig.json"
     }
   },

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "prettier": "^2.3.2",
     "react-test-renderer": "^17.0.1",
     "redux-mock-store": "^1.5.4",
-    "typescript": "^4.3.5"
+    "typescript": "4.2.4"
   },
   "eslintConfig": {
     "extends": "react-app",
@@ -105,7 +105,13 @@
       "jest": true
     },
     "rules": {
-      "no-undef": "off"
+      "no-undef": "off",
+      "@typescript-eslint/switch-exhaustiveness-check": "warn"
+    },
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+      "ecmaVersion": 2018,
+      "project": "./tsconfig.json"
     }
   },
   "prettier": {

--- a/src/components/GoalTimeline/Redux/GoalActions.ts
+++ b/src/components/GoalTimeline/Redux/GoalActions.ts
@@ -149,26 +149,26 @@ export function asyncUpdateGoal(goal: Goal) {
 // Returns true if input goal updated.
 export async function loadGoalData(goal: Goal): Promise<boolean> {
   switch (goal.goalType) {
-    case GoalType.MergeDups: {
+    case GoalType.MergeDups:
       await loadMergeDupsData(goal);
       return true;
-    }
+    default:
+      return false;
   }
-  return false;
 }
 
 // Returns true if input goal updated.
 export function updateStepFromData(goal: Goal): boolean {
   switch (goal.goalType) {
-    case GoalType.MergeDups: {
+    case GoalType.MergeDups:
       const currentGoalData = goal.data as MergeDupData;
       goal.steps[goal.currentStep] = {
         words: currentGoalData.plannedWords[goal.currentStep],
       };
       return true;
-    }
+    default:
+      return false;
   }
-  return false;
 }
 
 export function getUserEditId(): string | undefined {

--- a/src/components/ProjectExport/DownloadButton.tsx
+++ b/src/components/ProjectExport/DownloadButton.tsx
@@ -1,5 +1,5 @@
 import { IconButton, Tooltip } from "@material-ui/core";
-import { Cached, Error, GetApp } from "@material-ui/icons";
+import { Cached, Error as ErrorIcon, GetApp } from "@material-ui/icons";
 import React, { createRef, useEffect, useState } from "react";
 import { Translate } from "react-localize-redux";
 import { useDispatch, useSelector } from "react-redux";
@@ -40,24 +40,25 @@ export default function DownloadButton(props: DownloadButtonProps) {
     return `${projectName}_${getNowDateTimeString()}.zip`;
   }
 
-  async function download() {
-    const projectName = await getProjectName(exportState.projectId);
-    setFileName(makeExportName(projectName));
-    asyncDownloadExport(exportState.projectId)(dispatch)
-      .then((url) => {
-        if (url) {
-          setFileUrl(url);
-          reset();
-        }
-      })
-      .catch(console.error);
+  function download() {
+    getProjectName(exportState.projectId).then((projectName) => {
+      setFileName(makeExportName(projectName));
+      asyncDownloadExport(exportState.projectId)(dispatch)
+        .then((url) => {
+          if (url) {
+            setFileUrl(url);
+            reset();
+          }
+        })
+        .catch(console.error);
+    });
   }
 
   function reset() {
     resetExport(exportState.projectId)(dispatch);
   }
 
-  function textId() {
+  function textId(): string {
     switch (exportState.status) {
       case ExportStatus.InProgress:
         return "projectExport.exportInProgress";
@@ -65,17 +66,21 @@ export default function DownloadButton(props: DownloadButtonProps) {
         return "projectExport.downloadReady";
       case ExportStatus.Failure:
         return "projectExport.exportFailed";
+      default:
+        throw new Error("Not implemented");
     }
   }
 
-  function icon() {
+  function icon(): JSX.Element {
     switch (exportState.status) {
       case ExportStatus.InProgress:
         return <Cached />;
       case ExportStatus.Success:
         return <GetApp />;
       case ExportStatus.Failure:
-        return <Error />;
+        return <ErrorIcon />;
+      default:
+        return <div />;
     }
   }
 
@@ -87,12 +92,14 @@ export default function DownloadButton(props: DownloadButtonProps) {
       : themeColors.primary;
   }
 
-  function iconFunction() {
+  function iconFunction(): () => void {
     switch (exportState.status) {
       case ExportStatus.Success:
         return download;
       case ExportStatus.Failure:
         return reset;
+      default:
+        return () => {};
     }
   }
 

--- a/src/goals/CharInventoryCreation/components/CharacterList/CharacterStatusText.tsx
+++ b/src/goals/CharInventoryCreation/components/CharacterList/CharacterStatusText.tsx
@@ -23,11 +23,13 @@ export default function CharacterStatusText(props: CharacterStatusTextProps) {
   );
 }
 
-function CharacterStatusStyle(status: CharacterStatus) {
+function CharacterStatusStyle(status: CharacterStatus): { color: string } {
   switch (status) {
     case CharacterStatus.Accepted:
       return { color: themeColors.success };
     case CharacterStatus.Rejected:
       return { color: themeColors.error };
+    case CharacterStatus.Undecided:
+      return { color: themeColors.primary };
   }
 }


### PR DESCRIPTION
- Enable exhaustiveness checks for `switch` statements in the frontend. (https://stackoverflow.com/a/60166264/)
- Downgrade to TypeScript `4.2.4` to support `@typescript-eslint/parser` which doesn't support TypeScript 4.3.x in the version we have pinned
  - https://github.com/typescript-eslint/typescript-eslint/issues/3272
  - `npm` is pinning `@typescript-eslint/parser` at `4.21` (4 months old) rather than `4.29`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1298)
<!-- Reviewable:end -->
