### PR TITLE
Use Python 3.9 to build the user guide

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-
 # User guide build environment.
-FROM python:3.8 AS user_guide_builder
+FROM python:3.9 AS user_guide_builder
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,8 @@ extend-exclude =
 # tox-gh-actions configuration.
 [gh-actions]
 python =
-    3.8: lint, fmt-check, type-check, user-guide
-    3.9: lint
+    3.8: lint
+    3.9: lint, fmt-check, type-check, user-guide
     3.10: lint
 
 [tox]


### PR DESCRIPTION
Set Python 3.9 as the default version to build the user guide, type check, etc.

This follows the policy of selecting the second from newest Python version for production.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1522)
<!-- Reviewable:end -->
