### PR TITLE
Remove GitHub Actions tests for Python 3.7

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Python 3.7 is not required since #1313.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1409)
<!-- Reviewable:end -->
