### PR TITLE
Focus on gloss after closing dialogs

### DIFF
--- a/src/components/DataEntry/DataEntryTable/DataEntryTable.tsx
+++ b/src/components/DataEntry/DataEntryTable/DataEntryTable.tsx
@@ -16,7 +16,9 @@ import {
   WritingSystem,
 } from "api/models";
 import * as backend from "backend";
-import NewEntry from "components/DataEntry/DataEntryTable/NewEntry/NewEntry";
+import NewEntry, {
+  FocusTarget,
+} from "components/DataEntry/DataEntryTable/NewEntry/NewEntry";
 import RecentEntry from "components/DataEntry/DataEntryTable/RecentEntry/RecentEntry";
 import { getFileNameForWord } from "components/Pronunciations/AudioRecorder";
 import Recorder from "components/Pronunciations/Recorder";
@@ -586,7 +588,7 @@ export class DataEntryTable extends React.Component<
                   recorder={this.recorder}
                   focusNewEntry={() => {
                     if (this.refNewEntry.current) {
-                      this.refNewEntry.current.focusVernInput();
+                      this.refNewEntry.current.focus(FocusTarget.Vernacular);
                     }
                   }}
                   analysisLang={this.state.analysisLang}

--- a/src/components/DataEntry/DataEntryTable/EntryCellComponents/GlossWithSuggestions.tsx
+++ b/src/components/DataEntry/DataEntryTable/EntryCellComponents/GlossWithSuggestions.tsx
@@ -15,6 +15,7 @@ interface GlossWithSuggestionsProps {
   onBlur?: () => void;
   analysisLang: WritingSystem;
   textFieldId: string;
+  onComponentDidUpdate?: () => void;
 }
 
 /**
@@ -25,6 +26,9 @@ export default class GlossWithSuggestions extends React.Component<GlossWithSugge
   spellChecker = new SpellChecker(this.props.analysisLang.bcp47);
 
   componentDidUpdate(prevProps: GlossWithSuggestionsProps) {
+    if (this.props.onComponentDidUpdate) {
+      this.props.onComponentDidUpdate();
+    }
     if (prevProps.analysisLang.bcp47 !== this.props.analysisLang.bcp47) {
       this.spellChecker = new SpellChecker(this.props.analysisLang.bcp47);
     }

--- a/src/components/DataEntry/DataEntryTable/EntryCellComponents/VernWithSuggestions.tsx
+++ b/src/components/DataEntry/DataEntryTable/EntryCellComponents/VernWithSuggestions.tsx
@@ -16,12 +16,19 @@ interface VernWithSuggestionsProps {
   handleEnterAndTab: (e: React.KeyboardEvent) => void;
   vernacularLang: WritingSystem;
   textFieldId: string;
+  onComponentDidUpdate?: () => void;
 }
 
 /**
  * An editable vernacular field for new words, that suggests words already in database.
  */
 export default class VernWithSuggestions extends React.Component<VernWithSuggestionsProps> {
+  componentDidUpdate() {
+    if (this.props.onComponentDidUpdate) {
+      this.props.onComponentDidUpdate();
+    }
+  }
+
   render() {
     return (
       <React.Fragment>

--- a/src/components/DataEntry/DataEntryTable/NewEntry/NewEntry.tsx
+++ b/src/components/DataEntry/DataEntryTable/NewEntry/NewEntry.tsx
@@ -46,6 +46,7 @@ interface NewEntryState {
   vernOpen: boolean;
   senseOpen: boolean;
   selectedWord?: Word;
+  shouldFocusOnGloss?: boolean;
 }
 
 function focusInput(inputRef: React.RefObject<HTMLDivElement>) {
@@ -82,6 +83,22 @@ export default class NewEntry extends React.Component<
   }
   vernInput: React.RefObject<HTMLDivElement>;
   glossInput: React.RefObject<HTMLDivElement>;
+
+  async componentDidUpdate(_: NewEntryProps, prevState: NewEntryState) {
+    if (
+      (prevState.vernOpen || prevState.senseOpen) &&
+      !(this.state.vernOpen || this.state.senseOpen)
+    ) {
+      this.setState({ shouldFocusOnGloss: true });
+    }
+  }
+
+  conditionalFocusOnGloss(): void {
+    if (this.state.shouldFocusOnGloss) {
+      this.focusGlossInput();
+      this.setState({ shouldFocusOnGloss: false });
+    }
+  }
 
   addAudio(audioFile: File) {
     const audioFileURLs = [...this.state.audioFileURLs];
@@ -383,6 +400,7 @@ export default class NewEntry extends React.Component<
             }
             analysisLang={this.props.analysisLang}
             textFieldId={`${idAffix}-gloss`}
+            onComponentDidUpdate={() => this.conditionalFocusOnGloss()}
           />
         </Grid>
         <Grid

--- a/src/components/DataEntry/DataEntryTable/NewEntry/NewEntry.tsx
+++ b/src/components/DataEntry/DataEntryTable/NewEntry/NewEntry.tsx
@@ -1,5 +1,5 @@
 import { Grid, Typography } from "@material-ui/core";
-import React from "react";
+import React, { ReactElement } from "react";
 import { Translate } from "react-localize-redux";
 import { Key } from "ts-key-enum";
 
@@ -89,9 +89,15 @@ export default class NewEntry extends React.Component<
   vernInput: React.RefObject<HTMLDivElement>;
   glossInput: React.RefObject<HTMLDivElement>;
 
-  async componentDidUpdate(_: NewEntryProps, prevState: NewEntryState) {
-    // When the vern/sense dialogs are closed, focus needs to return to text fields.
-    // This sets a flag to trigger focus once the input components are updated.
+  async componentDidUpdate(
+    _: NewEntryProps,
+    prevState: NewEntryState
+  ): Promise<void> {
+    /* When the vern/sense dialogs are closed, focus needs to return to text
+    fields. The following sets a flag (state.shouldFocus) to trigger focus once
+    the input components are updated. Focus is triggered by
+    this.conditionalFocus() passed to each input component and called within its
+    respective componentDidUpdate(). */
     if (
       (prevState.vernOpen || prevState.senseOpen) &&
       !(this.state.vernOpen || this.state.senseOpen)
@@ -115,8 +121,8 @@ export default class NewEntry extends React.Component<
     }
   }
 
-  /** This function is for a child input component to use in componentDidUpdate
-   * to move focus to itself, if the current state says it should. */
+  /** This function is for a child input component to call in componentDidUpdate
+   * to move focus to itself, if the current state.shouldFocus says it should. */
   conditionalFocus(target: FocusTarget): void {
     if (this.state.shouldFocus === target) {
       this.focus(target);
@@ -124,7 +130,7 @@ export default class NewEntry extends React.Component<
     }
   }
 
-  addAudio(audioFile: File) {
+  addAudio(audioFile: File): void {
     const audioFileURLs = [...this.state.audioFileURLs];
     audioFileURLs.push(URL.createObjectURL(audioFile));
     this.setState({
@@ -132,7 +138,7 @@ export default class NewEntry extends React.Component<
     });
   }
 
-  removeAudio(fileName: string) {
+  removeAudio(fileName: string): void {
     this.setState((prevState) => ({
       audioFileURLs: prevState.audioFileURLs.filter(
         (fileURL) => fileURL !== fileName
@@ -140,7 +146,7 @@ export default class NewEntry extends React.Component<
     }));
   }
 
-  updateGlossField(newValue: string) {
+  updateGlossField(newValue: string): void {
     this.setState((prevState, props) => ({
       newEntry: {
         ...prevState.newEntry,
@@ -152,7 +158,7 @@ export default class NewEntry extends React.Component<
     }));
   }
 
-  updateVernField(newValue: string, openDialog?: boolean) {
+  updateVernField(newValue: string, openDialog?: boolean): void {
     const stateUpdates: Partial<NewEntryState> = {};
     if (newValue !== this.state.newEntry.vernacular) {
       if (this.state.selectedWord) {
@@ -183,7 +189,7 @@ export default class NewEntry extends React.Component<
     });
   }
 
-  updateNote(text: string) {
+  updateNote(text: string): void {
     this.setState((prevState, props) => ({
       newEntry: {
         ...prevState.newEntry,
@@ -192,7 +198,7 @@ export default class NewEntry extends React.Component<
     }));
   }
 
-  resetState() {
+  resetState(): void {
     this.setState({
       newEntry: newWord(),
       activeGloss: "",
@@ -204,7 +210,7 @@ export default class NewEntry extends React.Component<
     this.focus(FocusTarget.Vernacular);
   }
 
-  addNewWordAndReset() {
+  addNewWordAndReset(): void {
     const newEntry: Word = this.state.newEntry.senses.length
       ? this.state.newEntry
       : {
@@ -221,7 +227,7 @@ export default class NewEntry extends React.Component<
     this.resetState();
   }
 
-  addOrUpdateWord() {
+  addOrUpdateWord(): void {
     if (this.state.dupVernWords.length) {
       // Duplicate vern ...
       if (!this.state.selectedWord) {
@@ -245,7 +251,7 @@ export default class NewEntry extends React.Component<
     }
   }
 
-  handleEnter(e: React.KeyboardEvent, checkGloss: boolean) {
+  handleEnter(e: React.KeyboardEvent, checkGloss: boolean): void {
     if (!this.state.vernOpen && e.key === Key.Enter) {
       // The user can never submit a new entry without a vernacular
       if (this.state.newEntry.vernacular) {
@@ -262,7 +268,7 @@ export default class NewEntry extends React.Component<
     }
   }
 
-  handleCloseVernDialog(selectedWordId?: string) {
+  handleCloseVernDialog(selectedWordId?: string): void {
     let selectedWord: Word | undefined;
     let senseOpen = false;
     if (selectedWordId === "") {
@@ -276,7 +282,7 @@ export default class NewEntry extends React.Component<
     this.setState({ selectedWord, senseOpen, vernOpen: false });
   }
 
-  handleCloseSenseDialog(senseIndex?: number) {
+  handleCloseSenseDialog(senseIndex?: number): void {
     if (senseIndex === undefined) {
       this.setState({ selectedWord: undefined, vernOpen: true });
     } else if (senseIndex >= 0) {
@@ -307,7 +313,7 @@ export default class NewEntry extends React.Component<
     return keepers;
   }
 
-  updateSuggestedVerns(value?: string) {
+  updateSuggestedVerns(value?: string): void {
     let suggestedVerns: string[] = [];
     if (value) {
       suggestedVerns = [...this.autoCompleteCandidates(value)];
@@ -336,7 +342,7 @@ export default class NewEntry extends React.Component<
     this.setState({ suggestedVerns });
   }
 
-  render() {
+  render(): ReactElement {
     return (
       <Grid container id={idAffix} alignItems="center">
         <Grid

--- a/src/components/DataEntry/DataEntryTable/NewEntry/NewEntry.tsx
+++ b/src/components/DataEntry/DataEntryTable/NewEntry/NewEntry.tsx
@@ -96,11 +96,11 @@ export default class NewEntry extends React.Component<
       (prevState.vernOpen || prevState.senseOpen) &&
       !(this.state.vernOpen || this.state.senseOpen)
     ) {
-      this.setState({
-        shouldFocus: this.state.selectedWord
+      this.setState((state: NewEntryState) => ({
+        shouldFocus: state.selectedWord
           ? FocusTarget.Gloss
           : FocusTarget.Vernacular,
-      });
+      }));
     }
   }
 
@@ -115,7 +115,8 @@ export default class NewEntry extends React.Component<
     }
   }
 
-  // This function is for child input components to grab focus when they load.
+  /** This function is for a child input component to use in componentDidUpdate
+   * to move focus to itself, if the current state says it should. */
   conditionalFocus(target: FocusTarget): void {
     if (this.state.shouldFocus === target) {
       this.focus(target);


### PR DESCRIPTION
Closes #608

In the case that the user ESCapes out of the dialogs, the focus returns to the vernacular field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1536)
<!-- Reviewable:end -->
