### PR TITLE
Remove unused HTTPS certificate instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,12 +108,10 @@ A rapid word collection tool. See the [User Guide](https://sillsdev.github.io/Th
 
 ### Prepare the Environment
 
-1. (Windows Only) Run `dotnet dev-certs https` and `dotnet dev-certs https --trust` to generate and trust an SSL
-   certificate.
-2. Set the environment variable `COMBINE_JWT_SECRET_KEY` to a string **containing at least 16 characters**, such as
+1. Set the environment variable `COMBINE_JWT_SECRET_KEY` to a string **containing at least 16 characters**, such as
    _This is a secret key_. Set it in your `.profile` (Linux or Mac 10.14-), your `.zprofile` (Mac 10.15+), or the
    _System_ app (Windows).
-3. If you want the email services to work you will need to set the following environment variables. These values must be
+2. If you want the email services to work you will need to set the following environment variables. These values must be
    kept secret, so ask your email administrator to supply them.
 
    - `COMBINE_SMTP_SERVER`
@@ -123,16 +121,16 @@ A rapid word collection tool. See the [User Guide](https://sillsdev.github.io/Th
    - `COMBINE_SMTP_ADDRESS`
    - `COMBINE_SMTP_FROM`
 
-4. _(Optional)_ To opt in to segment.com analytics to test the analytics during development:
+3. _(Optional)_ To opt in to segment.com analytics to test the analytics during development:
 
    ```bash
    # For Windows, use `copy`.
    cp .env.local.template .env.local
    ```
 
-5. Run `npm start` from the project directory to install dependencies and start the project.
+4. Run `npm start` from the project directory to install dependencies and start the project.
 
-6. Consult our [C#](docs/style_guide/c_sharp_style_guide.md) and [TypeScript](docs/style_guide/ts_style_guide.md) style
+5. Consult our [C#](docs/style_guide/c_sharp_style_guide.md) and [TypeScript](docs/style_guide/ts_style_guide.md) style
    guides for best coding practices in this project.
 
 [chocolatey]: https://chocolatey.org/


### PR DESCRIPTION
We no longer support having the backend host HTTPS directly (NGINX or Kubernetes does this), so simplify initial setup instructions for developers by removing references to this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1623)
<!-- Reviewable:end -->
