### PR TITLE
[DataEntryTable] Improve updating of recent entries

### DIFF
--- a/src/components/DataEntry/DataEntryTable/EntryCellComponents/GlossWithSuggestions.tsx
+++ b/src/components/DataEntry/DataEntryTable/EntryCellComponents/GlossWithSuggestions.tsx
@@ -8,6 +8,7 @@ import SpellChecker from "components/DataEntry/spellChecker";
 
 interface GlossWithSuggestionsProps {
   isNew?: boolean;
+  isDisabled?: boolean;
   gloss: string;
   glossInput?: React.RefObject<HTMLDivElement>;
   updateGlossField: (newValue: string) => void;
@@ -38,6 +39,7 @@ export default class GlossWithSuggestions extends React.Component<GlossWithSugge
     return (
       <Autocomplete
         id={this.props.textFieldId}
+        disabled={this.props.isDisabled}
         filterOptions={(options: unknown[]) =>
           options.length <= this.maxSuggestions
             ? options

--- a/src/components/DataEntry/DataEntryTable/EntryCellComponents/VernWithSuggestions.tsx
+++ b/src/components/DataEntry/DataEntryTable/EntryCellComponents/VernWithSuggestions.tsx
@@ -35,8 +35,9 @@ export default class VernWithSuggestions extends React.Component<VernWithSuggest
       <React.Fragment>
         <Autocomplete
           id={this.props.textFieldId}
-          freeSolo
           disabled={this.props.isDisabled}
+          // freeSolo allows use of a typed entry not available as a drop-down option
+          freeSolo
           value={this.props.vernacular}
           options={this.props.suggestedVerns ? this.props.suggestedVerns : []}
           onBlur={this.props.onBlur}

--- a/src/components/DataEntry/DataEntryTable/EntryCellComponents/tests/GlossWithSuggestions.test.tsx
+++ b/src/components/DataEntry/DataEntryTable/EntryCellComponents/tests/GlossWithSuggestions.test.tsx
@@ -19,4 +19,36 @@ describe("Tests GlossWithSuggestions", () => {
       );
     });
   });
+
+  it("renders new without crashing", () => {
+    renderer.act(() => {
+      renderer.create(
+        <LocalizedGlossWithSuggestions
+          isNew
+          gloss={""}
+          glossInput={React.createRef<HTMLDivElement>()}
+          updateGlossField={jest.fn()}
+          handleEnterAndTab={jest.fn()}
+          analysisLang={{} as WritingSystem}
+          textFieldId={""}
+        />
+      );
+    });
+  });
+
+  it("renders disabled without crashing", () => {
+    renderer.act(() => {
+      renderer.create(
+        <LocalizedGlossWithSuggestions
+          isDisabled
+          gloss={""}
+          glossInput={React.createRef<HTMLDivElement>()}
+          updateGlossField={jest.fn()}
+          handleEnterAndTab={jest.fn()}
+          analysisLang={{} as WritingSystem}
+          textFieldId={""}
+        />
+      );
+    });
+  });
 });

--- a/src/components/DataEntry/DataEntryTable/EntryCellComponents/tests/VernWithSuggestions.test.tsx
+++ b/src/components/DataEntry/DataEntryTable/EntryCellComponents/tests/VernWithSuggestions.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import renderer from "react-test-renderer";
 
 import LocalizedVernWithSuggestions from "components/DataEntry/DataEntryTable/EntryCellComponents/VernWithSuggestions";
