### PR TITLE
Spawn new Thread for the export [backend], auto-download when export done [frontend]

### DIFF
--- a/Backend.Tests/Controllers/LiftControllerTests.cs
+++ b/Backend.Tests/Controllers/LiftControllerTests.cs
@@ -196,7 +196,7 @@ namespace Backend.Tests.Controllers
             await _wordService.Update(_projId, wordToUpdate.Id, word);
             await _wordService.DeleteFrontierWord(_projId, wordToDelete.Id);
 
-            _liftController.ExportLiftFile(_projId, UserId).Wait();
+            _liftController.CreateLiftExportThenSignal(_projId, UserId).Wait();
             var result = (FileStreamResult)_liftController.DownloadLiftFile(_projId, UserId).Result;
             Assert.NotNull(result);
 

--- a/Backend.Tests/Helper/TimeTests.cs
+++ b/Backend.Tests/Helper/TimeTests.cs
@@ -16,12 +16,20 @@ namespace Backend.Tests.Helper
         }
 
         [Test]
-        public void UtcNowIso8601()
+        public void TestUtcNowIso8601()
         {
             var time = Time.UtcNowIso8601();
             Assert.That(time.Contains("T"));
             Assert.That(time.EndsWith("Z"));
             Assert.That(DateTime.Now, Is.EqualTo(DateTime.Parse(time)).Within(TimeSpan.FromSeconds(10)));
+        }
+
+        [Test]
+        public void TestUtcNowFilesafe()
+        {
+            var time = Time.UtcNowFilesafe();
+            Assert.False(time.Contains(":"));
+            Assert.False(time.Contains("/"));
         }
     }
 }

--- a/Backend.Tests/Helper/TimeTests.cs
+++ b/Backend.Tests/Helper/TimeTests.cs
@@ -23,13 +23,5 @@ namespace Backend.Tests.Helper
             Assert.That(time.EndsWith("Z"));
             Assert.That(DateTime.Now, Is.EqualTo(DateTime.Parse(time)).Within(TimeSpan.FromSeconds(10)));
         }
-
-        [Test]
-        public void TestUtcNowFilesafe()
-        {
-            var time = Time.UtcNowFilesafe();
-            Assert.False(time.Contains(":"));
-            Assert.False(time.Contains("/"));
-        }
     }
 }

--- a/Backend/Controllers/LiftController.cs
+++ b/Backend/Controllers/LiftController.cs
@@ -246,7 +246,7 @@ namespace BackendFramework.Controllers
                 _liftService.SetExportInProgress(userId, false);
                 return BadRequest("No words to export.");
             }
-            Thread exportThread = new Thread(async () => await CreateLiftExportThenSignal(projectId, userId));
+            var exportThread = new Thread(async () => await CreateLiftExportThenSignal(projectId, userId));
             exportThread.Start();
 
             return Ok(projectId);

--- a/Backend/Controllers/LiftController.cs
+++ b/Backend/Controllers/LiftController.cs
@@ -209,8 +209,7 @@ namespace BackendFramework.Controllers
             return await ExportLiftFile(projectId, userId);
         }
 
-        // These internal methods are extracted for unit testing
-        internal async Task<IActionResult> ExportLiftFile(string projectId, string userId)
+        private async Task<IActionResult> ExportLiftFile(string projectId, string userId)
         {
             if (!await _permissionService.HasProjectPermission(HttpContext, Permission.ImportExport))
             {
@@ -254,9 +253,10 @@ namespace BackendFramework.Controllers
             return Ok(projectId);
         }
 
+        // These internal methods are extracted for unit testing.
         internal async Task<bool> CreateLiftExportThenSignal(string projectId, string userId)
         {
-            // Export the data to a zip, read into memory, and delete zip
+            // Export the data to a zip, read into memory, and delete zip.
             var exportedFilepath = await CreateLiftExport(projectId);
 
             // Store the temporary path to the exported file for user to download later.

--- a/Backend/Controllers/LiftController.cs
+++ b/Backend/Controllers/LiftController.cs
@@ -247,10 +247,10 @@ namespace BackendFramework.Controllers
                 return BadRequest("No words to export.");
             }
 
-            async void StartExport() => await CreateLiftExportThenSignal(projectId, userId);
-            var exportThread = new Thread(StartExport);
-            exportThread.Start();
-
+            // Run the task without waiting for completion.
+            // This Task will be scheduled within the exiting Async executor thread pool efficiently.
+            // See: https://stackoverflow.com/a/64614779/1398841
+            _ = Task.Run(() => CreateLiftExportThenSignal(projectId, userId));
             return Ok(projectId);
         }
 

