### PR TITLE
Fix handling case if audio file is missing

### DIFF
--- a/Backend/Controllers/AudioController.cs
+++ b/Backend/Controllers/AudioController.cs
@@ -51,7 +51,7 @@ namespace BackendFramework.Controllers
             }
 
             var filePath = FileStorage.GenerateAudioFilePath(projectId, fileName);
-            if (!System.IO.File.Exists(fileName))
+            if (!System.IO.File.Exists(filePath))
             {
                 return BadRequest("Audio file does not exist.");
             }

--- a/Backend/Controllers/AudioController.cs
+++ b/Backend/Controllers/AudioController.cs
@@ -51,13 +51,15 @@ namespace BackendFramework.Controllers
             }
 
             var filePath = FileStorage.GenerateAudioFilePath(projectId, fileName);
-            var file = System.IO.File.OpenRead(filePath);
-            if (file is null)
+            try
             {
-                return BadRequest("The file does not exist.");
+                var file = System.IO.File.OpenRead(filePath);
+                return File(file, "application/octet-stream");
             }
-
-            return File(file, "application/octet-stream");
+            catch (FileNotFoundException)
+            {
+                return BadRequest("Audio file does not exist.");
+            }
         }
 
         /// <summary>

--- a/Backend/Controllers/AudioController.cs
+++ b/Backend/Controllers/AudioController.cs
@@ -51,15 +51,13 @@ namespace BackendFramework.Controllers
             }
 
             var filePath = FileStorage.GenerateAudioFilePath(projectId, fileName);
-            try
-            {
-                var file = System.IO.File.OpenRead(filePath);
-                return File(file, "application/octet-stream");
-            }
-            catch (FileNotFoundException)
+            if (!System.IO.File.Exists(fileName))
             {
                 return BadRequest("Audio file does not exist.");
             }
+
+            var file = System.IO.File.OpenRead(filePath);
+            return File(file, "application/octet-stream");
         }
 
         /// <summary>


### PR DESCRIPTION
Previously, we were testing `if file is null`, but the compiler enforces that it cannot be `null`. In fact, the way `OpenRead` signals that the file does not exist is to throw an `Exception`.

This change will properly return a `BadRequest` in the event the file has been deleted or moved rather than allowing an uncaught exception to bubble into a 500 server error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1357)
<!-- Reviewable:end -->
