### PR TITLE
Upgrade to .NET 6

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -42,6 +42,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      # Manually install .NET to work around:
+      # https://github.com/github/codeql-action/issues/757
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "6.0"
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1
         with:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet: ["5.0.x"]
+        dotnet: ["6.0.x"]
     steps:
       - uses: actions/checkout@v2
       - name: Setup dotnet

--- a/Backend.Tests/Backend.Tests.csproj
+++ b/Backend.Tests/Backend.Tests.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.14.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.14.1" />
-    <PackageReference Include="MongoDB.Driver" Version="2.13.2" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.15.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.15.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.14.1" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
 

--- a/Backend.Tests/Controllers/AudioControllerTests.cs
+++ b/Backend.Tests/Controllers/AudioControllerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Backend.Tests.Mocks;
 using BackendFramework.Controllers;
 using BackendFramework.Interfaces;
@@ -57,8 +58,7 @@ namespace Backend.Tests.Controllers
             _ = _audioController.UploadAudioFile(_projId, word.Id, fileUpload).Result;
 
             var action = _wordController.GetWord(_projId, word.Id).Result;
-
-            var foundWord = (Word)((ObjectResult)action).Value;
+            var foundWord = (Word)((ObjectResult)action).Value!;
             Assert.IsNotNull(foundWord.Audio);
         }
 

--- a/Backend.Tests/Controllers/AvatarControllerTests.cs
+++ b/Backend.Tests/Controllers/AvatarControllerTests.cs
@@ -69,7 +69,7 @@ namespace Backend.Tests.Controllers
 
             var action = _userController.GetUser(_jwtAuthenticatedUser.Id).Result;
 
-            var foundUser = (User)((ObjectResult)action).Value;
+            var foundUser = (User)((ObjectResult)action).Value!;
             Assert.IsNotNull(foundUser.Avatar);
 
             // Clean up.

--- a/Backend.Tests/Controllers/BannerControllerTests.cs
+++ b/Backend.Tests/Controllers/BannerControllerTests.cs
@@ -1,4 +1,5 @@
-﻿using Backend.Tests.Mocks;
+﻿using System.Threading.Tasks;
+using Backend.Tests.Mocks;
 using BackendFramework.Controllers;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
@@ -28,9 +29,9 @@ namespace Backend.Tests.Controllers
         [Test]
         public void TestUpdateBanner()
         {
-            var result = (bool)((ObjectResult)_bannerController.UpdateBanner(_siteBanner).Result).Value;
+            var result = (bool)((ObjectResult)_bannerController.UpdateBanner(_siteBanner).Result).Value!;
             Assert.IsTrue(result);
-            var banner = (SiteBanner)((ObjectResult)_bannerController.GetBanner(Type).Result).Value;
+            var banner = (SiteBanner)((ObjectResult)_bannerController.GetBanner(Type).Result).Value!;
             Assert.AreEqual(banner, _siteBanner);
         }
 
@@ -45,10 +46,10 @@ namespace Backend.Tests.Controllers
         [Test]
         public void TestGetBannerNoPermission()
         {
-            var result = (bool)((ObjectResult)_bannerController.UpdateBanner(_siteBanner).Result).Value;
+            var result = (bool)((ObjectResult)_bannerController.UpdateBanner(_siteBanner).Result).Value!;
             Assert.IsTrue(result);
             _bannerController.ControllerContext.HttpContext = PermissionServiceMock.UnauthorizedHttpContext();
-            var banner = (SiteBanner)((ObjectResult)_bannerController.GetBanner(Type).Result).Value;
+            var banner = (SiteBanner)((ObjectResult)_bannerController.GetBanner(Type).Result).Value!;
             Assert.AreEqual(banner, _siteBanner);
         }
     }

--- a/Backend.Tests/Controllers/LiftControllerTests.cs
+++ b/Backend.Tests/Controllers/LiftControllerTests.cs
@@ -425,9 +425,16 @@ namespace Backend.Tests.Controllers
                 return true;
             }
 
-            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            public void Log<TState>(
+                LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception, string> formatter)
             {
-                Console.WriteLine($"{logLevel}: {eventId} {state} {exception.Message}");
+                var message = "";
+                if (exception is not null)
+                {
+                    message = exception.Message;
+                }
+
+                Console.WriteLine($"{logLevel}: {eventId} {state} {message}");
             }
         }
     }