--- a/Backend/Controllers/LiftController.cs
+++ b/Backend/Controllers/LiftController.cs
@@ -261,7 +261,7 @@ namespace BackendFramework.Controllers
 
             // Store the temporary path to the exported file for user to download later.
             _liftService.StoreExport(userId, exportedFilepath);
-            await _notifyService.Clients.All.SendAsync("DownloadReady", userId);
+            await _notifyService.Clients.All.SendAsync(CombineHub.DownloadReady, userId);
             return true;
         }
 

--- a/Backend/Controllers/LiftController.cs
+++ b/Backend/Controllers/LiftController.cs
@@ -246,7 +246,9 @@ namespace BackendFramework.Controllers
                 _liftService.SetExportInProgress(userId, false);
                 return BadRequest("No words to export.");
             }
-            var exportThread = new Thread(async () => await CreateLiftExportThenSignal(projectId, userId));
+
+            async void StartExport() => await CreateLiftExportThenSignal(projectId, userId);
+            var exportThread = new Thread(StartExport);
             exportThread.Start();
 
             return Ok(projectId);

--- a/Backend/Helper/CombineHub.cs
+++ b/Backend/Helper/CombineHub.cs
@@ -4,5 +4,6 @@ namespace BackendFramework.Helper
 {
     public class CombineHub : Hub
     {
+        public const string DownloadReady = "DownloadReady";
     }
 }

--- a/Backend/Helper/FileStorage.cs
+++ b/Backend/Helper/FileStorage.cs
@@ -98,20 +98,6 @@ namespace BackendFramework.Helper
         }
 
         /// <summary>
-        /// Generate a path to the temporary Lift Export folder used during export.
-        /// </summary>
-        /// <exception cref="InvalidIdException"> Throws when id invalid. </exception>
-        /// <remarks> This function may be removed in the future and replaced by temporary directory use. </remarks>
-        public static string GenerateLiftExportDirPath(string projectId, bool createDir = true)
-        {
-            if (!Sanitization.SanitizeId(projectId))
-            {
-                throw new InvalidIdException();
-            }
-            return GenerateProjectDirPath(projectId, ExportDir, createDir);
-        }
-
-        /// <summary>
         /// Generate the path to where Avatar images are stored.
         /// </summary>
         /// <exception cref="InvalidIdException"> Throws when id invalid. </exception>

--- a/Backend/Helper/FileStorage.cs
+++ b/Backend/Helper/FileStorage.cs
@@ -27,69 +27,113 @@ namespace BackendFramework.Helper
         [Serializable]
         public class HomeFolderNotFoundException : Exception { }
 
+        /// <summary> Indicates an invalid input id. </summary>
+        [Serializable]
+        public class InvalidIdException : Exception { }
+
         /// <summary>
         /// Generate a path to the file name of an audio file for the Project based on the Word ID.
         /// </summary>
+        /// <exception cref="InvalidIdException"> Throws when id invalid. </exception>
         public static string GenerateAudioFilePathForWord(string projectId, string wordId)
         {
+            if (!Sanitization.SanitizeId(projectId) || !Sanitization.SanitizeId(wordId))
+            {
+                throw new InvalidIdException();
+            }
             return GenerateProjectFilePath(projectId, AudioPathSuffix, wordId, FileType.Audio);
         }
 
         /// <summary>
         /// Generate a path to the file name of an audio file for the Project.
         /// </summary>
+        /// <exception cref="InvalidIdException"> Throws when id invalid. </exception>
         public static string GenerateAudioFilePath(string projectId, string fileName)
         {
+            if (!Sanitization.SanitizeId(projectId))
+            {
+                throw new InvalidIdException();
+            }
             return GenerateProjectFilePath(projectId, AudioPathSuffix, fileName);
         }
 
         /// <summary>
         /// Generate a path to the directory where audio files are stored for the Project.
         /// </summary>
