### PR TITLE
Migrate to version 2 of CodeCov GitHub Action

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -22,10 +22,12 @@ jobs:
       # Coverage.
       - run: dotnet test Backend.Tests/Backend.Tests.csproj /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
       - name: Upload coverage report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
-          file: Backend.Tests/coverage.cobertura.xml
+          files: Backend.Tests/coverage.cobertura.xml
           flags: backend
+          name: Backend
+          fail_ci_if_error: true
 
       # Development build.
       - run: dotnet build BackendFramework.sln

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -27,10 +27,12 @@ jobs:
         env:
           CI: true
       - name: Upload coverage report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
-          file: coverage/clover.xml
+          files: coverage/clover.xml
           flags: frontend
+          name: Frontend
+          fail_ci_if_error: true
 
       # Release build.
       - run: npm run build

--- a/Backend.Tests/Backend.Tests.csproj
+++ b/Backend.Tests/Backend.Tests.csproj
@@ -8,8 +8,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="coverlet.collector" Version="3.1.2"/>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Backend\BackendFramework.csproj" />


### PR DESCRIPTION
Closes #1600

Closes #1603 

-  #1576 removed `coverlet.msbuild` extension which is needed for coverage file generation. This PR adds it back in.
- The CI will now fail if coverage fails to upload, which will catch errors like this in the future

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1601)
<!-- Reviewable:end -->
