### PR TITLE
Document the canonical way to activate a Python virtual environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Create an isolated Python virtual environment
 
 ```bash
 $ python3 -m venv venv
-$ . venv/bin/activate
+$ source venv/bin/activate
 ```
 
 ### macOS Python Installation

--- a/README.md
+++ b/README.md
@@ -252,10 +252,11 @@ $ sudo apt update
 $ sudo apt install python3 python3-venv
 ```
 
-Create an isolated Python virtual environment
+Create and activate an isolated Python virtual environment
 
 ```bash
 $ python3 -m venv venv
+# This command is shell-specific, for the common use case of bash:
 $ source venv/bin/activate
 ```
 
@@ -269,7 +270,7 @@ Install Python 3 using Homebrew:
 $ brew install python
 ```
 
-Once Python is installed, create an isolated Python virtual environment:
+Create and activate isolated Python virtual environment:
 
 ```bash
 $ python3 -m venv venv


### PR DESCRIPTION
This usage also matches the macOS instructions

For reference, see: https://docs.python.org/3/tutorial/venv.html#creating-virtual-environments

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1470)
<!-- Reviewable:end -->