+        /// <exception cref="InvalidIdException"> Throws when id invalid. </exception>
         public static string GenerateAudioFileDirPath(string projectId, bool createDir = true)
         {
+            if (!Sanitization.SanitizeId(projectId))
+            {
+                throw new InvalidIdException();
+            }
             return GenerateProjectDirPath(projectId, AudioPathSuffix, createDir);
         }
 
         /// <summary>
         /// Generate a path to the parent directory where Lift exports are stored.
         /// </summary>
+        /// <exception cref="InvalidIdException"> Throws when id invalid. </exception>
         /// <remarks> This function is not expected to be used often. </remarks>
         public static string GenerateImportExtractedLocationDirPath(string projectId, bool createDir = true)
         {
+            if (!Sanitization.SanitizeId(projectId))
+            {
+                throw new InvalidIdException();
+            }
             return GenerateProjectDirPath(projectId, ImportExtractedLocation, createDir);
         }
 
         /// <summary>
         /// Generate a path to the Lift import folder. This also stores audio files within it.
         /// </summary>
+        /// <exception cref="InvalidIdException"> Throws when id invalid. </exception>
         public static string GenerateLiftImportDirPath(string projectId, bool createDir = true)
         {
+            if (!Sanitization.SanitizeId(projectId))
+            {
+                throw new InvalidIdException();
+            }
             return GenerateProjectDirPath(projectId, LiftImportSuffix, createDir);
         }
 
         /// <summary>
         /// Generate a path to the temporary Lift Export folder used during export.
         /// </summary>
+        /// <exception cref="InvalidIdException"> Throws when id invalid. </exception>
         /// <remarks> This function may be removed in the future and replaced by temporary directory use. </remarks>
         public static string GenerateLiftExportDirPath(string projectId, bool createDir = true)
         {
+            if (!Sanitization.SanitizeId(projectId))
+            {
+                throw new InvalidIdException();
+            }
             return GenerateProjectDirPath(projectId, ExportDir, createDir);
         }
 
         /// <summary>
         /// Generate the path to where Avatar images are stored.
         /// </summary>
+        /// <exception cref="InvalidIdException"> Throws when id invalid. </exception>
         public static string GenerateAvatarFilePath(string userId)
         {
+            if (!Sanitization.SanitizeId(userId))
+            {
+                throw new InvalidIdException();
+            }
             return GenerateFilePath(AvatarsDir, userId, FileType.Avatar);
         }
 
         /// <summary>
         /// Get the top-level path to where all files are stored for the project.
         /// </summary>
+        /// <exception cref="InvalidIdException"> Throws when id invalid. </exception>
         public static string GetProjectDir(string projectId)
         {
+            if (!Sanitization.SanitizeId(projectId))
+            {
+                throw new InvalidIdException();
+            }
             return GenerateProjectDirPath(projectId, "", false);
         }
 

--- a/Backend/Helper/Time.cs
+++ b/Backend/Helper/Time.cs
@@ -26,6 +26,14 @@ namespace BackendFramework.Helper
         {
             return dateTime.ToString(RoundTripIso8601Format);
         }
+
+        /// <summary>
+        /// Construct a string for the current DateTime in a filepath-safe format.
+        /// </summary>
+        public static string UtcNowFilesafe()
+        {
+            return Sanitization.MakeFriendlyForPath(UtcNowIso8601());
+        }
     }
 }
 

--- a/Backend/Helper/Time.cs
+++ b/Backend/Helper/Time.cs
@@ -26,14 +26,6 @@ namespace BackendFramework.Helper
         {
             return dateTime.ToString(RoundTripIso8601Format);
         }
-
-        /// <summary>
-        /// Construct a string for the current DateTime in a filepath-safe format.
-        /// </summary>
-        public static string UtcNowFilesafe()
-        {
-            return Sanitization.MakeFriendlyForPath(UtcNowIso8601());
-        }
     }
 }
 

