### PR TITLE
Remove Unused Permission enumeration member

### DIFF
--- a/Backend/Controllers/ProjectController.cs
+++ b/Backend/Controllers/ProjectController.cs
@@ -120,7 +120,6 @@ namespace BackendFramework.Controllers
                     Permission.DeleteEditSettingsAndUsers,
                     Permission.ImportExport,
                     Permission.MergeAndReviewEntries,
-                    Permission.Unused,
                     Permission.WordEntry
                 },
                 ProjectId = project.Id

--- a/Backend/Models/UserRole.cs
+++ b/Backend/Models/UserRole.cs
@@ -86,8 +86,7 @@ namespace BackendFramework.Models
         /// <summary> Can merge words and change the char set </summary>
         MergeAndReviewEntries = 3,
 
-        /// <summary> Unused </summary>
-        Unused = 2,
+        // Permission value 2 is currently unused. It is not defined so that it does not propagate through OpenAPI.
 
         /// <summary> Can enter words </summary>
         WordEntry = 1

--- a/Backend/Services/InviteService.cs
+++ b/Backend/Services/InviteService.cs
@@ -60,7 +60,6 @@ namespace BackendFramework.Services
                     Permissions = new List<Permission>
                 {
                     Permission.MergeAndReviewEntries,
-                    Permission.Unused,
                     Permission.WordEntry
                 },
                     ProjectId = project.Id

--- a/README.md
+++ b/README.md
@@ -590,8 +590,9 @@ Task: add an existing user to a project
 Notes:
 
 1. The `--project` and `--user` options may be shortened to `--p` and `--u` respectively.
-2. The user is added to the project with normal project member permissions (`[3,2,1]`). Add the `--admin` option to add
-   the user with project administrator permissions (`[5,4,3,2,1]`)
+2. The user is added to the project with normal project member permissions (`MergeAndReviewEntries`, and
+   `WordEntry`). Add the `--admin` option to add the user with project administrator permissions 
+   (`DeleteEditSettingsAndUsers`, `ImportExport`, `MergeAndReviewEntries`, and `WordEntry`)
 
 ### Backup _TheCombine_
 

--- a/deploy/roles/combine_maintenance/files/add_user_to_proj.py
+++ b/deploy/roles/combine_maintenance/files/add_user_to_proj.py
@@ -5,8 +5,10 @@ Add user to a project.
 This script will add a user to a Combine project in the database
 
 To add the user to the project, we need to:
- 1. If the --admin argument is used, set the requested permissions to [5,4,3,2,1];
-    otherwise, set them to [3,2,1]
+ 1. If the --admin argument is used, set the requested permissions to
+        [DeleteEditSettingsAndUsers, ImportExport, MergeAndReviewEntries, WordEntry];
+    otherwise
+        [MergeAndReviewEntries, WordEntry]
  2. Look up the user id - check the "user" info against the username and
     email fields in the UsersCollection.
  3. Check to see if the user is already in the project.  If he/she is

--- a/deploy/roles/combine_maintenance/files/add_user_to_proj.py
+++ b/deploy/roles/combine_maintenance/files/add_user_to_proj.py
@@ -62,13 +62,11 @@ def main() -> None:
             Permission.DeleteEditSettingsAndUsers.value,
             Permission.ImportExport.value,
             Permission.MergeAndReviewEntries.value,
-            Permission.Unused.value,
             Permission.WordEntry.value,
         ]
     else:
         req_permissions = [
             Permission.MergeAndReviewEntries.value,
-            Permission.Unused.value,
             Permission.WordEntry.value,
         ]
 

--- a/deploy/roles/combine_maintenance/files/add_user_to_proj.py
+++ b/deploy/roles/combine_maintenance/files/add_user_to_proj.py
@@ -6,7 +6,7 @@ This script will add a user to a Combine project in the database
 
 To add the user to the project, we need to:
  1. If the --admin argument is used, set the requested permissions to