--- a/Backend.Tests/Controllers/ProjectControllerTests.cs
+++ b/Backend.Tests/Controllers/ProjectControllerTests.cs
@@ -76,7 +76,7 @@ namespace Backend.Tests.Controllers
         public void TestCreateProject()
         {
             var project = Util.RandomProject();
-            var userProject = (UserCreatedProject)((ObjectResult)_projController.CreateProject(project).Result).Value;
+            var userProject = (UserCreatedProject)((ObjectResult)_projController.CreateProject(project).Result).Value!;
             project.Id = userProject.Project.Id;
             Assert.Contains(project, _projRepo.GetAllProjects().Result);
         }
@@ -120,7 +120,7 @@ namespace Backend.Tests.Controllers
         {
             var project = _projRepo.Create(Util.RandomProject()).Result;
             var sdList = (List<SemanticDomainWithSubdomains>)(
-                (ObjectResult)_projController.GetSemDoms(project!.Id).Result).Value;
+                (ObjectResult)_projController.GetSemDoms(project!.Id).Result).Value!;
             Assert.That(sdList, Has.Count.EqualTo(3));
             Assert.That(sdList[0].Subdomains, Has.Count.EqualTo(3));
             Assert.That(sdList[0].Subdomains[0].Subdomains, Has.Count.EqualTo(3));
@@ -135,9 +135,11 @@ namespace Backend.Tests.Controllers
             var modProject = project1!.Clone();
             modProject.Name = "Proj";
             _ = _projController.UpdateProject(modProject.Id, modProject);
-            var isOldProjDup = ((ObjectResult)_projController.ProjectDuplicateCheck("Proj").Result).Value;
+            var isOldProjDup =
+                ((ObjectResult)_projController.ProjectDuplicateCheck("Proj").Result).Value!;
             Assert.IsTrue((bool)isOldProjDup);
-            var isNewProjDup = ((ObjectResult)_projController.ProjectDuplicateCheck("NewProj").Result).Value;
+            var isNewProjDup =
+                ((ObjectResult)_projController.ProjectDuplicateCheck("NewProj").Result).Value!;
             Assert.IsFalse((bool)isNewProjDup);
         }
     }

--- a/Backend.Tests/Controllers/UserControllerTests.cs
+++ b/Backend.Tests/Controllers/UserControllerTests.cs
@@ -53,7 +53,7 @@ namespace Backend.Tests.Controllers
             var action = _userController.GetUser(user.Id).Result;
             Assert.IsInstanceOf<ObjectResult>(action);
 
-            var foundUser = (User)((ObjectResult)action).Value;
+            var foundUser = (User)((ObjectResult)action).Value!;
             Assert.That(foundUser, Is.EqualTo(user));
         }
 
@@ -75,7 +75,7 @@ namespace Backend.Tests.Controllers
             var action = _userController.GetUserByEmail(email).Result;
             Assert.IsInstanceOf<ObjectResult>(action);
 
-            var foundUser = (User)((ObjectResult)action).Value;
+            var foundUser = (User)((ObjectResult)action).Value!;
             Assert.That(foundUser, Is.EqualTo(user));
         }
 
@@ -103,7 +103,7 @@ namespace Backend.Tests.Controllers
         public void TestCreateUser()
         {
             var user = RandomUser();
-            var id = (string)((ObjectResult)_userController.CreateUser(user).Result).Value;
+            var id = (string)((ObjectResult)_userController.CreateUser(user).Result).Value!;
             user.Id = id;
             Assert.Contains(user, _userRepo.GetAllUsers().Result);
         }
@@ -157,19 +157,19 @@ namespace Backend.Tests.Controllers
             _userRepo.Create(user2);
 
             var result1 = (ObjectResult)_userController.CheckUsername(username1.ToLowerInvariant()).Result;
-            Assert.IsTrue((bool)result1.Value);
+            Assert.IsTrue((bool)result1.Value!);
 
             var result2 = (ObjectResult)_userController.CheckUsername(username2.ToUpperInvariant()).Result;
-            Assert.IsTrue((bool)result2.Value);
+            Assert.IsTrue((bool)result2.Value!);
 
             var result3 = (ObjectResult)_userController.CheckUsername(username1).Result;
-            Assert.IsTrue((bool)result3.Value);
+            Assert.IsTrue((bool)result3.Value!);
 
             var result4 = (ObjectResult)_userController.CheckUsername("NewUsername").Result;
