### PR TITLE
Refactor configuration roles

### DIFF
--- a/deploy/group_vars/nuc/main.yml
+++ b/deploy/group_vars/nuc/main.yml
@@ -60,7 +60,8 @@ k8s_components:
 
 image_pull_secret: aws-login-credentials
 
-app_namespace: thecombine
+create_namespaces:
+  - "{{ app_namespace }}"
 
 aws_ecr_login:
   cron: no

--- a/deploy/group_vars/qa/main.yml
+++ b/deploy/group_vars/qa/main.yml
@@ -59,7 +59,7 @@ k8s_components: []
 
 image_pull_secret: aws-login-credentials
 
-app_namespace: thecombine
+create_namespaces: []
 
 k8s_user: sillsdev
 k8s_group: sillsdev

--- a/deploy/group_vars/server/main.yml
+++ b/deploy/group_vars/server/main.yml
@@ -73,7 +73,7 @@ k8s_components: []
 
 image_pull_secret: aws-login-credentials
 
-app_namespace: thecombine
+create_namespaces: []
 
 k8s_user: sillsdev
 k8s_group: sillsdev

--- a/deploy/playbook_kube_config.yml
+++ b/deploy/playbook_kube_config.yml
@@ -35,9 +35,14 @@
     - name: Create The Combine Kubernetes cluster
       delegate_to: localhost
       block:
+        # Normally, the list of "combine_namespaces" is only used for the
+        # "app_namespace" on the NUC.  It is implemented as a list so that the
+        # "combine-cert-proxy" namespace can be created on development servers.
+        # (Namespaces are controlled by another group on the production cluster.)
         - name: Create Application Namespace
           import_role:
             name: k8s_namespace
+          when: (create_namespaces | default([])) | length
 
         - name: Setup Service Accounts
           import_role:

--- a/deploy/roles/aws_login_job/tasks/main.yml
+++ b/deploy/roles/aws_login_job/tasks/main.yml
@@ -26,38 +26,24 @@
 # - cron job to keep login fresh
 ##############################################################
 - name: Create AWS login resource specifications
-  template:
-    src: "{{ item }}.j2"
-    dest: "{{ k8s_aws_login_cfg }}/{{ item }}"
-    mode: 0600
-  with_items:
-    - aws-login-config.yaml
-    - aws-access-secrets.yaml
-    - aws-ecr-login-oneshot.yaml
-
-- name: Apply AWS login resource specifications
-  command: >
-    kubectl --kubeconfig={{ kubecfg }}
-    apply -f {{ k8s_aws_login_cfg }}/{{ item }}
-  with_items:
-    - aws-login-config.yaml
-    - aws-access-secrets.yaml
-    - aws-ecr-login-oneshot.yaml
+  import_role:
+    name: k8s_make_resources
+  vars:
+    k8s_config_dir: "{{ k8s_aws_login_cfg }}"
+    k8s_templates:
+      - aws-login-config.yaml
+      - aws-access-secrets.yaml
+      - aws-ecr-login-oneshot.yaml
 
 ##############################################################
 # Create cron job to refresh AWS login credentials if
 # specified, that is, aws_ecr_login.cron is true
 ##############################################################
 - name: Create cron job to refresh AWS login credentials
-  block:
-    - name: Create cron job specifications
-      template:
-        src: aws-ecr-login-cronjob.yaml.j2
-        dest: "{{ k8s_aws_login_cfg }}/aws-ecr-login-cronjob.yaml"
-        mode: 0600
-
-    - name: Apply cron job specifications
-      command: >
-        kubectl --kubeconfig={{ kubecfg }}
-        apply -f {{ k8s_aws_login_cfg }}/aws-ecr-login-cronjob.yaml
+  import_role:
+    name: k8s_make_resources
+  vars:
+    k8s_config_dir: "{{ k8s_aws_login_cfg }}"
+    k8s_templates:
+      - aws-ecr-login-cronjob.yaml
   when: aws_ecr_login.cron

