### PR TITLE
Increase backend unit test coverage

### DIFF
--- a/Backend.Tests/Helper/SanitizationTests.cs
+++ b/Backend.Tests/Helper/SanitizationTests.cs
@@ -109,7 +109,7 @@ namespace Backend.Tests.Helper
             new List<string> { "make spaces underscores", "make_spaces_underscores" },
             new List<string> { "(){}[]", "()()()" },
             new List<string> { "こんにちは", "-----" },
-            new List<string> { "⁇⸘¡", ",,,"}
+            new List<string> { "⁇⸘¡", ",,," }
         };
         [TestCaseSource(nameof(_namesUnfriendlyFriendly))]
         public void TestMakeFriendlyForPath(List<string> nameName)

--- a/Backend.Tests/Helper/SanitizationTests.cs
+++ b/Backend.Tests/Helper/SanitizationTests.cs
@@ -108,7 +108,8 @@ namespace Backend.Tests.Helper
             new List<string> { "math+and=currency$to<dash", "math-and-currency-to-dash" },
             new List<string> { "make spaces underscores", "make_spaces_underscores" },
             new List<string> { "(){}[]", "()()()" },
-            new List<string> { "こんにちは", "-----" }
+            new List<string> { "こんにちは", "-----" },
+            new List<string> { "⁇⸘¡", ",,,"}
         };
         [TestCaseSource(nameof(_namesUnfriendlyFriendly))]
         public void TestMakeFriendlyForPath(List<string> nameName)

--- a/Backend.Tests/Helper/TimeTests.cs
+++ b/Backend.Tests/Helper/TimeTests.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using NUnit.Framework;
+using BackendFramework.Helper;
+
+namespace Backend.Tests.Helper
+{
+    public class TimeTests
+    {
+        [Test]
+        public void TestToUtcIso8601()
+        {
+            Assert.AreEqual(
+                Time.ToUtcIso8601(new DateTime(2020, 1, 1)),
+                "2020-01-01T00:00:00.0000000"
+            );
+        }
+
+        [Test]
+        public void UtcNowIso8601()
+        {
+            var time = Time.UtcNowIso8601();
+            Assert.That(time.Contains("T"));
+            Assert.That(time.EndsWith("Z"));
+            Assert.That(DateTime.Now, Is.EqualTo(DateTime.Parse(time)).Within(TimeSpan.FromMinutes(5)));
+        }
+    }
+}

--- a/Backend.Tests/Helper/TimeTests.cs
+++ b/Backend.Tests/Helper/TimeTests.cs
@@ -21,7 +21,7 @@ namespace Backend.Tests.Helper
             var time = Time.UtcNowIso8601();
             Assert.That(time.Contains("T"));
             Assert.That(time.EndsWith("Z"));
-            Assert.That(DateTime.Now, Is.EqualTo(DateTime.Parse(time)).Within(TimeSpan.FromMinutes(5)));
+            Assert.That(DateTime.Now, Is.EqualTo(DateTime.Parse(time)).Within(TimeSpan.FromSeconds(10)));
         }
     }
 }

--- a/Backend.Tests/Models/EmailInviteTests.cs
+++ b/Backend.Tests/Models/EmailInviteTests.cs
@@ -14,8 +14,8 @@ namespace Backend.Tests.Models
         [Test]
         public void TestEquals()
         {
-            var field = new EmailInvite { Email = Email, Token = Token, ExpireTime = _expireTime};
-            Assert.That(field.Equals(new EmailInvite { Email = Email, Token = Token, ExpireTime = _expireTime}));
+            var field = new EmailInvite { Email = Email, Token = Token, ExpireTime = _expireTime };
+            Assert.That(field.Equals(new EmailInvite { Email = Email, Token = Token, ExpireTime = _expireTime }));
         }
 
         [Test]

