### PR TITLE
Switch to kubernetes deployment

### DIFF
--- a/deploy/group_vars/qa/main.yml
+++ b/deploy/group_vars/qa/main.yml
@@ -72,7 +72,7 @@ k8s_group: sillsdev
 #   Recreate - for the NUCs where they are updated offline
 #   RollingUpdate - for the servers and qa which are available
 #              during an update
-k8s_update_strategy: RollingUpdate
+k8s_update_strategy: Recreate
 
 #######################################
 # Ingress configuration

--- a/deploy/group_vars/server/main.yml
+++ b/deploy/group_vars/server/main.yml
@@ -84,7 +84,7 @@ cert_proxy_namespace: combine-cert-proxy
 #   Recreate - for the NUCs where they are updated offline
 #   RollingUpdate - for the servers and qa which are available
 #              during an update
-k8s_update_strategy: RollingUpdate
+k8s_update_strategy: Recreate
 
 #######################################
 # Ingress configuration

--- a/deploy/hosts.yml
+++ b/deploy/hosts.yml
@@ -31,8 +31,9 @@ all:
           #   playbook_install.yml
           # to manage this host
           combine_server_name: legacy.thecombine.app
-          cert_mode: cert-server
+          cert_mode: letsencrypt
           combine_addl_domain_list: []
+          combine_cert_proxy_list: []
           config_captcha_required: "true"
           config_captcha_sitekey: "6LdZIlkaAAAAAES4FZ5d01Shj5G4X0e2CHYg0D5t"
         thecombine.app:

--- a/deploy/hosts.yml
+++ b/deploy/hosts.yml
@@ -25,20 +25,24 @@ all:
           kubecfgdir: qa
     server:
       hosts:
-        thecombine.app:
-          combine_server_name: thecombine.app
+        legacy.thecombine.app:
+          # use the
+          #   playbook_target_setup.yml, and
+          #   playbook_install.yml
+          # to manage this host
+          combine_server_name: legacy.thecombine.app
           cert_mode: cert-server
-          combine_addl_domain_list:
-            - thecombine.languagetechnology.org
+          combine_addl_domain_list: []
           config_captcha_required: "true"
           config_captcha_sitekey: "6LdZIlkaAAAAAES4FZ5d01Shj5G4X0e2CHYg0D5t"
-          k8s_components:
-            - ingress_controller
-            - cert_manager
-            - cert_proxy_server
-        kube.thecombine.app:
+        thecombine.app:
+          # use the
+          #   playbook_kube_install.yml,
+          #   playbook_kube_config.yml, and
+          #   playbook_kube_admin.yml
+          # to manage this host
           kubecfgdir: rke
-          combine_server_name: kube.thecombine.app
+          combine_server_name: thecombine.app
           config_captcha_required: "true"
           config_captcha_sitekey: "6LdZIlkaAAAAAES4FZ5d01Shj5G4X0e2CHYg0D5t"
           k8s_components:

--- a/deploy/hosts.yml
+++ b/deploy/hosts.yml
@@ -42,7 +42,7 @@ all:
           #   playbook_kube_config.yml, and
           #   playbook_kube_admin.yml
           # to manage this host
-          kubecfgdir: rke
+          kubecfgdir: prod
           combine_server_name: thecombine.app
           config_captcha_required: "true"
           config_captcha_sitekey: "6LdZIlkaAAAAAES4FZ5d01Shj5G4X0e2CHYg0D5t"

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -1,7 +1,7 @@
 # How To Deploy _The Combine_
 
-This document describes how to install the framework that is needed to deploy _The Combine_ to a target machine in
-Docker containers.
+This document describes how to install the framework that is needed to deploy _The Combine_ to a target Kubernetes
+cluster.
 
 <table>
 <tr>
@@ -12,8 +12,19 @@ Docker containers.
 </tr>
 </table>
 
+## Assumptions
+
+_The Combine_ is designed to be installed on a server on the internet or an organization's intranet or on a standalone
+PC such as an Intel NUC. The instructions assume that:
+
+1.  a server already has Kubernetes installed and that the basic infrastucture and namespaces are already configured;
+    and
+2.  a standalone PC starts with bare hardware.
+
 ## Conventions
 
+- the term _NUC_ will be used to describe a target that is a standalone PC. It can be any 64-bit Intel Architecture
+  machine.
 - most of the commands described in this document are to be run from within the <tt>git</tt> repository for _The
   Combine_ that has been cloned on the host machine. This directory is referred to as \<COMBINE\>.
 - the target machine where _The Combine_ is being installed will be referred to as _\<target\>_
