### PR TITLE
Disable backups by default for all but production installations

### DIFF
--- a/deploy/helm/thecombine/charts/maintenance/templates/cronjob-daily-backup.yaml
+++ b/deploy/helm/thecombine/charts/maintenance/templates/cronjob-daily-backup.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.backupSchedule }}
+{{- if empty .Values.backupSchedule | not }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/deploy/helm/thecombine/values.yaml
+++ b/deploy/helm/thecombine/values.yaml
@@ -49,10 +49,7 @@ frontend:
 
 # Maintenance configuration items
 maintenance:
-  #######################################
-  # Backup Schedule
-  # Run every day at 03:15 UTC
-  backupSchedule: "15 03 * * *"
+  backupSchedule: ""
   # Maximum number of backups to keep on AWS S3 service
   maxBackups: "3"
 

--- a/deploy/scripts/setup_files/combine_config.yaml
+++ b/deploy/scripts/setup_files/combine_config.yaml
@@ -45,6 +45,11 @@ targets:
         - nuc2.thecombine.app
       global:
         awsS3Location: prod.thecombine.app
+      maintenence:
+        #######################################
+        # Backup Schedule
+        # Run every day at 03:15 UTC
+        backupSchedule: "15 03 * * *"
 
 # Set of profiles
 # Each key of 'profiles' defines one of the profiles used by the set of targets.


### PR DESCRIPTION
Currently the helm chart for the combine is set to configure a cron job to run a backup at 03:15 UTC every day.  Change the default to not create regular backups and override this for the production environment only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1621)
<!-- Reviewable:end -->