--- a/Backend.Tests/Models/EmailInviteTests.cs
+++ b/Backend.Tests/Models/EmailInviteTests.cs
@@ -7,6 +7,32 @@ namespace Backend.Tests.Models
 {
     public class EmailInviteTests
     {
+        private const string Email = "user@combine.org";
+        private const string Token = "Token";
+        private readonly DateTime _expireTime = new(2020, 1, 1);
+
+        [Test]
+        public void TestEquals()
+        {
+            var field = new EmailInvite { Email = Email, Token = Token, ExpireTime = _expireTime};
+            Assert.That(field.Equals(new EmailInvite { Email = Email, Token = Token, ExpireTime = _expireTime}));
+        }
+
+        [Test]
+        public void TestEqualsNull()
+        {
+            var invite = new EmailInvite();
+            Assert.IsFalse(invite.Equals(null));
+        }
+
+        [Test]
+        public void TestNotEquals()
+        {
+            var invite = new EmailInvite { Email = Email, Token = Token };
+            Assert.IsFalse(invite.Equals(new EmailInvite { Email = Email, Token = "Other Token" }));
+            Assert.IsFalse(invite.Equals(new EmailInvite { Email = "Other Email", Token = Token }));
+        }
+
         [Test]
         public void TestClone()
         {
@@ -22,6 +48,15 @@ namespace Backend.Tests.Models
                 Assert.That(invite.ExpireTime, Is.EqualTo(DateTime.Now).Within(TimeSpan.FromDays(daysUntilExpire)));
                 Assert.That(WebEncoders.Base64UrlDecode(invite.Token).Length, Is.EqualTo(8));
             }
+        }
+
+        [Test]
+        public void TestHashCode()
+        {
+            Assert.AreNotEqual(
+                new EmailInvite { Email = Email }.GetHashCode(),
+                new EmailInvite { Email = "Different Name" }.GetHashCode()
+            );
         }
     }
 }

--- a/Backend.Tests/Models/ProjectTests.cs
+++ b/Backend.Tests/Models/ProjectTests.cs
@@ -83,12 +83,12 @@ namespace Backend.Tests.Models
         [Test]
         public void TestClone()
         {
-            var system = new WritingSystem { Name = Name, Bcp47 = "en", Font = "calibri" };
-            var project = new Project { Name = Name, VernacularWritingSystem = system };
-            var domain = new SemanticDomain { Name = Name, Id = "1", Description = "text" };
+            var system = new WritingSystem { Name = "WritingSystemName", Bcp47 = "en", Font = "calibri" };
+            var project = new Project { Name = "ProjectName", VernacularWritingSystem = system };
+            var domain = new SemanticDomain { Name = "SemanticDomainName", Id = "1", Description = "text" };
             project.SemanticDomains.Add(domain);
 
-            var customField = new CustomField { Name = Name, Type = "type" };
+            var customField = new CustomField { Name = "CustomFieldName", Type = "type" };
             project.CustomFields.Add(customField);
 
             var emailInvite = new EmailInvite(10, "user@combine.org");

--- a/Backend.Tests/Models/ProjectTests.cs
+++ b/Backend.Tests/Models/ProjectTests.cs
@@ -87,8 +87,13 @@ namespace Backend.Tests.Models
             var project = new Project { Name = Name, VernacularWritingSystem = system };
             var domain = new SemanticDomain { Name = Name, Id = "1", Description = "text" };
             project.SemanticDomains.Add(domain);
+
             var customField = new CustomField { Name = Name, Type = "type" };
             project.CustomFields.Add(customField);
+
+            var emailInvite = new EmailInvite(10, "user@combine.org");
+            project.InviteTokens.Add(emailInvite);
+
             var project2 = project.Clone();
             Assert.AreEqual(project, project2);
         }

--- a/Backend.Tests/Models/ProjectTests.cs
+++ b/Backend.Tests/Models/ProjectTests.cs
@@ -111,31 +111,30 @@ namespace Backend.Tests.Models
         [Test]
         public void TestEquals()
         {
-            var system = new CustomField { Name = Name, Type = Type };
-            Assert.That(system.Equals(new CustomField { Name = Name, Type = Type }));
+            var field = new CustomField { Name = Name, Type = Type };
+            Assert.That(field.Equals(new CustomField { Name = Name, Type = Type }));
         }
 
         [Test]
         public void TestEqualsNull()
         {
-            var system = new CustomField { Name = Name };
-            Assert.IsFalse(system.Equals(null));
+            var field = new CustomField { Name = Name };
+            Assert.IsFalse(field.Equals(null));
         }
 
         [Test]
         public void TestNotEquals()
         {
-            var system = new CustomField { Name = Name, Type = Type };
-            Assert.IsFalse(system.Equals(new CustomField { Name = Name, Type = "Other Type" }));
-            Assert.IsFalse(system.Equals(new CustomField { Name = "Other Name", Type = Type }));
+            var field = new CustomField { Name = Name, Type = Type };
+            Assert.IsFalse(field.Equals(new CustomField { Name = Name, Type = "Other Type" }));
+            Assert.IsFalse(field.Equals(new CustomField { Name = "Other Name", Type = Type }));
         }
 
         [Test]
         public void TestClone()
         {
-            var system = new CustomField { Name = Name, Type = Type };
-            var clonedSystem = system.Clone();
-            Assert.AreEqual(system, clonedSystem);
+            var field = new CustomField { Name = Name, Type = Type };
+            Assert.AreEqual(field, field.Clone());
         }
 
         [Test]

