### PR TITLE
Quote string environment variables in docker-compose .env files

### DIFF
--- a/deploy/roles/combine_config/templates/env.backend.j2
+++ b/deploy/roles/combine_config/templates/env.backend.j2
@@ -1,8 +1,8 @@
-COMBINE_JWT_SECRET_KEY={{ combine_jwt_secret_key }}
-COMBINE_SMTP_SERVER={{ combine_smtp_server }}
+COMBINE_JWT_SECRET_KEY="{{ combine_jwt_secret_key }}"
+COMBINE_SMTP_SERVER="{{ combine_smtp_server }}"
 COMBINE_SMTP_PORT={{ combine_smtp_port }}
-COMBINE_SMTP_ADDRESS={{ combine_smtp_address }}
-COMBINE_SMTP_USERNAME={{ combine_smtp_username }}
-COMBINE_SMTP_PASSWORD={{ combine_smtp_password }}
-COMBINE_SMTP_FROM={{ combine_smtp_from }}
+COMBINE_SMTP_ADDRESS="{{ combine_smtp_address }}"
+COMBINE_SMTP_USERNAME="{{ combine_smtp_username }}"
+COMBINE_SMTP_PASSWORD="{{ combine_smtp_password }}"
+COMBINE_SMTP_FROM="{{ combine_smtp_from }}"
 COMBINE_PASSWORD_RESET_EXPIRE_TIME={{ combine_password_reset_expire_time }}

--- a/deploy/roles/combine_config/templates/env.certmgr.j2
+++ b/deploy/roles/combine_config/templates/env.certmgr.j2
@@ -2,9 +2,9 @@ CERT_MODE={{ cert_mode }}
 CERT_EMAIL={{ cert_email }}
 CERT_STAGING={{ cert_is_staging }}
 MAX_CONNECT_TRIES={{ cert_max_connect_tries }}
-SERVER_NAME={{ combine_server_name }}
-CERT_ADDL_DOMAINS={{ combine_addl_domain_list | default([]) | join(' ') }}
-CERT_PROXY_DOMAINS={{ combine_cert_proxy_list | default([]) | join(' ') }}
+SERVER_NAME="{{ combine_server_name }}"
+CERT_ADDL_DOMAINS="{{ combine_addl_domain_list | default([]) | join(' ') }}"
+CERT_PROXY_DOMAINS="{{ combine_cert_proxy_list | default([]) | join(' ') }}"
 CERT_PROXY_RENEWAL={{ cert_proxy_renewal | default(60) }}
 CERT_SELF_RENEWAL={{ cert_self_renewal | default(30) }}
 {% if cert_mode == "cert-server" %}

--- a/deploy/roles/combine_config/templates/env.frontend.j2
+++ b/deploy/roles/combine_config/templates/env.frontend.j2
@@ -1,12 +1,12 @@
 
-SERVER_NAME={{ combine_server_name }}
-SSL_CERTIFICATE={{ ssl_certificate }}
-SSL_PRIVATE_KEY={{ ssl_private_key }}
-CERT_ADDL_DOMAINS={{ combine_addl_domain_list | default([]) | join(' ') }}
-CERT_PROXY_DOMAINS={{ combine_cert_proxy_list | default([]) | join(' ') }}
+SERVER_NAME="{{ combine_server_name }}"
+SSL_CERTIFICATE="{{ ssl_certificate }}"
+SSL_PRIVATE_KEY="{{ ssl_private_key }}"
+CERT_ADDL_DOMAINS="{{ combine_addl_domain_list | default([]) | join(' ') }}"
+CERT_PROXY_DOMAINS="{{ combine_cert_proxy_list | default([]) | join(' ') }}"
 CONFIG_USE_CONNECTION_URL=true
 CONFIG_CAPTCHA_REQD={{ config_captcha_required }}
-CONFIG_CAPTCHA_SITE_KEY={{ config_captcha_sitekey }}
+CONFIG_CAPTCHA_SITE_KEY="{{ config_captcha_sitekey }}"
 CONFIG_EMAIL_ENABLED={{ config_email_enabled }}
 CONFIG_SHOW_CERT_EXPIRATION={{ config_show_cert_expiration }}
 {% if config_analytics_write_key is defined %}


### PR DESCRIPTION
Update the templates for `.env.frontend`, `,env.backend`, and `.env.certmgr` to enclose most string environment variables in double-quotes - when running under `zsh` on a Mac, the missing quotes were a problem.  This solution has been tested on Windows, Ubuntu (`bash`), and Mac (`zsh`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1512)
<!-- Reviewable:end -->