-            Assert.IsFalse((bool)result4.Value);
+            Assert.IsFalse((bool)result4.Value!);
 
             var result5 = (ObjectResult)_userController.CheckUsername("").Result;
-            Assert.IsTrue((bool)result5.Value);
+            Assert.IsTrue((bool)result5.Value!);
         }
 
         [Test]
@@ -183,19 +183,19 @@ namespace Backend.Tests.Controllers
             _userRepo.Create(user2);
 
             var result1 = (ObjectResult)_userController.CheckEmail(email1.ToLowerInvariant()).Result;
-            Assert.IsTrue((bool)result1.Value);
+            Assert.IsTrue((bool)result1.Value!);
 
             var result2 = (ObjectResult)_userController.CheckEmail(email2.ToUpperInvariant()).Result;
-            Assert.IsTrue((bool)result2.Value);
+            Assert.IsTrue((bool)result2.Value!);
 
             var result3 = (ObjectResult)_userController.CheckEmail(email1).Result;
-            Assert.IsTrue((bool)result3.Value);
+            Assert.IsTrue((bool)result3.Value!);
 
             var result4 = (ObjectResult)_userController.CheckEmail("NewEmail").Result;
-            Assert.IsFalse((bool)result4.Value);
+            Assert.IsFalse((bool)result4.Value!);
 
             var result5 = (ObjectResult)_userController.CheckEmail("").Result;
-            Assert.IsTrue((bool)result5.Value);
+            Assert.IsTrue((bool)result5.Value!);
         }
     }
 }

--- a/Backend.Tests/Controllers/UserEditControllerTests.cs
+++ b/Backend.Tests/Controllers/UserEditControllerTests.cs
@@ -140,7 +140,7 @@ namespace Backend.Tests.Controllers
         public async Task TestCreateUserEdit()
         {
             var userEdit = new UserEdit { ProjectId = _projId };
-            var updatedUser = (User)((ObjectResult)await _userEditController.CreateUserEdit(_projId)).Value;
+            var updatedUser = (User)((ObjectResult)await _userEditController.CreateUserEdit(_projId)).Value!;
             userEdit.Id = updatedUser.WorkedProjects[_projId];
             Assert.Contains(userEdit, await _userEditRepo.GetAllUserEdits(_projId));
         }

--- a/Backend.Tests/Controllers/UserRoleControllerTests.cs
+++ b/Backend.Tests/Controllers/UserRoleControllerTests.cs
@@ -121,7 +121,7 @@ namespace Backend.Tests.Controllers
         public async Task TestCreateUserRole()
         {
             var userRole = RandomUserRole();
-            var id = (string)((ObjectResult)await _userRoleController.CreateUserRole(_projId, userRole)).Value;
+            var id = (string)((ObjectResult)await _userRoleController.CreateUserRole(_projId, userRole)).Value!;
             userRole.Id = id;
             Assert.Contains(userRole, await _userRoleRepo.GetAllUserRoles(_projId));
         }
@@ -171,7 +171,7 @@ namespace Backend.Tests.Controllers
             updatePermissions.Add(Permission.WordEntry);
 
             var result = await _userRoleController.UpdateUserRolePermissions(_projId, userId, updatePermissions.ToArray());
-            var newUserRoleId = (string)((OkObjectResult)result).Value;
+            var newUserRoleId = (string)((OkObjectResult)result).Value!;
             var action = await _userRoleController.GetUserRole(_projId, newUserRoleId);
             var updatedUserRole = ((ObjectResult)action).Value as UserRole;
             Assert.AreEqual(updatePermissions, updatedUserRole?.Permissions);

--- a/Backend.Tests/Controllers/WordControllerTests.cs
+++ b/Backend.Tests/Controllers/WordControllerTests.cs
@@ -111,7 +111,7 @@ namespace Backend.Tests.Controllers
             await _wordRepo.Create(Util.RandomWord(_projId));
             await _wordRepo.Create(Util.RandomWord("OTHER_PROJECT"));
 
-            var words = (List<Word>)((ObjectResult)await _wordController.GetProjectWords(_projId)).Value;
+            var words = (List<Word>)((ObjectResult)await _wordController.GetProjectWords(_projId)).Value!;
             Assert.That(words, Has.Count.EqualTo(3));
             (await _wordRepo.GetAllWords(_projId)).ForEach(word => Assert.Contains(word, words));
         }
