### PR TITLE
Correct brace style in C# style guide

### DIFF
--- a/Backend/Startup.cs
+++ b/Backend/Startup.cs
@@ -143,7 +143,7 @@ namespace BackendFramework
             services.AddSignalR();
 
             // Configure Swashbuckle OpenAPI generation.
-            // https://docs.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-swashbuckle?view=aspnetcore-6.0
+            // https://docs.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-swashbuckle
             services.AddSwaggerGen();
 
             services.Configure<Settings>(

--- a/Backend/Startup.cs
+++ b/Backend/Startup.cs
@@ -143,7 +143,7 @@ namespace BackendFramework
             services.AddSignalR();
 
             // Configure Swashbuckle OpenAPI generation.
-            // https://docs.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-swashbuckle?view=aspnetcore-3.1
+            // https://docs.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-swashbuckle?view=aspnetcore-6.0
             services.AddSwaggerGen();
 
             services.Configure<Settings>(

--- a/README.md
+++ b/README.md
@@ -717,7 +717,7 @@ The process for configuring and deploying _TheCombine_ for production targets is
 
 - [C#](https://www.w3schools.com/cs/default.asp)
 - [Our style guide](docs/style_guide/c_sharp_style_guide.md)
-- [ASP.NET](https://docs.microsoft.com/en-us/aspnet/core/getting-started/?view=aspnetcore-6.0)
+- [ASP.NET](https://docs.microsoft.com/en-us/aspnet/core/getting-started)
 - [NUnit](https://docs.nunit.org/articles/nunit/intro.html) (unit testing)
 
 ### Frontend (Typescript + React + Redux)

--- a/README.md
+++ b/README.md
@@ -717,7 +717,7 @@ The process for configuring and deploying _TheCombine_ for production targets is
 
 - [C#](https://www.w3schools.com/cs/default.asp)
 - [Our style guide](docs/style_guide/c_sharp_style_guide.md)
-- [ASP.NET](https://docs.microsoft.com/en-us/aspnet/core/getting-started/?view=aspnetcore-5.0)
+- [ASP.NET](https://docs.microsoft.com/en-us/aspnet/core/getting-started/?view=aspnetcore-6.0)
 - [NUnit](https://docs.nunit.org/articles/nunit/intro.html) (unit testing)
 
 ### Frontend (Typescript + React + Redux)

--- a/docs/style_guide/c_sharp_style_guide.md
+++ b/docs/style_guide/c_sharp_style_guide.md
@@ -51,8 +51,7 @@ foreach (var i in Range(0, 4))
 for (var i = 0; i < 4; i++)
 ```
 
-The signature of [`Range`](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.range?view=net-6.0)
-is:
+The signature of [`Range`](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.range?view=net-6.0) is:
 
 ```c#
 Range (int start, int count);

--- a/docs/style_guide/c_sharp_style_guide.md
+++ b/docs/style_guide/c_sharp_style_guide.md
@@ -10,7 +10,7 @@ In general, follow the Microsoft C# Coding Guidelines described in the following
 
 # Exceptions
 
-The following guidelines supersede the Microsoft C# Coding Guidelines, an should be used.
+The following guidelines supersede the Microsoft C# Coding Guidelines, and should be used.
 
 ## Type Inference
 

--- a/docs/style_guide/c_sharp_style_guide.md
+++ b/docs/style_guide/c_sharp_style_guide.md
@@ -51,7 +51,7 @@ foreach (var i in Range(0, 4))
 for (var i = 0; i < 4; i++)
 ```
 
-The signature of [`Range`](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.range?view=net-6.0) is:
+The signature of [`Range`](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.range) is:
 
 ```c#
 Range (int start, int count);

--- a/docs/style_guide/c_sharp_style_guide.md
+++ b/docs/style_guide/c_sharp_style_guide.md
@@ -51,7 +51,7 @@ foreach (var i in Range(0, 4))
 for (var i = 0; i < 4; i++)
 ```
 
-The signature of [`Range`](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.range?view=netcore-5.0)
+The signature of [`Range`](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.range?view=net-6.0)
 is:
 
 ```c#

--- a/docs/style_guide/c_sharp_style_guide.md
+++ b/docs/style_guide/c_sharp_style_guide.md
@@ -22,13 +22,14 @@ Add braces to one-line `if` statements;
 
 ```c#
 # Yes:
-if (isEmpty) {
-  callFun();
+if (isEmpty)
+{
+    callFun();
 }
 
 # No:
 if (isEmpty)
-  callFun();
+    callFun();
 ```
 
 ### Rationale


### PR DESCRIPTION
- Correct C# style guide to follow the standard C# brace and indentation style.
- Remove all .NET version-specific query args from hyperlinks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1513)
<!-- Reviewable:end -->
