### PR TITLE
Fix deployment name for cert proxy server

### DIFF
--- a/.github/actions/combine-deploy-update/action.yml
+++ b/.github/actions/combine-deploy-update/action.yml
@@ -45,5 +45,5 @@ runs:
       run: kubectl --context ${{ inputs.kube_context }}
         --namespace combine-cert-proxy
         set image deployment/combine-cert-proxy
-        maintenance="${{ inputs.image_repo }}/combine_maint:${{ inputs.image_tag }}"
+        combine-cert-proxy="${{ inputs.image_repo }}/combine_maint:${{ inputs.image_tag }}"
       shell: bash


### PR DESCRIPTION
The container name for the `deployment/cert-proxy-server` should be `cert-proxy-server`, not `maintenance`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1607)
<!-- Reviewable:end -->