-        [DeleteEditSettingsAndUsers, ImportExport, MergeAndReviewEntries, WordEntry];
+        [DeleteEditSettingsAndUsers, ImportExport, MergeAndReviewEntries, WordEntry]
     otherwise
         [MergeAndReviewEntries, WordEntry]
  2. Look up the user id - check the "user" info against the username and

--- a/deploy/roles/combine_maintenance/files/combine_app.py
+++ b/deploy/roles/combine_maintenance/files/combine_app.py
@@ -18,7 +18,7 @@ class Permission(enum.Enum):
     """Define enumerated type for Combine user permissions."""
 
     WordEntry = 1
-    Unused = 2
+    # Integer value 2 is currently unused.
     MergeAndReviewEntries = 3
     ImportExport = 4
     DeleteEditSettingsAndUsers = 5

--- a/maintenance/scripts/combine_app.py
+++ b/maintenance/scripts/combine_app.py
@@ -18,7 +18,7 @@ class Permission(enum.Enum):
     """Define enumerated type for Combine user permissions."""
 
     WordEntry = 1
-    Unused = 2
+    # Integer value 2 is currently unused.
     MergeAndReviewEntries = 3
     ImportExport = 4
     DeleteEditSettingsAndUsers = 5

--- a/src/api/models/permission.ts
+++ b/src/api/models/permission.ts
@@ -19,7 +19,6 @@
  */
 export enum Permission {
   WordEntry = "WordEntry",
-  Unused = "Unused",
   MergeAndReviewEntries = "MergeAndReviewEntries",
   ImportExport = "ImportExport",
   DeleteEditSettingsAndUsers = "DeleteEditSettingsAndUsers",

--- a/src/components/ProjectSettings/ProjectUsers/AddProjectUsers.tsx
+++ b/src/components/ProjectSettings/ProjectUsers/AddProjectUsers.tsx
@@ -40,11 +40,7 @@ export default function AddProjectUsers() {
     if (!projectUsers.map((u) => u.id).includes(user.id)) {
       backend
         .addOrUpdateUserRole(
-          [
-            Permission.MergeAndReviewEntries,
-            Permission.Unused,
-            Permission.WordEntry,
-          ],
+          [Permission.MergeAndReviewEntries, Permission.WordEntry],
           user.id
         )
         .then(() => {

--- a/src/components/ProjectSettings/ProjectUsers/CancelConfirmDialogCollection.tsx
+++ b/src/components/ProjectSettings/ProjectUsers/CancelConfirmDialogCollection.tsx
@@ -59,7 +59,6 @@ export default function CancelConfirmDialogCollection(
     addOrUpdateUserRole(
       [
         Permission.WordEntry,
-        Permission.Unused,
         Permission.MergeAndReviewEntries,
         Permission.ImportExport,
         Permission.DeleteEditSettingsAndUsers,
@@ -84,11 +83,7 @@ export default function CancelConfirmDialogCollection(
 
   function removeAdmin(userId: string) {
     addOrUpdateUserRole(
-      [
-        Permission.MergeAndReviewEntries,
-        Permission.Unused,
-        Permission.WordEntry,
-      ],
+      [Permission.MergeAndReviewEntries, Permission.WordEntry],
       userId
     )
       .then(() => {
@@ -111,7 +106,6 @@ export default function CancelConfirmDialogCollection(
     addOrUpdateUserRole(
       [
         Permission.WordEntry,
-        Permission.Unused,
         Permission.MergeAndReviewEntries,
         Permission.ImportExport,
         Permission.DeleteEditSettingsAndUsers,
@@ -123,7 +117,6 @@ export default function CancelConfirmDialogCollection(
         addOrUpdateUserRole(
           [
             Permission.WordEntry,
-            Permission.Unused,
             Permission.MergeAndReviewEntries,
             Permission.ImportExport,
             Permission.DeleteEditSettingsAndUsers,


### PR DESCRIPTION
Closes #1485 

@jmgrady When this is released, we will need to run a one-time database migration script on the live server to remove all `2` Permission objects from all Users. This will allow this value can be reused safely in the future if needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1491)
<!-- Reviewable:end -->