--- a/Backend.Tests/Models/ProjectTests.cs
+++ b/Backend.Tests/Models/ProjectTests.cs
@@ -1,4 +1,5 @@
-﻿using BackendFramework.Models;
+﻿using System.Linq;
+using BackendFramework.Models;
 using NUnit.Framework;
 
 namespace Backend.Tests.Models
@@ -10,7 +11,6 @@ namespace Backend.Tests.Models
         [Test]
         public void TestEquals()
         {
-
             var project = new Project { Name = Name };
             Assert.That(project.Equals(new Project { Name = Name }));
         }
@@ -87,8 +87,64 @@ namespace Backend.Tests.Models
             var project = new Project { Name = Name, VernacularWritingSystem = system };
             var domain = new SemanticDomain { Name = Name, Id = "1", Description = "text" };
             project.SemanticDomains.Add(domain);
+            var customField = new CustomField { Name = Name, Type = "type" };
+            project.CustomFields.Add(customField);
             var project2 = project.Clone();
             Assert.AreEqual(project, project2);
+        }
+
+        [Test]
+        public void TestHashCode()
+        {
+            Assert.AreNotEqual(
+                new Project { Name = Name }.GetHashCode(),
+                new Project { Name = "Different Name" }.GetHashCode()
+            );
+        }
+    }
+
+    public class CustomFieldTests
+    {
+        private const string Name = "Name";
+        private const string Type = "Type";
+
+        [Test]
+        public void TestEquals()
+        {
+            var system = new CustomField { Name = Name, Type = Type };
+            Assert.That(system.Equals(new CustomField { Name = Name, Type = Type }));
+        }
+
+        [Test]
+        public void TestEqualsNull()
+        {
+            var system = new CustomField { Name = Name };
+            Assert.IsFalse(system.Equals(null));
+        }
+
+        [Test]
+        public void TestNotEquals()
+        {
+            var system = new CustomField { Name = Name, Type = Type };
+            Assert.IsFalse(system.Equals(new CustomField { Name = Name, Type = "Other Type" }));
+            Assert.IsFalse(system.Equals(new CustomField { Name = "Other Name", Type = Type }));
+        }
+
+        [Test]
+        public void TestClone()
+        {
+            var system = new CustomField { Name = Name, Type = Type };
+            var clonedSystem = system.Clone();
+            Assert.AreEqual(system, clonedSystem);
+        }
+
+        [Test]
+        public void TestHashCode()
+        {
+            Assert.AreNotEqual(
+                new CustomField { Name = Name }.GetHashCode(),
+                new CustomField { Name = "Different Name" }.GetHashCode()
+            );
         }
     }
 

--- a/Backend.Tests/Models/UserEditTests.cs
+++ b/Backend.Tests/Models/UserEditTests.cs
@@ -36,7 +36,7 @@ namespace Backend.Tests.Models
         {
             Assert.AreNotEqual(
                 new UserEdit { ProjectId = ProjectId }.GetHashCode(),
-                new UserEdit { ProjectId = "Different Id" });
+                new UserEdit { ProjectId = "Different Id" }.GetHashCode());
         }
     }
 

--- a/Backend.Tests/Models/UserTests.cs
+++ b/Backend.Tests/Models/UserTests.cs
@@ -22,12 +22,35 @@ namespace Backend.Tests.Models
         }
 
         [Test]