@@ -135,10 +135,10 @@ namespace Backend.Tests.Controllers
         public async Task TestIsFrontierNonempty()
         {
             await _wordRepo.Create(Util.RandomWord("OTHER_PROJECT"));
-            var shouldBeFalse = (bool)((ObjectResult)await _wordController.IsFrontierNonempty(_projId)).Value;
+            var shouldBeFalse = (bool)((ObjectResult)await _wordController.IsFrontierNonempty(_projId)).Value!;
             Assert.False(shouldBeFalse);
             await _wordRepo.Create(Util.RandomWord(_projId));
-            var shouldBeTrue = (bool)((ObjectResult)await _wordController.IsFrontierNonempty(_projId)).Value;
+            var shouldBeTrue = (bool)((ObjectResult)await _wordController.IsFrontierNonempty(_projId)).Value!;
             Assert.True(shouldBeTrue);
         }
 
@@ -164,7 +164,7 @@ namespace Backend.Tests.Controllers
             var inWord2 = await _wordRepo.Create(Util.RandomWord(_projId));
             await _wordRepo.Create(Util.RandomWord("OTHER_PROJECT"));
 
-            var frontier = (List<Word>)((ObjectResult)await _wordController.GetProjectFrontierWords(_projId)).Value;
+            var frontier = (List<Word>)((ObjectResult)await _wordController.GetProjectFrontierWords(_projId)).Value!;
             Assert.That(frontier, Has.Count.EqualTo(2));
             Assert.Contains(inWord1, frontier);
             Assert.Contains(inWord2, frontier);
@@ -202,7 +202,7 @@ namespace Backend.Tests.Controllers
             var action = await _wordController.GetWord(_projId, word.Id);
             Assert.IsInstanceOf<ObjectResult>(action);
 
-            var foundWord = (Word)((ObjectResult)action).Value;
+            var foundWord = (Word)((ObjectResult)action).Value!;
             Assert.AreEqual(word, foundWord);
         }
 
@@ -229,7 +229,7 @@ namespace Backend.Tests.Controllers
         {
             var word = Util.RandomWord(_projId);
 
-            var id = (string)((ObjectResult)await _wordController.CreateWord(_projId, word)).Value;
+            var id = (string)((ObjectResult)await _wordController.CreateWord(_projId, word)).Value!;
             word.Id = id;
 
             Assert.AreEqual(word, (await _wordRepo.GetAllWords(_projId))[0]);
@@ -239,15 +239,15 @@ namespace Backend.Tests.Controllers
             var newDuplicate = oldDuplicate.Clone();
 
             await _wordController.CreateWord(_projId, oldDuplicate);
-            var result = (string)((ObjectResult)await _wordController.CreateWord(_projId, newDuplicate)).Value;
+            var result = (string)((ObjectResult)await _wordController.CreateWord(_projId, newDuplicate)).Value!;
             Assert.AreEqual(result, "Duplicate");
 
             newDuplicate.Senses.RemoveAt(2);
-            result = (string)((ObjectResult)await _wordController.CreateWord(_projId, newDuplicate)).Value;
+            result = (string)((ObjectResult)await _wordController.CreateWord(_projId, newDuplicate)).Value!;
             Assert.AreEqual(result, "Duplicate");
 
             newDuplicate.Senses = new List<Sense>();
-            result = (string)((ObjectResult)await _wordController.CreateWord(_projId, newDuplicate)).Value;
+            result = (string)((ObjectResult)await _wordController.CreateWord(_projId, newDuplicate)).Value!;
             Assert.AreNotEqual(result, "Duplicate");
         }
 
@@ -277,7 +277,8 @@ namespace Backend.Tests.Controllers
             var modWord = origWord.Clone();
             modWord.Vernacular = "NewVernacular";
 
-            var id = (string)((ObjectResult)await _wordController.UpdateWord(_projId, modWord.Id, modWord)).Value;
+            var id = (string)((ObjectResult)await _wordController.UpdateWord(
+                _projId, modWord.Id, modWord)).Value!;
 
             var finalWord = modWord.Clone();
             finalWord.Id = id;

--- a/Backend/BackendFramework.csproj
+++ b/Backend/BackendFramework.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
@@ -12,11 +12,11 @@
     <EmbeddedResource Include="Data\sdList.txt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.12" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.14.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.14.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.15.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.15.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-    <PackageReference Include="MongoDB.Driver" Version="2.13.2" />
