### PR TITLE
Remove duplicated CORS attributes from Controllers

### DIFF
--- a/Backend/Controllers/AudioController.cs
+++ b/Backend/Controllers/AudioController.cs
@@ -4,18 +4,14 @@ using BackendFramework.Helper;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 namespace BackendFramework.Controllers
 {
-
     [Authorize]
     [Produces("application/json")]
     [Route("v1/projects/{projectId}/words/{wordId}/audio")]
-    [EnableCors("AllowAll")]
-
     public class AudioController : Controller
     {
         private readonly IWordRepository _wordRepo;

--- a/Backend/Controllers/AvatarController.cs
+++ b/Backend/Controllers/AvatarController.cs
@@ -4,7 +4,6 @@ using BackendFramework.Helper;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
@@ -13,7 +12,6 @@ namespace BackendFramework.Controllers
     [Authorize]
     [Produces("application/json")]
     [Route("v1/users/{userId}/avatar")]
-    [EnableCors("AllowAll")]
     public class AvatarController : Controller
     {
         private readonly IUserRepository _userRepo;

--- a/Backend/Controllers/InviteController.cs
+++ b/Backend/Controllers/InviteController.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -14,7 +13,6 @@ namespace BackendFramework.Controllers
     [Authorize]
     [Produces("application/json")]
     [Route("v1/invite")]
-    [EnableCors("AllowAll")]
     public class InviteController : Controller
     {
         private readonly IProjectRepository _projRepo;

--- a/Backend/Controllers/LiftController.cs
+++ b/Backend/Controllers/LiftController.cs
@@ -7,13 +7,12 @@ using BackendFramework.Helper;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
-using SIL.Lift.Parsing;
 using SIL.IO;
+using SIL.Lift.Parsing;
 
 [assembly: InternalsVisibleTo("Backend.Tests")]
 namespace BackendFramework.Controllers
@@ -21,7 +20,6 @@ namespace BackendFramework.Controllers
     [Authorize]
     [Produces("application/json")]
     [Route("v1/projects/{projectId}/lift")]
-    [EnableCors("AllowAll")]
     public class LiftController : Controller
     {
         private readonly IProjectRepository _projRepo;

--- a/Backend/Controllers/MergeController.cs
+++ b/Backend/Controllers/MergeController.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -15,7 +13,6 @@ namespace BackendFramework.Controllers
     [Authorize]
     [Produces("application/json")]
     [Route("v1/projects/{projectId}/merge")]
-    [EnableCors("AllowAll")]
     public class MergeController : Controller
     {
         private readonly IMergeService _mergeService;

--- a/Backend/Controllers/ProjectController.cs
+++ b/Backend/Controllers/ProjectController.cs
@@ -4,9 +4,8 @@ using BackendFramework.Helper;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Cors;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace BackendFramework.Controllers
@@ -14,7 +13,6 @@ namespace BackendFramework.Controllers
     [Authorize]
     [Produces("application/json")]
     [Route("v1/projects")]
-    [EnableCors("AllowAll")]
     public class ProjectController : Controller
     {
         private readonly IProjectRepository _projRepo;

--- a/Backend/Controllers/UserController.cs
+++ b/Backend/Controllers/UserController.cs
@@ -6,7 +6,6 @@ using BackendFramework.Helper;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -17,7 +16,6 @@ namespace BackendFramework.Controllers
     [Authorize]
     [Produces("application/json")]
     [Route("v1/users")]
-    [EnableCors("AllowAll")]
     public class UserController : Controller
     {
         private readonly IUserRepository _userRepo;

--- a/Backend/Controllers/UserEditController.cs
+++ b/Backend/Controllers/UserEditController.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -14,7 +13,6 @@ namespace BackendFramework.Controllers
     [Authorize]
     [Produces("application/json")]
     [Route("v1/projects/{projectId}/useredits")]
-    [EnableCors("AllowAll")]
     public class UserEditController : Controller
     {
         private readonly IProjectRepository _projRepo;

--- a/Backend/Controllers/UserRoleController.cs
+++ b/Backend/Controllers/UserRoleController.cs
@@ -4,9 +4,8 @@ using BackendFramework.Helper;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Cors;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace BackendFramework.Controllers
@@ -14,7 +13,6 @@ namespace BackendFramework.Controllers
     [Authorize]
     [Produces("application/json")]
     [Route("v1/projects/{projectId}/userroles")]
-    [EnableCors("AllowAll")]
     public class UserRoleController : Controller
     {
         private readonly IProjectRepository _projRepo;

--- a/Backend/Controllers/WordController.cs
+++ b/Backend/Controllers/WordController.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -13,7 +12,6 @@ namespace BackendFramework.Controllers
     [Authorize]
     [Produces("application/json")]
     [Route("v1/projects/{projectId}/words")]
-    [EnableCors("AllowAll")]
     public class WordController : Controller
     {
         private readonly IProjectRepository _projRepo;

--- a/Backend/Startup.cs
+++ b/Backend/Startup.cs
@@ -23,7 +23,7 @@ namespace BackendFramework
     [ExcludeFromCodeCoverage]
     public class Startup
     {
-        private const string AllowedOrigins = "AllowAll";
+        private const string LocalhostCorsPolicy = "LocalhostCorsPolicy";
 
         private readonly ILogger<Startup> _logger;
 
@@ -95,7 +95,7 @@ namespace BackendFramework
             {
                 services.AddCors(options =>
                 {
-                    options.AddPolicy(AllowedOrigins,
+                    options.AddPolicy(LocalhostCorsPolicy,
                         builder => builder
                             .AllowAnyHeader()
                             .AllowAnyMethod()
@@ -251,7 +251,8 @@ namespace BackendFramework
             }
 
             app.UseRouting();
-            app.UseCors(AllowedOrigins);
+            // Apply CORS policy to all requests.
+            app.UseCors(LocalhostCorsPolicy);
 
             app.UseForwardedHeaders(new ForwardedHeadersOptions
             {


### PR DESCRIPTION
The call in `Startup.Configure` to `app.UseCors(LocalhostCorsPolicy);` should apply CORS headers to all requests.

Remove duplicated `EnableCors[]` attributes to `Controller`s, which should not be needed.

CORS is only needed for local development outside of Docker, so that is the context that should be tested for this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1356)
<!-- Reviewable:end -->