--- a/deploy/roles/k8s_accounts/defaults/main.yml
+++ b/deploy/roles/k8s_accounts/defaults/main.yml
@@ -1,10 +1,4 @@
 ---
-k8s_account_templates:
-  - service_acct_ecr_login.yml
-  - service_acct_maint.yml
-  - role_ecr_login.yml
-  - role_maintenance.yml
-
 k8s_service_accounts:
   ecr_login: account-ecr-login
   maintenance: account-maintenance

--- a/deploy/roles/k8s_accounts/tasks/main.yml
+++ b/deploy/roles/k8s_accounts/tasks/main.yml
@@ -1,21 +1,11 @@
 ---
-- name: Create directory for the service account configuration files
-  file:
-    path: "{{ k8s_account_cfg }}"
-    state: directory
-    mode: 0700
-
-- name: Create service account and role configuration files
-  template:
-    src: "{{ item }}.j2"
-    dest: "{{ k8s_account_cfg }}/{{ item }}"
-    mode: 0600
-  loop: "{{ k8s_account_templates }}"
-  tags:
-    - config_only
-
-- name: Create the service accounts and roles
-  command: kubectl --kubeconfig={{ kubecfg }} apply -f {{ item }}
-  args:
-    chdir: "{{ k8s_account_cfg }}"
-  loop: "{{ k8s_account_templates }}"
+- name: Configure TheCombine Cluster
+  import_role:
+    name: k8s_make_resources
+  vars:
+    k8s_config_dir: "{{ k8s_account_cfg }}"
+    k8s_templates:
+      - service_acct_ecr_login.yml
+      - service_acct_maint.yml
+      - role_ecr_login.yml
+      - role_maintenance.yml

--- a/deploy/roles/k8s_cert_manager/defaults/main.yml
+++ b/deploy/roles/k8s_cert_manager/defaults/main.yml
@@ -1,2 +1,0 @@
----
-cert_manager_version: v1.4.0

--- a/deploy/roles/k8s_cert_manager/tasks/main.yml
+++ b/deploy/roles/k8s_cert_manager/tasks/main.yml
@@ -1,23 +1,9 @@
 ---
-- name: Create directory for cert-manager configuration files
-  file:
-    path: "{{ k8s_cert_mgr_cfg }}"
-    state: directory
-    mode: 0700
-
-- name: Create Issuer configuration file
-  template:
-    src: "{{ item }}.j2"
-    dest: "{{ k8s_cert_mgr_cfg }}/{{ item }}"
-    mode: 0600
-  with_items:
-    - letsencrypt_prod.yaml
-    - letsencrypt_staging.yaml
-
-- name: Apply Issuer configuration file
-  command: kubectl --kubeconfig={{ kubecfg }} apply -f {{ k8s_cert_mgr_cfg }}/{{ item }}
-  args:
-    chdir: "{{ k8s_working_dir }}"
-  with_items:
-    - letsencrypt_prod.yaml
-    - letsencrypt_staging.yaml
+- name: Configure cert-manager
+  import_role:
+    name: k8s_make_resources
+  vars:
+    k8s_config_dir: "{{ k8s_cert_mgr_cfg }}"
+    k8s_templates:
+      - letsencrypt_prod.yaml
+      - letsencrypt_staging.yaml

--- a/deploy/roles/k8s_config/defaults/main.yml
+++ b/deploy/roles/k8s_config/defaults/main.yml
@@ -1,25 +1,5 @@
 ---
 #######################################
-# Kubernetes resource templates
-k8s_resource_templates:
-  - persistentvolumeclaim-backend-data.yaml
-  - persistentvolumeclaim-database-data.yaml
-  - env-backend-configmap.yaml
-  - env-backend-secrets.yaml
-  - env-frontend-configmap.yaml
-  - env-maintenance-configmap.yaml
-  - aws-s3-credentials.yaml
-  - deployment-backend.yaml
-  - deployment-database.yaml
-  - deployment-frontend.yaml
-  - deployment-maintenance.yaml
-  - cronjob-daily-backup.yaml
-  - ingress-combine.yaml
-  - service-backend.yaml
-  - service-database.yaml
-  - service-frontend.yaml
-
-#######################################
 # Persistent storage size configurations
 backend_data_size: 4Gi
 database_data_size: 2Gi

