### PR TITLE
Revert pinning pip to deal with pip-tools incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ environment. This will be denoted with the `(venv)` prefix on the prompt.
 With an active virtual environment, install Python development requirements for this project:
 
 ```bash
-(venv) $ python -m pip install --upgrade pip==21.2 pip-tools
+(venv) $ python -m pip install --upgrade pip pip-tools
 (venv) $ python -m piptools sync dev-requirements.txt
 ```
 


### PR DESCRIPTION
Revert part of #1420, as the following upstream `pip-tools` issue has been resolved and released into `pip-tools` 6.4.0:

- https://github.com/jazzband/pip-tools/issues/1503

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1431)
<!-- Reviewable:end -->
