### PR TITLE
Add instructions for installing Helm

### DIFF
--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -139,7 +139,12 @@ Note that this functionality is under development and is not complete.
 #### Additional Host Requirements
 
 In addition to the software listed in the section [Prepare your host system](#prepare-your-host-system) you will need to
-install the [kubectl](https://kubernetes.io/docs/tasks/tools/) tool.
+install:
+
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) for examining and modifying your Kubernetes cluster; and
+- [Helm](https://helm.sh/docs/intro/install/) for installing Helm Charts (Kubernetes Packages).
+
+Both of these tools are used by the Ansible playbooks that setup the Kubernetes cluster for running _The Combine_.
 
 #### Installing the Kubernetes Cluster
 


### PR DESCRIPTION
Add instructions for installing Helm to docs/deploy/README.md.

Helm should be installed on the client machine rather than the target since the Ansible installation and configuration playbooks for The Combine will not have `ssh` access to the Production and QA Kubernetes clusters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1375)
<!-- Reviewable:end -->
