### PR TITLE
Fix mk_release.py support on Windows

### DIFF
--- a/scripts/mk_release.py
+++ b/scripts/mk_release.py
@@ -108,12 +108,13 @@ def list_commits(end_commit: str) -> None:
     """
     try:
         log_results = subprocess.run(
-            ["git", "log"],
+            ["git", "log", "--no-color"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             universal_newlines=True,
             check=True,
             text=True,
+            encoding="utf-8",
         )
     except subprocess.CalledProcessError as err:
         print(f"CalledProcessError returned {err.returncode}")


### PR DESCRIPTION
Fix Windows support for `mk_release.py` added in #1444

Without this change, the following exception is thrown:

```
Traceback (most recent call last):
  File "C:\Program Files\Python39\lib\threading.py", line 954, in _bootstrap_inner
    self.run()
  File "C:\Program Files\Python39\lib\threading.py", line 892, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Program Files\Python39\lib\subprocess.py", line 1479, in _readerthread
    buffer.append(fh.read())
  File "C:\Program Files\Python39\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 275773: character maps to <undefined>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1445)
<!-- Reviewable:end -->