--- a/Backend/Services/LiftService.cs
+++ b/Backend/Services/LiftService.cs
@@ -181,7 +181,7 @@ namespace BackendFramework.Services
 
             // Generate the zip dir.
             var exportDir = FileStorage.GenerateLiftExportDirPath(projectId);
-            var liftExportDir = Path.Combine(exportDir, "LiftExport-" + Time.UtcNowIso8601());
+            var liftExportDir = Path.Combine(exportDir, "LiftExport-" + Time.UtcNowFilesafe());
 
             var projNameAsPath = Sanitization.MakeFriendlyForPath(proj.Name, "Lift");
             var zipDir = Path.Combine(liftExportDir, projNameAsPath);

--- a/Backend/Services/LiftService.cs
+++ b/Backend/Services/LiftService.cs
@@ -181,10 +181,10 @@ namespace BackendFramework.Services
 
             // Generate the zip dir.
             var exportDir = FileStorage.GenerateLiftExportDirPath(projectId);
-            var liftExportDir = Path.Combine(exportDir, "LiftExport-" + Time.UtcNowFilesafe());
+            var tempExportDir = FileOperations.GetRandomTempDir();
 
             var projNameAsPath = Sanitization.MakeFriendlyForPath(proj.Name, "Lift");
-            var zipDir = Path.Combine(liftExportDir, projNameAsPath);
+            var zipDir = Path.Combine(tempExportDir, projNameAsPath);
             Directory.CreateDirectory(zipDir);
 
             // Add audio dir inside zip dir.
@@ -347,7 +347,7 @@ namespace BackendFramework.Services
             ZipFile.CreateFromDirectory(zipParentDir, destinationFileName);
 
             // Clean up the temporary folder structure that was compressed.
-            Directory.Delete(liftExportDir, true);
+            Directory.Delete(tempExportDir, true);
 
             return destinationFileName;
         }

--- a/Backend/Services/LiftService.cs
+++ b/Backend/Services/LiftService.cs
@@ -181,11 +181,7 @@ namespace BackendFramework.Services
 
             // Generate the zip dir.
             var exportDir = FileStorage.GenerateLiftExportDirPath(projectId);
-            var liftExportDir = Path.Combine(exportDir, "LiftExport");
-            if (Directory.Exists(liftExportDir))
-            {
-                Directory.Delete(liftExportDir, true);
-            }
+            var liftExportDir = Path.Combine(exportDir, "LiftExport-" + Time.UtcNowIso8601());
 
             var projNameAsPath = Sanitization.MakeFriendlyForPath(proj.Name, "Lift");
             var zipDir = Path.Combine(liftExportDir, projNameAsPath);

--- a/Backend/Services/LiftService.cs
+++ b/Backend/Services/LiftService.cs
@@ -180,7 +180,6 @@ namespace BackendFramework.Services
             var vernacularBcp47 = proj.VernacularWritingSystem.Bcp47;
 
             // Generate the zip dir.
-            var exportDir = FileStorage.GenerateLiftExportDirPath(projectId);
             var tempExportDir = FileOperations.GetRandomTempDir();
 
             var projNameAsPath = Sanitization.MakeFriendlyForPath(proj.Name, "Lift");
@@ -337,7 +336,7 @@ namespace BackendFramework.Services
             }
 
             // Compress everything.