+    <PackageReference Include="MongoDB.Driver" Version="2.14.1" />
     <PackageReference Include="MailKit" Version="2.15.0" />
 
     <!-- SIL Maintained Dependencies. -->

--- a/Backend/BackendFramework.csproj
+++ b/Backend/BackendFramework.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -1,5 +1,5 @@
 # Docker multi-stage build.
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS builder
 WORKDIR /app
 
 # Copy csproj and restore (fetch dependencies) as distinct layers.
@@ -11,7 +11,7 @@ COPY . ./
 RUN dotnet publish -c Release -o build
 
 # Build runtime image.
-FROM mcr.microsoft.com/dotnet/aspnet:5.0
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
 
 ENV ASPNETCORE_URLS=http://+:5000
 ENV COMBINE_IS_IN_CONTAINER=1

--- a/Backend/Helper/PasswordHash.cs
+++ b/Backend/Helper/PasswordHash.cs
@@ -73,7 +73,7 @@ namespace BackendFramework.Helper
         private static byte[] CreateSalt()
         {
             byte[] salt;
-            using var crypto = new RNGCryptoServiceProvider();
+            using var crypto = RandomNumberGenerator.Create();
             crypto.GetBytes(salt = new byte[SaltLength]);
             return salt;
         }

--- a/Backend/Models/EmailInvite.cs
+++ b/Backend/Models/EmailInvite.cs
@@ -14,7 +14,7 @@ namespace BackendFramework.Models
         [Required]
         public DateTime ExpireTime { get; set; }
 
-        private static readonly RNGCryptoServiceProvider Rng = new();
+        private static readonly RandomNumberGenerator Rng = RandomNumberGenerator.Create();
         private const int TokenSize = 8;
 
         public EmailInvite()

--- a/Backend/Models/PasswordReset.cs
+++ b/Backend/Models/PasswordReset.cs
@@ -8,7 +8,7 @@ namespace BackendFramework.Models
 {
     public class PasswordReset
     {
-        private static readonly RNGCryptoServiceProvider Rng = new();
+        private static readonly RandomNumberGenerator Rng = RandomNumberGenerator.Create();
         private const int TokenSize = 8;
 
         [BsonId]

--- a/Backend/Properties/launchSettings.json
+++ b/Backend/Properties/launchSettings.json
@@ -25,7 +25,8 @@
         "Key": "Value",
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:5000"
+      "applicationUrl": "http://localhost:5000",
+      "hotReloadProfile": "aspnetcore"
     }
   }
 }

--- a/Backend/Services/LiftService.cs
+++ b/Backend/Services/LiftService.cs
@@ -13,7 +13,6 @@ using BackendFramework.Interfaces;
 using BackendFramework.Models;
 using SIL.DictionaryServices.Lift;
 using SIL.DictionaryServices.Model;
-using SIL.Extensions;
 using SIL.Lift;
 using SIL.Lift.Options;
 using SIL.Lift.Parsing;

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ A rapid word collection tool. See the [User Guide](https://sillsdev.github.io/Th
      - On Ubuntu, follow
        [this guide](https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions) using
        the appropriate Node.js version.
-   - [.NET Core SDK 5.0](https://dotnet.microsoft.com/download/dotnet/5.0)
+   - [.NET Core SDK 6.0](https://dotnet.microsoft.com/download/dotnet/6.0)
      - On Ubuntu 20.04, follow these
        [instructions](https://docs.microsoft.com/en-us/dotnet/core/install/linux-ubuntu#2004-).
    - [MongoDB](https://docs.mongodb.com/manual/administration/install-community/) and add /bin to PATH Environment

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "analyze": "source-map-explorer 'build/static/js/*.js'",
-    "backend": "dotnet run --project Backend/BackendFramework.csproj",
+    "backend": "dotnet watch --project Backend/BackendFramework.csproj",
     "build": "react-scripts build",
     "database": "mongod --dbpath=./mongo_database",
     "drop-database": "tsc scripts/dropDB.ts && node scripts/dropDB.js",


### PR DESCRIPTION
Closes #1172

- Upgrade to .NET 6
- Upgrade to C# 10
- Enable Backend hot reload
- Remove obsolete `RNGCryptoServiceProvider`
- In unit test code, use `!` to suppress more aggressive null checks when casting to `ObjectResult` from API endpoints under test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1509)
<!-- Reviewable:end -->
