### PR TITLE
Fix backup scripts

### DIFF
--- a/deploy/scripts/setup_combine.py
+++ b/deploy/scripts/setup_combine.py
@@ -285,6 +285,8 @@ def main() -> None:
                 config_file = Path(secrets_dir).resolve() / f"config_{chart}.yaml"
                 with open(config_file, "w") as file:
                     yaml.dump(this_config["set"], file)
+            else:
+                config_file = None
 
             # create the base helm install command
             chart_dir = helm_dir / chart

--- a/maintenance/scripts/combine_app.py
+++ b/maintenance/scripts/combine_app.py
@@ -99,7 +99,7 @@ class CombineApp:
                     "pods",
                     "--field-selector=status.phase==Running",
                     "-o" f"jsonpath={{.items[{instance}].metadata.name}}",
-                    f"-l=combine-component={service}",
+                    f"-l=combine-component={service.value}",
                 ]
             ).stdout.strip()
         return self.pod_id_cache[service.value]

--- a/maintenance/scripts/combine_backup.py
+++ b/maintenance/scripts/combine_backup.py
@@ -41,7 +41,10 @@ def main() -> None:
 
     step.print("Make sure backend and database are available")
     wait_time = int(os.getenv("wait_time", 60))
-    if not wait_for_dependents(["database", "backend"], timeout=wait_time):
+    if not wait_for_dependents(
+        [CombineApp.Component.Database.value, CombineApp.Component.Backend.value],
+        timeout=wait_time,
+    ):
         print("Database or Backend are not available")
         sys.exit(1)
 

--- a/maintenance/scripts/maint_utils.py
+++ b/maintenance/scripts/maint_utils.py
@@ -18,9 +18,11 @@ def run_cmd(cmd: List[str], *, check_results: bool = True) -> subprocess.Complet
             check=check_results,
         )
     except subprocess.CalledProcessError as err:
-        print(f"CalledProcessError returned {err.returncode}")
-        print(f"stdout: {err.stdout}")
-        print(f"stderr: {err.stderr}")
+        print("CalledProcessError")
+        print(f"...Command: {err.cmd}")
+        print(f"...returncode {err.returncode}")
+        print(f"...stdout: {err.stdout}")
+        print(f"...stderr: {err.stderr}")
         sys.exit(err.returncode)
 
 


### PR DESCRIPTION
_TheCombine_ backup process broke with the delivery of PR #1561.

The cause of the problem was that literal strings for the different combine components, frontend, backend, etc., were replaced by an enumerated type in the Python scripts in the `maintenance` container.  One case was missed where the name of the enum was used instead of the `value`.

In addition, this PR makes the following improvements:
- Fix case of variable in `setup_combine.py` being read before it was initialized;
- Replaced additional instances of literal strings with the component enums; and
- Improved exception handling for `subprocess.CalledProcessError` - adds the command that failed to the error report.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1598)
<!-- Reviewable:end -->
