### PR TITLE
Drop Node 12 support, add Node 16

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -33,7 +33,7 @@ jobs:
           flags: frontend
 
       # Release build.
-      - run: npm build
+      - run: npm run build
 
   docker_build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://medium.com/the-node-js-collection/node-js-16-available-now-7f5099a97e70

> As per the release schedule, Node.js 16 will be the ‘Current’ release for the next 6 months and then promoted to Long-term Support (LTS) in October 2021

https://endoflife.date/nodejs

- Node 12 has already ended active support, and it's security support ends in 8 months

Some of our `npm` scripts already fail under Node 12 (for example license report generation).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1320)
<!-- Reviewable:end -->