+        public void TestHashCode()
+        {
+            Assert.AreNotEqual(
+                new User { Name = Name }.GetHashCode(),
+                new User { Name = "Different Name" }.GetHashCode()
+            );
+        }
+
+        [Test]
         public void TestSanitize()
         {
             var user = new User { Avatar = "ava", Password = "pas", Token = "tok" };
             Assert.IsFalse(user.Equals(new User()));
             user.Sanitize();
             Assert.IsTrue(user.Equals(new User()));
+        }
+    }
+
+    public class CredentialsTest
+    {
+        private const string Username = "Henry";
+        private const string Password = "Password";
+
+        [Test]
+        public void TestConstructor()
+        {
+            var credentials = new Credentials();
+            Assert.AreEqual(credentials.Username, "");
+            Assert.AreEqual(credentials.Password, "");
         }
     }
 }

--- a/Backend.Tests/Models/UserTests.cs
+++ b/Backend.Tests/Models/UserTests.cs
@@ -42,9 +42,6 @@ namespace Backend.Tests.Models
 
     public class CredentialsTest
     {
-        private const string Username = "Henry";
-        private const string Password = "Password";
-
         [Test]
         public void TestConstructor()
         {

--- a/Backend.Tests/Models/WordTests.cs
+++ b/Backend.Tests/Models/WordTests.cs
@@ -192,7 +192,10 @@ namespace Backend.Tests.Models
         [Test]
         public void TestHashCode()
         {
-            Assert.AreNotEqual(new Gloss { Language = "1" }.GetHashCode(), new Gloss { Language = "2" });
+            Assert.AreNotEqual(
+                new Gloss { Language = "1" }.GetHashCode(),
+                new Gloss { Language = "2" }.GetHashCode()
+            );
         }
     }
 

--- a/Backend/Models/EmailInvite.cs
+++ b/Backend/Models/EmailInvite.cs
@@ -47,5 +47,22 @@ namespace BackendFramework.Models
                 ExpireTime = ExpireTime
             };
         }
+
+        public override bool Equals(object? obj)
+        {
+            if (obj is not EmailInvite emailInvite || GetType() != obj.GetType())
+            {
+                return false;
+            }
+
+            return Email == emailInvite.Email
+                   && Token == emailInvite.Token
+                   && ExpireTime == emailInvite.ExpireTime;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Email, Token, ExpireTime);
+        }
     }
 }

--- a/Backend/Models/Project.cs
+++ b/Backend/Models/Project.cs
@@ -311,15 +311,6 @@ namespace BackendFramework.Models
             Project = new Project();
             User = new User();
         }
-
-        public UserCreatedProject Clone()
-        {
-            return new()
-            {
-                Project = Project.Clone(),
-                User = User.Clone()
-            };
-        }
     }
 
     /// <remarks>

--- a/Backend/Models/Project.cs
+++ b/Backend/Models/Project.cs
@@ -217,9 +217,9 @@ namespace BackendFramework.Models
     public class CustomField
     {
         [Required]
-        private string Name { get; set; }
+        public string Name { get; set; }
         [Required]
-        private string Type { get; set; }
+        public string Type { get; set; }
 
         public CustomField()
         {
@@ -234,6 +234,21 @@ namespace BackendFramework.Models
                 Name = (string)Name.Clone(),
                 Type = (string)Type.Clone()
             };
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (obj is not CustomField customField || GetType() != obj.GetType())
+            {
+                return false;
+            }
+
+            return Name == customField.Name && Type == customField.Type;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Name, Type);
         }
     }
 
@@ -265,7 +280,7 @@ namespace BackendFramework.Models
 
         public override bool Equals(object? obj)
         {
-            if (!(obj is WritingSystem ws) || GetType() != obj.GetType())
+            if (obj is not WritingSystem ws || GetType() != obj.GetType())
             {
                 return false;
             }


### PR DESCRIPTION
Add unit test coverage for:

-  `User` `Model`
- `Project` `CustomField`
- `Project` `InviteTokens`
- Remove unused `UserCreatedProject.Clone()`
- Unicode punctuation for `Sanitization.MakeFriendlyForPath()`
- `Helper.Time`
- `Helper.Sanitization`

Follow on to #1271

After this PR, all `Model`s have 100% test coverage as are `Helper.Time` and `Helper.Sanitization`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1307)
<!-- Reviewable:end -->