@@ -28,30 +39,21 @@ Docker containers.
       2. [Windows Host](#windows-host)
    2. [Installing and Running _The Combine_](#installing-and-running-the-combine)
       1. [Minimum System Requirements](#minimum-system-requirements)
-      2. [Install Combine Pre-requisites](#install-combine-pre-requisites)
-      3. [Install The Combine](#install-the-combine)
-      4. [Running _The Combine_ Docker Containers](#running-the-combine-docker-containers)
-      5. [Running _The Combine_ in a Kubernetes Cluster](#running-the-combine-in-a-kubernetes-cluster)
-         1. [Additional Host Requirements](#additional-host-requirements)
-         2. [Installing the Kubernetes Cluster](#installing-the-kubernetes-cluster)
-         3. [Maintenance Scripts for Kubernetes](#maintenance-scripts-for-kubernetes)
+      2. [Prepare to Install _The Combine_ on a NUC](#prepare-to-install-the-combine-on-a-nuc)
+      3. [Prepare to Install _The Combine_ on a Server](#prepare-to-install-the-combine-on-a-server)
+      4. [Install _The Combine_ Cluster](#install-the-combine-cluster)
+      5. [Maintenance Scripts for Kubernetes](#maintenance-scripts-for-kubernetes)
       6. [Creating Your Own Inventory File](#creating-your-own-inventory-file)
-2. [Backups](#backups)
-   1. [Automated Backups](#automated-backups)
-   2. [Running a Backup Manually](#running-a-backup-manually)
-   3. [Restoring Database and Backend From a Previous Backup](#restoring-database-and-backend-from-a-previous-backup)
+2. [Automated Backups](#automated-backups)
 3. [Design](#design)
-   1. [Docker Compose Implementation](#docker-compose-implementation)
-   2. [Kubernetes Implementation](./kubernetes_design/README.md)
 4. [Additional Details](#additional-details)
-   1. [Install Ubuntu Bionic Server](#install-ubuntu-bionic-server)
+   1. [Install Ubuntu Server](#install-ubuntu-server)
    2. [Vault Password](#vault-password)
-   3. [Updating Packages](#updating-packages)
 
 # Step-by-step Instructions
 
 This section gives you step-by-step instructions for installing _The Combine_ on a new NUC/PC with links to more
-detailed information. The instructions assume that the target system already has Ubuntu Server 18.04 installed and is
+detailed information. The instructions assume that the target system already has Ubuntu Server 20.04 installed and is
 accessible via `ssh`.
 
 ## Prepare your host system
@@ -63,6 +65,8 @@ Install the following components:
 - Ubuntu 20.04 (Desktop or Server), 64-bit
 - Git
 - [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#latest-releases-via-apt-ubuntu)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) for examining and modifying your Kubernetes cluster
+- [Helm](https://helm.sh/docs/intro/install/) for installing Helm Charts (Kubernetes Packages)
 - clone the project repo:
   ```
   git clone https://github.com/sillsdev/TheCombine
@@ -82,13 +86,13 @@ The scripts for installing _The Combine_ use _Ansible_ to manage an installation
 available for Windows but will run in the Windows Subsystem for Linux (WSL). Microsoft has instructions for installing
 WSL on Windows 10 at
 [Windows Subsystem for Linux Installation Guide for Windows 10](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
-At the end of the instructions there are instructions for installing various Linux images including Ubuntu 18.04.
+At the end of the instructions there are instructions for installing various Linux images including Ubuntu 20.04.
 
 Once Ubuntu is installed, run the Ubuntu subsystem and follow the instructions for the [Linux Host](#linux-host)
 
 ## Installing and Running _The Combine_
 
-To install and start up _The Combine_ you will need to run the following Ansible playbooks. Each time you will be
+To install and start up _The Combine_ you will need to run the following Ansible playbooks. Each time you may be
 prompted for passwords:
 
 - `BECOME password` - enter your `sudo` password for the _\<target_user\>_ on the _\<target\>_ machine.
@@ -100,17 +104,16 @@ prompted for passwords:
 The minimum system requirements for installing _The Combine_ on a target are:
 
 - Ubuntu 20.04 Server operating system (see [Install Ubuntu Focal Server](#install-ubuntu-focal-server))
-- 2 GB RAM
-- 15 GB Storage
+- 4 GB RAM
+- 32 GB Storage
 
-### Install Combine Pre-requisites
+### Prepare to Install _The Combine_ on a NUC
 
-Run the first playbook to install all the packages that are needed by _The Combine_ and to setup the Docker
-configuration files:
+Install Kubernetes and setup your configuration file for running `kubectl`:
 
 ```bash
 cd <COMBINE>/deploy
-ansible-playbook playbook_target_setup.yml --limit <target> -u <target_user> -K --ask-vault-pass
+ansible-playbook playbook_kube_install.yml --limit <target> -u <target_user> -K --ask-vault-pass
 ```
 
 Notes:
@@ -120,89 +123,31 @@ Notes:
   your own inventory file (see [below](#creating-your-own-inventory-file)). The _\<target\>_ can be a hostname or a
   group in the inventory file, e.g. `qa`.
 
-### Install The Combine
+### Prepare to Install _The Combine_ on a Server
+
+1. Login to the Kubernetes Dashboard for the Production (or QA) server. You need to have an account on the server that
+   was created by the operations group.
+2. Copy your `kubectl` configuration to the clipboard and paste it into a file named `~/.kube/{{ kubecfgdir }}/config`.
+   `{{ kubecfgdir }}` is defined in `deploy/hosts.yml` for each server. The current values are `prod` for the production
+   server and `qa` for the QA server.
+
+### Install _The Combine_ Cluster
 
 To install _The Combine_ run the following command:
 
-```
+```bash
 cd <COMBINE>/deploy
-ansible-playbook playbook_install.yml --limit <target> -u <target_user> -K --ask-vault-pass
+ansible-playbook playbook_kube_config.yml --limit <target> --ask-vault-pass
 ```
 
 Notes:
 
-- This is not needed for the Production server or for the QA server. _The Combine_ is installed on these systems using
-  the CI/CD tools.
 - You will be prompted for the version of _The Combine_ to install. The version is the Docker image tag in the AWS ECR
-  image repository. The standard releases are tagged with the version number, e.g. _0.6.5_.
+  image repository. The standard releases are tagged with the version number, e.g. _0.7.9_.
 
-### Running _The Combine_ Docker Containers
+### Maintenance Scripts for Kubernetes
 
-_The Combine_'s docker containers are built by SIL's _TeamCity_ server. Once they are built successfully, they are
-pushed to Amazon's Elastic Container Registry (AWS ECR). The production `docker-compose.yml` files will pull the images
-from AWS_ECR.
-
-### Running _The Combine_ in a Kubernetes Cluster
-
-Note that this functionality is under development and is not complete.
-
-#### Additional Host Requirements
-
-In addition to the software listed in the section [Prepare your host system](#prepare-your-host-system) you will need to
-install:
-
-- [kubectl](https://kubernetes.io/docs/tasks/tools/) for examining and modifying your Kubernetes cluster; and
-- [Helm](https://helm.sh/docs/intro/install/) for installing Helm Charts (Kubernetes Packages).
-
-Both of these tools are used by the Ansible playbooks that setup the Kubernetes cluster for running _The Combine_.
-
-#### Installing the Kubernetes Cluster
-
-The method for installing _The Combine_ running in a kubernetes cluster varies depending on the type of target system.
-
-##### Production or QA Server
-
-1. Login to the Kubernetes Dashboard for the Production (or QA) server. You need to have an account on the server that
-   was created by the operations group.
-2. Copy your `kubectl` configuration to the clipboard and paste it into a file named `~/.kube/prod/config`
-   (`~/.kube/qa/config` for the QA server).
-3. Setup _The Combine_ in the Kubernetes cluster
-
-   Run the commands:
-
-   ```bash
-   cd <COMBINE>/deploy
-   ansible-playbook playbook_kube_config.yml --limit <target> --ask-vault-pass
-   ```
-
-##### NUC
-
-Run the following _Ansible_ playbooks to install Kubernetes and setup _The Combine_:
-
-```bash
-cd <COMBINE>/deploy
-ansible-playbook playbook_kube_install.yml --limit <target> -u <target_user> -K --ask-vault-pass
-ansible-playbook playbook_kube_config.yml --limit <target> --ask-vault-pass
-```
-
-##### Installation Notes
-
-- The playbooks to install the Kubernetes cluster assume that either:
-  - `k8s_engine` is set to a value other than `none`; or
-  - Kubernetes is already installed on the target, for example, a _Rancher_ environment that is managed by another
-    group.
-- Do not add the `-K` option if you do not need to enter your password to run `sudo` commands _on the target machine_.
-  The `-K` should only be used for the `playbook_kube_install.yml` playbook.
-- The `playbook_kube_config.yml` playbook will prompt you for the version of _The Combine_ to install. The version is
-  the Docker image tag in the AWS ECR image repository. The standard releases are tagged with the version number, e.g.
-  _0.7.5_.
-- The _\<target\>_ must be listed in the hosts.yml file (in \<COMBINE\>/deploy). If it is not, then you need to create
-  your own inventory file (see [below](#creating-your-own-inventory-file)). The _\<target\>_ can be a hostname or a
-  group, such as, `qa`, in the inventory file.
-
-#### Maintenance Scripts for Kubernetes
-
-There is a set of maintenance scripts that can be run in the kubernetes cluster:
+There are several maintenance scripts that can be run in the kubernetes cluster:
 
 - `combine-backup-job.sh` - performs a backup of _The Combine_ database and backend files, pushes the backup to AWS S3
   storage and then removes old backups keeping the latest 3 backups.
@@ -221,9 +166,13 @@ kubectl [--kubeconfig=<path-to-kubernetes-file] [-n thecombine] exec -it deploym
 
 Notes:
 
-1. The `--kubeconfig` option is not required if a. the `KUBECONFIG` environment variable is set to the path of your
-   kubeconfig file, or b. if your kubeconfig file is located in `${HOME}/.kube/config`
-2. You can see the script options for a script by running:
+1. The `--kubeconfig` option is not required if
+
+   1. the `KUBECONFIG` environment variable is set to the path of your kubeconfig file, or
+
+   2. if your kubeconfig file is located in `${HOME}/.kube/config`.
+
+2. You can see the options for a script by running:
    ```
    kubectl [--kubeconfig=<path-to-kubernetes-file] [-n thecombine] exec -it deployment/maintenance -- <maintenance scripts> --help
    ```
@@ -263,130 +212,47 @@ See the Ansible documentation,
 [Build Your Inventory](https://docs.ansible.com/ansible/latest/network/getting_started/first_inventory.html) for more
 information on inventory files.
 
-# Backups
-
-## Automated Backups
+# Automated Backups
 
 If the ansible variables `backup_hours` and `backup_minutes` are defined for a target, then `cron` will be setup to
 create a backup of _The Combine_ database and backend files every day at the specified times. The hours/minutes can be
 set to any string that is recognized by `cron`. The backups are stored in an Amazon S3 bucket.
 
-## Running a Backup Manually
-
-A backup can be initiated on demand whether or not an automatic backup has been setup. To run a backup, perform the
-following steps:
-
-1.  `ssh` to the target using your account.
-2.  Switch user to `combine`, e.g. `sudo su -l combine`. Make sure you use the `-l` option.
-3.  `cd /opt/combine`
-4.  `bin/combine-backup`
-
-`bin/combine-backup -h` will print the usage information.
-
-## Restoring Database and Backend From a Previous Backup
-
-_The Combine_ database and backend files can be restored from a previous backup by performing the following steps:
-
-1. `ssh` to the target using your account.
-2. Switch user to `combine`, e.g. `sudo su -l combine`. Make sure you use the `-l` option.
-3. `cd /opt/combine`
-4. `bin/combine-restore`
-
-You may provide the backup to restore as an argument to `bin/combine-restore`; if no backup is specified,
-`combine-restore` will list the backups that are available in the AWS S3 bucket and allow you to select one.
-
-`bin/combine-restore -h` will print the usage information.
-
 # Design
-
-## Docker Compose Implementation
-
-_The Combine_ is deployed to target systems using Ansible. When deploying in Docker containers, `docker-compose` is used
-to manage the containers that make up _The Combine_. The following files are used to define the containers and their
-dependencies:
-
-- ./docker-compose.yml
-- ./Dockerfile
-- ./.env.frontend
-- ./Backend/Dockerfile
-- ./.env.backend
-- ./certmgr/Dockerfile
-- ./.env.certmgr
-
-With these files, we can use `docker-compose` to startup _The Combine_ in the development environment (see the project
-top-level README.md).
-
-`playbook_target_setup.yml` is an Ansible playbook that is used to install docker, docker-compose, and the files to
-configure the docker containers. It only needs to be run once. When running this playbook, it needs to be run as a user
-on the target system that can be elevated to `root` privileges. It needs to be run once at initial setup and if ever the
-playbook or its roles change.
-
-`playbook_target_setup.yml` does the following:
-
-1. Install Ansible dependencies to allow subsequent playbooks
-2. Install the docker subsystem. This includes
-   1. install docker prerequisite packages
-   2. setup docker package repository
-   3. install Docker Engine
-   4. install Docker Compose (including a link from `/usr/bin` to the executable)
-3. Create a combine user - the combine user will be used for installing, building and running _The Combine_. The default
-   user name is `combine`.
-   1. Create the primary group for `combine`
-   2. Create the `combine` user:
-      1. primary group is the group created above
-      2. `combine` user is also added to the `docker` group
-      3. ssh key is generated
-4. Install _The Combine_ configuration files
-   1. Create folders for the docker installation:
-      - combine app dir (`/opt/combine`)
-      - Nginx script dir (`/opt/combine/nginx/scripts`)
-   2. Install the `docker-compose.yml` that defines the containers and their environment;
-   3. Create the environment variable files for the frontend and backend containers, `.env.frontend`, `.env.backend`,
-      and `.env.certmgr`;
-   4. Create the runtime configuration for the UI;
-5. Setup access to the Amazon Web Services
-   1. Install the `aws-cli` package
-   2. Create the AWS access profiles
-6. Setup container backups
-   1. Create folders for the backups and for the scripts
-   2. Install the backup and the restore script
-   3. Schedule daily backups if configured
-
-## Kubernetes Implementation
 
 Please see the Kubernetes Design document at [./kubernetes_design/README.md](./kubernetes_design/README.md)
 
 # Additional Details
 
-## Install Ubuntu Focal Server
+## Install Ubuntu Server
 
 To install the OS on a new target machine, such as, a new NUC, follow these steps:
 
-1. Download the ISO image for Ubuntu Server from Ubuntu (currently at https://ubuntu.com/download/server#downloads;
-   click on _Download Ubuntu Server 20.04.2 LTS_)
+1. Download the ISO image for Ubuntu Server from Ubuntu (currently at https://ubuntu.com/download/server; click on
+   _Option 2 - Manual server installation_ and then _Download Ubuntu Server 20.04.3 LTS_)
 
-1. copy the .iso file to a bootable USB stick:
+2. copy the .iso file to a bootable USB stick:
 
    1. Ubuntu host: Use the _Startup Disk Creator_, or
    2. Windows host: follow the
       [tutorial](https://ubuntu.com/tutorials/tutorial-create-a-usb-stick-on-windows#1-overview) on ubuntu.com.
 
-1. Boot the PC from the bootable media and follow the installation instructions. In particular,
+3. Boot the PC from the bootable media and follow the installation instructions. In particular,
 
    1. You will want the installer to format the entire \[virtual\] disk. Using LVM is not recommended.
 
-   1. Make sure that you install the OpenSSH server when prompted:
+   2. Make sure that you install the OpenSSH server when prompted:
       ![alt text](images/ubuntu-software-selection.png "Ubuntu Server Software Selection")
 
       In addition, you may have your SSH keys from _Github_ or _Launchpad_ preinstalled as authorized keys.
 
-   1. You do not need to install any additional snaps; the _Ansible_ playbooks will install any needed software
+   3. You do not need to install any additional snaps; the _Ansible_ playbooks will install any needed software
 
-1. Update all packages:
+4. Update all packages:
    ```
    sudo apt update && sudo apt upgrade -y
    ```
-1. Reboot:
+5. Reboot:
    ```
    sudo reboot
    ```
@@ -410,10 +276,3 @@ If you use a file to hold the vault password, then:
 - _Make sure that the password file is not tracked in the git repository!_
 
 For example, use hidden file in your home directory, such as <tt>\$HOME/.ansible-vault</tt>, with mode of <tt>0600</tt>.
-
-## Updating Packages
-
-Currently, `docker-compose` is not managed by an _Ubuntu_ software repository and the software version is specified in
-the command that fetches the software from the source repository. To make managing software versions easier,
-`./deploy/vars/packages.yml` has been created to specify the software version of `docker-compose` and similar packages.
-To update the version of one of these packages, update the version in this file and re-run the specified playbook.


### PR DESCRIPTION
Update deployment scripts and documentation for running _The Combine_ in a Kubernetes cluster.  Dropping documentation of `docker-compose` deployment.

Closes #1457

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1483)
<!-- Reviewable:end -->
