### PR TITLE
Revert to using {} instead of undefined for empty goal edit steps

### DIFF
--- a/src/types/goals.ts
+++ b/src/types/goals.ts
@@ -14,7 +14,7 @@ import {
 import { newUser } from "types/user";
 
 export type GoalData = CreateCharInvData | MergeDupData;
-export type GoalStep = CreateCharInvStepData | MergeStepData | undefined;
+export type GoalStep = CreateCharInvStepData | MergeStepData | {};
 export type GoalChanges = CreateCharInvChanges | MergesCompleted;
 
 export interface GoalProps {
@@ -77,7 +77,7 @@ export class Goal {
   constructor(
     type = GoalType.Default,
     name = GoalName.Default,
-    steps: GoalStep[] = [undefined],
+    steps: GoalStep[] = [{}],
     data?: GoalData
   ) {
     this.guid = v4();


### PR DESCRIPTION
Reverting one small bit of #1523 that was causing null entries in the UserEdits database, making all future goals impossible for the given project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1527)
<!-- Reviewable:end -->