+import { newWritingSystem } from "types/project";
 
 describe("Tests VernWithSuggestions", () => {
   it("renders without crashing", () => {
@@ -13,6 +14,41 @@ describe("Tests VernWithSuggestions", () => {
           updateVernField={jest.fn()}
           handleEnterAndTab={jest.fn()}
           onBlur={jest.fn()}
+          vernacularLang={newWritingSystem()}
+          textFieldId={""}
+        />
+      );
+    });
+  });
+
+  it("renders new without crashing", () => {
+    renderer.act(() => {
+      renderer.create(
+        <LocalizedVernWithSuggestions
+          isNew
+          vernacular={""}
+          vernInput={React.createRef<HTMLDivElement>()}
+          updateVernField={jest.fn()}
+          handleEnterAndTab={jest.fn()}
+          onBlur={jest.fn()}
+          vernacularLang={newWritingSystem()}
+          textFieldId={""}
+        />
+      );
+    });
+  });
+
+  it("renders disabled without crashing", () => {
+    renderer.act(() => {
+      renderer.create(
+        <LocalizedVernWithSuggestions
+          isDisabled
+          vernacular={""}
+          vernInput={React.createRef<HTMLDivElement>()}
+          updateVernField={jest.fn()}
+          handleEnterAndTab={jest.fn()}
+          onBlur={jest.fn()}
+          vernacularLang={newWritingSystem()}
           textFieldId={""}
         />
       );

--- a/src/components/DataEntry/DataEntryTable/NewEntry/tests/NewEntry.test.tsx
+++ b/src/components/DataEntry/DataEntryTable/NewEntry/tests/NewEntry.test.tsx
@@ -12,7 +12,6 @@ describe("NewEntry", () => {
     renderer.act(() => {
       renderer.create(
         <NewEntry
-          allVerns={[]}
           allWords={[]}
           defunctWordIds={[]}
           updateWordWithNewGloss={jest.fn()}

--- a/src/components/DataEntry/DataEntryTable/RecentEntry/RecentEntry.tsx
+++ b/src/components/DataEntry/DataEntryTable/RecentEntry/RecentEntry.tsx
@@ -30,6 +30,7 @@ interface RecentEntryProps {
   focusNewEntry: () => void;
   analysisLang: WritingSystem;
   vernacularLang: WritingSystem;
+  disabled?: boolean;
 }
 
 interface RecentEntryState {
@@ -108,7 +109,9 @@ export default class RecentEntry extends React.Component<
         >
           <VernWithSuggestions
             vernacular={this.state.vernacular}
-            isDisabled={this.props.entry.senses.length > 1}
+            isDisabled={
+              this.props.disabled || this.props.entry.senses.length > 1
+            }
             updateVernField={(newValue: string) =>
               this.updateVernField(newValue)
             }
@@ -135,6 +138,7 @@ export default class RecentEntry extends React.Component<
         >
           <GlossWithSuggestions
             gloss={this.state.gloss}
+            isDisabled={this.props.disabled}
             updateGlossField={(newValue: string) =>
               this.updateGlossField(newValue)
             }
@@ -159,11 +163,13 @@ export default class RecentEntry extends React.Component<
             position: "relative",
           }}
         >
-          <EntryNote
-            noteText={this.props.entry.note.text}
-            updateNote={this.props.updateNote}
-            buttonId={`${idAffix}-${this.props.rowIndex}-note`}
-          />
+          {!this.props.disabled && (
+            <EntryNote
+              noteText={this.props.entry.note.text}
+              updateNote={this.props.updateNote}
+              buttonId={`${idAffix}-${this.props.rowIndex}-note`}
+            />
+          )}
         </Grid>
         <Grid
           item
@@ -174,17 +180,19 @@ export default class RecentEntry extends React.Component<
             position: "relative",
           }}
         >
-          <Pronunciations
-            wordId={this.props.entry.id}
-            pronunciationFiles={this.props.entry.audio}
-            recorder={this.props.recorder}
-            deleteAudio={(wordId: string, fileName: string) => {
-              this.props.deleteAudioFromWord(wordId, fileName);
-            }}
-            uploadAudio={(wordId: string, audioFile: File) => {
-              this.props.addAudioToWord(wordId, audioFile);
-            }}
-          />
+          {!this.props.disabled && (
+            <Pronunciations
+              wordId={this.props.entry.id}
+              pronunciationFiles={this.props.entry.audio}
+              recorder={this.props.recorder}
+              deleteAudio={(wordId: string, fileName: string) => {
+                this.props.deleteAudioFromWord(wordId, fileName);
+              }}
+              uploadAudio={(wordId: string, audioFile: File) => {
+                this.props.addAudioToWord(wordId, audioFile);
+              }}
+            />
+          )}
         </Grid>
         <Grid
           item
@@ -195,7 +203,7 @@ export default class RecentEntry extends React.Component<
             position: "relative",
           }}
         >
-          {this.state.hovering && (
+          {!this.props.disabled && this.state.hovering && (
             <DeleteEntry
               removeEntry={() => this.props.removeEntry()}
               buttonId={`${idAffix}-${this.props.rowIndex}-delete`}


### PR DESCRIPTION
 Specifically:
* While a recent entry is updating, temporarily disable it instead of making it disappear (Resolves: #1466)
* After an entry is updated, remove its old id from the `defunctWordIds` array (used to determine if an entry is updating)

Also:
* Move handling of `allVerns` inside `NewEntry`, since it isn't used in any other part of `DataEntryTable`.

The first item above improves the ux.
The second and third items above appear to improve performance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1560)
<!-- Reviewable:end -->