--- a/deploy/roles/k8s_config/tasks/main.yml
+++ b/deploy/roles/k8s_config/tasks/main.yml
@@ -1,19 +1,23 @@
 ---
-- name: Create directory for The Combine configuration files
-  file:
-    path: "{{ k8s_combine_cfg }}"
-    state: directory
-    mode: 0700
-
-- name: Create Kubernetes configuration files for The Combine
-  template:
-    src: "{{ item }}.j2"
-    dest: "{{ k8s_combine_cfg }}/{{ item }}"
-    mode: 0600
-  loop: "{{ k8s_resource_templates}}"
-
-- name: Apply Kubernetes configuration
-  command: kubectl --kubeconfig={{ kubecfg }} apply -f {{ item }}
-  args:
-    chdir: "{{ k8s_combine_cfg }}"
-  loop: "{{ k8s_resource_templates}}"
+- name: Configure TheCombine Cluster
+  import_role:
+    name: k8s_make_resources
+  vars:
+    k8s_config_dir: "{{ k8s_combine_cfg }}"
+    k8s_templates:
+      - persistentvolumeclaim-backend-data.yaml
+      - persistentvolumeclaim-database-data.yaml
+      - env-backend-configmap.yaml
+      - env-backend-secrets.yaml
+      - env-frontend-configmap.yaml
+      - env-maintenance-configmap.yaml
+      - aws-s3-credentials.yaml
+      - deployment-backend.yaml
+      - deployment-database.yaml
+      - deployment-frontend.yaml
+      - deployment-maintenance.yaml
+      - cronjob-daily-backup.yaml
+      - ingress-combine.yaml
+      - service-backend.yaml
+      - service-database.yaml
+      - service-frontend.yaml

--- a/deploy/roles/k8s_make_resources/tasks/main.yml
+++ b/deploy/roles/k8s_make_resources/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Create directory for The Combine configuration files
+  file:
+    path: "{{ k8s_config_dir }}"
+    state: directory
+    mode: 0700
+
+- name: Create Kubernetes configuration files for The Combine
+  template:
+    src: "{{ item }}.j2"
+    dest: "{{ k8s_config_dir }}/{{ item }}"
+    mode: 0600
+  loop: "{{ k8s_templates}}"
+
+- name: Apply Kubernetes configuration
+  command: kubectl --kubeconfig={{ kubecfg }} apply -f {{ item }}
+  args:
+    chdir: "{{ k8s_config_dir }}"
+  loop: "{{ k8s_templates}}"

--- a/deploy/roles/k8s_namespace/tasks/main.yml
+++ b/deploy/roles/k8s_namespace/tasks/main.yml
@@ -1,17 +1,8 @@
 ---
-- name: Create directory for the namespace configuration file
-  file:
-    path: "{{ k8s_namespace_cfg }}"
-    state: directory
-    mode: 0700
-
-- name: Create application namespace configuration files
-  template:
-    src: namespace-combine.yaml.j2
-    dest: "{{ k8s_namespace_cfg }}/namespace-combine.yaml"
-    mode: 0600
-
-- name: Create the namespace
-  command: kubectl --kubeconfig={{ kubecfg }} apply -f {{ k8s_namespace_cfg }}/namespace-combine.yaml
-  args:
-    chdir: "{{ k8s_working_dir }}"
+- name: Configure Namespaces
+  import_role:
+    name: k8s_make_resources
+  vars:
+    k8s_config_dir: "{{ k8s_namespace_cfg }}"
+    k8s_templates:
+      - namespace-combine.yaml

