### PR TITLE
Set indent_size within editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,9 +2,11 @@ root = true
 
 [*.{js,jsx,ts,tsx}]
 max_line_length = 80
+indent_size = 2
 
 [*.cs]
 max_line_length = 120
+indent_size = 4
 
 [*.md]
 max_line_length = 120


### PR DESCRIPTION
Since we use a different indent size for C# vs TS, set this explicitly within `.editorconfig` so that developers opening the project for the first time will have their editors/IDEs auto-configured properly.

These values match the defaults for `dotnet-format` and Prettier, respectively.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1551)
<!-- Reviewable:end -->