-            var destinationFileName = Path.Combine(exportDir,
+            var destinationFileName = Path.Combine(FileOperations.GetRandomTempDir(),
                 Path.Combine($"LiftExportCompressed-{proj.Id}_{DateTime.Now:yyyy-MM-dd_hh-mm-ss}.zip"));
             var zipParentDir = Path.GetDirectoryName(zipDir);
             if (zipParentDir is null)

--- a/src/components/App/SignalRHub.tsx
+++ b/src/components/App/SignalRHub.tsx
@@ -34,8 +34,7 @@ export default function SignalRHub() {
 
   useEffect(() => {
     if (connection) {
-      // The methodName must match what is used by the Backend in, e.g.,
-      // `_notifyService.Clients.All.SendAsync("DownloadReady", userId);`.
+      // The methodName must match what is in Backend/Helper/CombineHub.
       const methodName = "DownloadReady";
       // The method is what the frontend does upon message receipt.
       const method = (userId: string) => {

--- a/src/components/App/SignalRHub.tsx
+++ b/src/components/App/SignalRHub.tsx
@@ -21,7 +21,7 @@ export default function SignalRHub() {
       connection.stop();
     }
     setConnection(null);
-    if (exportState.status === ExportStatus.InProgress) {
+    if (exportState.status === ExportStatus.Exporting) {
       const newConnection = new HubConnectionBuilder()
         .withUrl(`${baseURL}/hub`)
         .withAutomaticReconnect()

--- a/src/components/App/SignalRHub.tsx
+++ b/src/components/App/SignalRHub.tsx
@@ -34,7 +34,7 @@ export default function SignalRHub() {
 
   useEffect(() => {
     if (connection) {
-      // The methodName must match what is in Backend/Helper/CombineHub.
+      // The methodName must match what is in Backend/Helper/CombineHub.cs.
       const methodName = "DownloadReady";
       // The method is what the frontend does upon message receipt.
       const method = (userId: string) => {

--- a/src/components/ProjectExport/DownloadButton.tsx
+++ b/src/components/ProjectExport/DownloadButton.tsx
@@ -42,7 +42,7 @@ export default function DownloadButton(props: DownloadButtonProps) {
   useEffect(() => {
     if (exportState.status === ExportStatus.Success) {
       download();
-    } // eslint-disable-next-line
+    } // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [exportState.status]);
 
   function makeExportName(projectName: string) {

--- a/src/components/ProjectExport/DownloadButton.tsx
+++ b/src/components/ProjectExport/DownloadButton.tsx
@@ -60,8 +60,10 @@ export default function DownloadButton(props: DownloadButtonProps) {
 
   function textId(): string {
     switch (exportState.status) {
-      case ExportStatus.InProgress:
+      case ExportStatus.Exporting:
         return "projectExport.exportInProgress";
+      case ExportStatus.Downloading:
+        return "projectExport.downloadInProgress";
       case ExportStatus.Success:
         return "projectExport.downloadReady";
       case ExportStatus.Failure:
@@ -73,7 +75,8 @@ export default function DownloadButton(props: DownloadButtonProps) {
 
   function icon(): ReactElement {
     switch (exportState.status) {
-      case ExportStatus.InProgress:
+      case ExportStatus.Exporting:
+      case ExportStatus.Downloading:
         return <Cached />;
       case ExportStatus.Success:
         return <GetApp />;

--- a/src/components/ProjectExport/ExportButton.tsx
+++ b/src/components/ProjectExport/ExportButton.tsx
@@ -1,12 +1,9 @@
-import { Tooltip } from "@material-ui/core";
 import { ButtonProps } from "@material-ui/core/Button";
-import React from "react";
 import { LocalizeContextProps, withLocalize } from "react-localize-redux";
 import { useDispatch, useSelector } from "react-redux";
 
 import { isFrontierNonempty } from "backend";
-import LoadingDoneButton from "components/Buttons/LoadingDoneButton";
-import DownloadButton from "components/ProjectExport/DownloadButton";
+import LoadingButton from "components/Buttons/LoadingButton";
 import { asyncExportProject } from "components/ProjectExport/Redux/ExportProjectActions";
 import { ExportStatus } from "components/ProjectExport/Redux/ExportProjectReduxTypes";
 import { StoreState } from "types";
@@ -32,42 +29,24 @@ export function ExportButton(props: ExportButtonProps & LocalizeContextProps) {
   const exportResult = useSelector(
     (state: StoreState) => state.exportProjectState
   );
-  const sameProject = props.projectId === exportResult.projectId;
   const loading =
     exportResult.status === ExportStatus.Exporting ||
-    exportResult.status === ExportStatus.Downloading;
-  const done =
     exportResult.status === ExportStatus.Success ||
     exportResult.status === ExportStatus.Downloading;
 
   return (
-    <React.Fragment>
-      <Tooltip
-        title={
-          done && !sameProject
-            ? props.translate("projectExport.downloadHint")
-            : ""
-        }
-      >
-        <span>
-          <LoadingDoneButton
-            loading={loading}
-            done={done && sameProject}
-            doneText={props.translate("projectExport.downloadReady")}
-            disabled={loading || done}
-            buttonProps={{
-              ...props.buttonProps,
-              onClick: exportProj,
-              color: "primary",
-              id: `project-${props.projectId}-export`,
-            }}
-          >
-            {props.translate("buttons.export")}
-          </LoadingDoneButton>
-        </span>
-      </Tooltip>
-      {sameProject && <DownloadButton />}
-    </React.Fragment>
+    <LoadingButton
+      loading={loading}
+      disabled={loading}
+      buttonProps={{
+        ...props.buttonProps,
+        onClick: exportProj,
+        color: "primary",
+        id: `project-${props.projectId}-export`,
+      }}
+    >
+      {props.translate("buttons.export")}
+    </LoadingButton>
   );
 }
 

--- a/src/components/ProjectExport/ExportButton.tsx
+++ b/src/components/ProjectExport/ExportButton.tsx
@@ -33,7 +33,9 @@ export function ExportButton(props: ExportButtonProps & LocalizeContextProps) {
     (state: StoreState) => state.exportProjectState
   );
   const sameProject = props.projectId === exportResult.projectId;
-  const loading = exportResult.status === ExportStatus.InProgress;
+  const loading =
+    exportResult.status === ExportStatus.Exporting ||
+    exportResult.status === ExportStatus.Downloading;
   const done = exportResult.status === ExportStatus.Success;
 
   return (

--- a/src/components/ProjectExport/ExportButton.tsx
+++ b/src/components/ProjectExport/ExportButton.tsx
@@ -36,7 +36,9 @@ export function ExportButton(props: ExportButtonProps & LocalizeContextProps) {
   const loading =
     exportResult.status === ExportStatus.Exporting ||
     exportResult.status === ExportStatus.Downloading;
-  const done = exportResult.status === ExportStatus.Success;
+  const done =
+    exportResult.status === ExportStatus.Success ||
+    exportResult.status === ExportStatus.Downloading;
 
   return (
     <React.Fragment>

--- a/src/components/ProjectExport/Redux/ExportProjectActions.ts
+++ b/src/components/ProjectExport/Redux/ExportProjectActions.ts
@@ -7,7 +7,7 @@ import { StoreStateDispatch } from "types/Redux/actions";
 
 export function asyncExportProject(projectId: string) {
   return async (dispatch: StoreStateDispatch) => {
-    dispatch(inProgress(projectId));
+    dispatch(exporting(projectId));
     exportLift(projectId).catch(() => dispatch(failure(projectId)));
   };
 }
@@ -18,6 +18,7 @@ export function downloadIsReady(projectId: string) {
 
 export function asyncDownloadExport(projectId: string) {
   return async (dispatch: StoreStateDispatch) => {
+    dispatch(downloading(projectId));
     return await downloadLift(projectId).catch(() => {
       dispatch(failure(projectId));
     });
@@ -31,9 +32,15 @@ export function resetExport(projectId?: string) {
   };
 }
 
-function inProgress(projectId: string): ExportProjectAction {
+function exporting(projectId: string): ExportProjectAction {
   return {
-    type: ExportStatus.InProgress,
+    type: ExportStatus.Exporting,
+    projectId,
+  };
+}
+function downloading(projectId: string): ExportProjectAction {
+  return {
+    type: ExportStatus.Downloading,
     projectId,
   };
 }

--- a/src/components/ProjectExport/Redux/ExportProjectReducer.ts
+++ b/src/components/ProjectExport/Redux/ExportProjectReducer.ts
@@ -1,29 +1,19 @@
-import { StoreAction, StoreActionTypes } from "rootActions";
-import {} from "components/ProjectExport/Redux/ExportProjectActions";
 import {
   defaultState,
   ExportProjectAction,
   ExportProjectState,
   ExportStatus,
 } from "components/ProjectExport/Redux/ExportProjectReduxTypes";
+import { StoreAction, StoreActionTypes } from "rootActions";
 
 export const exportProjectReducer = (
   state: ExportProjectState = defaultState,
   action: StoreAction | ExportProjectAction
 ): ExportProjectState => {
   switch (action.type) {
-    case ExportStatus.InProgress:
-      return {
-        ...defaultState,
-        projectId: action.projectId ?? "",
-        status: action.type,
-      };
+    case ExportStatus.Exporting:
+    case ExportStatus.Downloading:
     case ExportStatus.Success:
-      return {
-        ...defaultState,
-        projectId: action.projectId ?? "",
-        status: action.type,
-      };
     case ExportStatus.Failure:
       return {
         ...defaultState,
@@ -31,7 +21,6 @@ export const exportProjectReducer = (
         status: action.type,
       };
     case ExportStatus.Default:
-      return defaultState;
     case StoreActionTypes.RESET:
       return defaultState;
     default:

--- a/src/components/ProjectExport/Redux/ExportProjectReduxTypes.ts
+++ b/src/components/ProjectExport/Redux/ExportProjectReduxTypes.ts
@@ -1,6 +1,7 @@
 export enum ExportStatus {
   Default = "DEFAULT",
-  InProgress = "IN_PROGRESS",
+  Exporting = "EXPORTING",
+  Downloading = "DOWNLOADING",
   Success = "SUCCESS",
   Failure = "FAILURE",
 }

--- a/src/components/ProjectSettings/ProjectUsers/ActiveUsers.tsx
+++ b/src/components/ProjectSettings/ProjectUsers/ActiveUsers.tsx
@@ -40,7 +40,7 @@ export default function ActiveUsers() {
 
   useEffect(() => {
     getUserRoles().then(setProjUserRoles);
-    // eslint-disable-next-line
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectUsers, setProjUserRoles]);
 
   useEffect(() => {
@@ -51,12 +51,12 @@ export default function ActiveUsers() {
       }
     });
     Promise.all(promises).then(() => setUserAvatar(tempUserAvatar));
-    // eslint-disable-next-line
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectUsers, setUserAvatar]);
 
   useEffect(() => {
     setSortedUsers(getSortedUsers());
-    // eslint-disable-next-line
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectUsers, userOrder, reverseSorting, setSortedUsers]);
 
   function getSortedUsers() {

--- a/src/components/ProjectSettings/ProjectUsers/UserList.tsx
+++ b/src/components/ProjectSettings/ProjectUsers/UserList.tsx
@@ -49,7 +49,7 @@ export default function UserList(props: UserListProps) {
       }
     });
     Promise.all(promises).then(() => setUserAvatar(tempUserAvatar));
-    // eslint-disable-next-line
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.projectUsers, setUserAvatar]);
 
   function clearFilter() {

--- a/src/resources/translations.json
+++ b/src/resources/translations.json
@@ -318,6 +318,11 @@
       "Project is empty. You cannot export a project with no words.",
       "Project is empty. You cannot export a project with no words."
     ],
+    "downloadInProgress": [
+      "Download in progress",
+      "Download in progress",
+      "Download in progress"
+    ],
     "downloadReady": ["Download ready", "Download ready", "Download ready"],
     "exportFailed": ["Export failed", "Export failed", "Export failed"],
     "exportInProgress": [

--- a/src/resources/translations.json
+++ b/src/resources/translations.json
@@ -323,17 +323,11 @@
       "Download in progress",
       "Download in progress"
     ],
-    "downloadReady": ["Download ready", "Download ready", "Download ready"],
     "exportFailed": ["Export failed", "Export failed", "Export failed"],
     "exportInProgress": [
       "Export in progress",
       "Export in progress",
       "Export in progress"
-    ],
-    "downloadHint": [
-      "Another project finished exporting. Click on the download icon in the top bar to download it.",
-      "Another project finished exporting. Click on the download icon in the top bar to download it.",
-      "Another project finished exporting. Click on the download icon in the top bar to download it."
     ]
   },
   "projectSettings": {


### PR DESCRIPTION
Fixes #1379 
Bypasses #937 by not requiring the user to press a button when the export is ready to download.

Also, uses random temp export folders to prevent concurrency issues when there are multiple simultaneous attempts to export the same project.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1376)
<!-- Reviewable:end -->