--- a/deploy/roles/k8s_namespace/templates/namespace-combine.yaml.j2
+++ b/deploy/roles/k8s_namespace/templates/namespace-combine.yaml.j2
@@ -1,4 +1,7 @@
+{% for namespace in create_namespaces %}
+---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ app_namespace }}
+  name: {{ namespace }}
+{% endfor %}

--- a/deploy/roles/k8s_storage/defaults/main.yml
+++ b/deploy/roles/k8s_storage/defaults/main.yml
@@ -1,6 +1,2 @@
 ---
 k8s_storage_dir: "{{ combine_app_dir }}/volumes"
-
-# Local Working directory
-k8s_working_dir: "{{ ansible_env.HOME }}/kube_files"
-k8s_storage_cfg: "{{ k8s_working_dir }}/storage"

--- a/deploy/roles/k8s_storage/tasks/main.yml
+++ b/deploy/roles/k8s_storage/tasks/main.yml
@@ -1,28 +1,8 @@
 ---
-- name: Create directory for Storage configuration files
-  file:
-    path: "{{ k8s_storage_cfg }}"
-    state: directory
-    mode: 0700
-
-- name: Create Storage Class config
-  template:
-    src: "{{ item }}"
-    dest: "{{ k8s_storage_cfg }}/{{ item | basename | regex_replace('^(.*\\.yaml)\\.j2', '\\1') }}"
-    mode: 0600
-  with_fileglob:
-    - "templates/*.yaml.j2"
-
-- name: Lookup generated configuration files
-  find:
-    paths:
-      - "{{ k8s_storage_cfg }}"
-    file_type: file
-    patterns: "*.yaml"
-  register: kube_config
-
-- name: Apply Kubernetes configuration
-  command: kubectl apply -f {{ item.path }}
-  args:
-    chdir: "{{ k8s_working_dir }}"
-  with_items: "{{ kube_config.files | sort(attribute='path') }}"
+- name: Configure Storage Classes
+  import_role:
+    name: k8s_make_resources
+  vars:
+    k8s_config_dir: "{{ k8s_storage_cfg }}"
+    k8s_templates:
+      - storage.yaml

--- a/deploy/vars/config_common.yml
+++ b/deploy/vars/config_common.yml
@@ -4,6 +4,10 @@ combine_group: app
 combine_app_dir: /opt/combine
 combine_admin_email: admin@thecombine.app
 
+# k8s namespaces
+app_namespace: thecombine
+cert_proxy_namespace: combine-cert-proxy
+
 # Configure logging
 combine_use_syslog: true
 # common configuration items that are shared between the certmgr and frontend
@@ -20,7 +24,8 @@ k8s_combine_cfg: "{{ k8s_working_dir }}/thecombine"
 k8s_image_pull_cfg: "{{k8s_working_dir}}/image_pull"
 k8s_namespace_cfg: "{{k8s_working_dir}}/namespace"
 k8s_account_cfg: "{{k8s_working_dir}}/accounts"
-
+k8s_storage_cfg: "{{ k8s_working_dir}}/storage"
+k8s_cert_proxy_cfg: "{{ k8s_working_dir }}/cert_proxy"
 k8s_service_accounts:
   ecr_login: account-ecr-login
   maintenance: account-maintenance


### PR DESCRIPTION
Most of the Ansible roles for setting up the Combine under Kubernetes follow this pattern:
 - create directory for the Kubernetes configuration YAML files
 - build the configuration files from a list of template(s)
 - run `kubectl apply -f <filename>` on each of the configuration files

This PR introduces a role, `k8s_make_resources`, to perform these steps.  This role can be used to replace the list of tasks in the other roles with a single task of this form:
```
- name: <task name>
  import_role:
    name: k8s_make_resources
  vars:
    k8s_config_dir: <directory for the configuration files>
    k8s_templates:
      - <template1.yaml>
      - <template2.yaml>
      ...
```
Note that the `k8s_templates` list is a list of templates in the calling roles `templates` sub-directory and are listed _without_ the `.j2` extension.
