### PR TITLE
Set Python max line length in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,8 @@ indent_size = 2
 max_line_length = 120
 indent_size = 4
 
+[*.py]
+max_line_length = 99
+
 [*.md]
 max_line_length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ strict = true
 
 [tool.black]
 line-length = 99
-target-version = ["py38", "py39"]
+target-version = ["py38", "py39", "py310"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Follow on to #1551

Set this to the value used by `black` in `pyprojec.toml`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1558)
<!-- Reviewable:end -->
