### PR TITLE
Fix Helm deployment of the certificate proxy server

### DIFF
--- a/deploy/helm/cert-proxy-server/templates/env-nginx-configmap.yaml
+++ b/deploy/helm/cert-proxy-server/templates/env-nginx-configmap.yaml
@@ -5,4 +5,4 @@ metadata:
   name: {{ .Values.envNginxProxy }}
   namespace: {{ .Release.Namespace }}
 data:
-  SERVER_NAME: {{ .Values.global.serverName }}
+  SERVER_NAME: {{ .Values.certProxyServerName }}

--- a/deploy/helm/cert-proxy-server/templates/ingress-nuc.yaml
+++ b/deploy/helm/cert-proxy-server/templates/ingress-nuc.yaml
@@ -1,4 +1,5 @@
 {{- range .Values.combineCertProxyList }}
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/deploy/helm/cert-proxy-server/templates/init-nginx-pages.yaml
+++ b/deploy/helm/cert-proxy-server/templates/init-nginx-pages.yaml
@@ -3,5 +3,6 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.nginxPages }}
   namespace: {{ .Release.Namespace }}
-data:
-{{ (.Files.Glob "../files/pages/*").AsConfig | indent 2 }}
+# Add files as binary data since some are binary image files
+binaryData:
+{{ (.Files.Glob "files/pages/*").AsSecrets | indent 2 }}

--- a/deploy/helm/cert-proxy-server/values.yaml
+++ b/deploy/helm/cert-proxy-server/values.yaml
@@ -13,7 +13,6 @@ Release:
   Namespace: thecombine
 
 global:
-  serverName: cert-proxy.thecombine.app
   pullSecretName: aws-login-credentials
   awsS3Access: aws-s3-credentials
   # Update strategy should be "Recreate" or "Rolling Update"
@@ -27,6 +26,8 @@ global:
   imageRegistry: awsEcr
   # Default AWS S3 location
   awsS3Location: "thecombine.app"
+
+certProxyServerName: cert-proxy.thecombine.app
 
 serviceAccount:
   name: account-cert-server

--- a/deploy/scripts/setup_combine.py
+++ b/deploy/scripts/setup_combine.py
@@ -151,7 +151,9 @@ def get_target(config: Dict[str, Any]) -> str:
         sys.exit(ExitStatus.FAILURE.value)
 
 
-def add_override_values(config: Dict[str, Any], *, chart: str, temp_dir: Path, helm_cmd: List[str]) -> None:
+def add_override_values(
+    config: Dict[str, Any], *, chart: str, temp_dir: Path, helm_cmd: List[str]
+) -> None:
     """Add value overrides specified in the script configuration file."""
     if "override" in config and chart in config["override"]:
         override_file = temp_dir / f"config_{chart}.yaml"
@@ -160,8 +162,8 @@ def add_override_values(config: Dict[str, Any], *, chart: str, temp_dir: Path, h
         helm_cmd.extend(["-f", str(override_file)])
 
 
-def add_profile_values(config: Dict[str, Any],
-    *, profile_name: str, chart: str, temp_dir: Path, helm_cmd: List[str]
+def add_profile_values(
+    config: Dict[str, Any], *, profile_name: str, chart: str, temp_dir: Path, helm_cmd: List[str]
 ) -> None:
     """Add profile specific values for the chart."""
     # lookup the configuration values for the profile of the selected target
@@ -284,7 +286,12 @@ def main() -> None:
                     ]
                 )
 
-            add_override_values(this_config, chart=chart, temp_dir=Path(secrets_dir).resolve(), helm_cmd=helm_install_cmd)
+            add_override_values(
+                this_config,
+                chart=chart,
+                temp_dir=Path(secrets_dir).resolve(),
+                helm_cmd=helm_install_cmd,
+            )
 
             # add any additional configuration files from the command line
             if len(addl_configs) > 0:

--- a/deploy/scripts/setup_combine.py
+++ b/deploy/scripts/setup_combine.py
@@ -23,7 +23,7 @@ import os
 from pathlib import Path
 import sys
 import tempfile
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from enum_types import ExitStatus, HelmAction
 from utils import add_helm_opts, add_namespace, get_helm_opts, run_cmd
@@ -140,6 +140,7 @@ def get_installed_charts(helm_opts: List[str], helm_namespace: str) -> List[str]
 
 
 def get_target(config: Dict[str, Any]) -> str:
+    """List available targets and get selection from the user."""
     print("Available targets:")
     for key in config["targets"]:
         print(f"   {key}")
@@ -148,6 +149,35 @@ def get_target(config: Dict[str, Any]) -> str:
     except KeyboardInterrupt:
         print("Exiting.")
         sys.exit(ExitStatus.FAILURE.value)
+
+
+def add_override_values(config: Dict[str, Any], *, chart: str, temp_dir: Path, helm_cmd: List[str]) -> None:
+    """Add value overrides specified in the script configuration file."""
+    if "override" in config and chart in config["override"]:
+        override_file = temp_dir / f"config_{chart}.yaml"
+        with open(override_file, "w") as file:
+            yaml.dump(config["override"][chart], file)
+        helm_cmd.extend(["-f", str(override_file)])
+
+
+def add_profile_values(config: Dict[str, Any],
+    *, profile_name: str, chart: str, temp_dir: Path, helm_cmd: List[str]
+) -> None:
+    """Add profile specific values for the chart."""
+    # lookup the configuration values for the profile of the selected target
+    # get the path for the profile configuration file
+    if profile_name in config["profiles"]:
+        profile_def = scripts_dir / "setup_files" / "profiles" / f"{profile_name}.yaml"
+        if profile_def.exists:
+            with open(profile_def) as file:
+                profile_values = yaml.safe_load(file)
+            if chart in profile_values["charts"]:
+                profile_file = temp_dir / f"profile_{profile_name}_{chart}.yaml"
+                with open(profile_file, "w") as file:
+                    yaml.dump(profile_values["charts"][chart], file)
+                helm_cmd.extend(["-f", str(profile_file)])
+        else:
+            print(f"Warning: cannot find profile {profile_name}", file=sys.stderr)
 
 
 def main() -> None:
@@ -173,7 +203,6 @@ def main() -> None:
 
     # create list of target specific variable values
     target_vars = [
-        f"global.serverName={this_config['serverName']}",
         f"global.imageTag={args.image_tag}",
     ]
     if args.repo:
@@ -187,15 +216,6 @@ def main() -> None:
     # lookup directory for helm files
     helm_dir = scripts_dir.parent / "helm"
 
-    # lookup the configuration values for the profile of the selected target
-    if profile in config["profiles"]:
-        # get the path for the profile configuration file
-        profile_config: Optional[Path] = (
-            scripts_dir / "setup_files" / "profiles" / f"{profile}.yaml"
-        )
-    else:
-        profile_config = None
-        print(f"Warning: cannot find profile {profile}", file=sys.stderr)
     # open a temporary directory for creating the secrets YAML files
     with tempfile.TemporaryDirectory() as secrets_dir:
         for chart in config["profiles"][profile]["charts"]:
@@ -227,12 +247,6 @@ def main() -> None:
                 output_file=secrets_file,
                 env_vars_req=this_config["env_vars_required"],
             )
-            if "override" in this_config:
-                override_file = Path(secrets_dir).resolve() / f"config_{chart}.yaml"
-                with open(override_file, "w") as file:
-                    yaml.dump(this_config["override"], file)
-            else:
-                override_file = None
 
             # create the base helm install command
             chart_dir = helm_dir / chart
@@ -251,9 +265,16 @@ def main() -> None:
             # set the dry-run option if desired
             if args.dry_run:
                 helm_install_cmd.extend(["--dry-run"])
+
             # add the profile specific configuration
-            if profile_config is not None and profile_config.exists:
-                helm_install_cmd.extend(["-f", str(profile_config)])
+            add_profile_values(
+                config,
+                profile_name=profile,
+                chart=chart,
+                temp_dir=Path(secrets_dir).resolve(),
+                helm_cmd=helm_install_cmd,
+            )
+
             # add the secrets file
             if include_secrets:
                 helm_install_cmd.extend(
@@ -262,8 +283,9 @@ def main() -> None:
                         str(secrets_file),
                     ]
                 )
-            if override_file is not None:
-                helm_install_cmd.extend(["-f", str(override_file)])
+
+            add_override_values(this_config, chart=chart, temp_dir=Path(secrets_dir).resolve(), helm_cmd=helm_install_cmd)
+
             # add any additional configuration files from the command line
             if len(addl_configs) > 0:
                 helm_install_cmd.extend(addl_configs)

--- a/deploy/scripts/setup_files/combine_config.yaml
+++ b/deploy/scripts/setup_files/combine_config.yaml
@@ -54,9 +54,6 @@ targets:
           configCaptchaRequired: "true"
           configCaptchaSiteKey: "6LdZIlkaAAAAAES4FZ5d01Shj5G4X0e2CHYg0D5t"
       # override values for 'cert-proxy-server' chart
-      cert-proxy-server:
-        global:
-          serverName: cert-proxy.thecombine.app
 
 # Set of profiles
 # Each key of 'profiles' defines one of the profiles used by the set of targets.

--- a/deploy/scripts/setup_files/combine_config.yaml
+++ b/deploy/scripts/setup_files/combine_config.yaml
@@ -11,45 +11,52 @@
 #            helm `--set` option.
 targets:
   localhost:
-    serverName: thecombine.local
     profile: dev
     env_vars_required: false
     override:
-      frontend:
-        configCaptchaRequired: "true"
-        configCaptchaSiteKey: "6LdBKdIeAAAAAD6hEBDPa0zUMitfVfQvpkgjehNV"
-      global:
-        awsS3Location: dev.thecombine.app
+      # override values for 'thecombine' chart
+      thecombine:
+        global:
+          serverName: thecombine.local
   nuc1:
-    serverName: nuc1.thecombine.app
     profile: nuc
     env_vars_required: true
+    override:
+      # override values for 'thecombine' chart
+      thecombine:
+        global:
+          serverName: nuc1.thecombine.app
   nuc2:
-    serverName: nuc2.thecombine.app
     profile: nuc
     env_vars_required: true
+    override:
+      # override values for 'thecombine' chart
+      thecombine:
+        global:
+          serverName: nuc2.thecombine.app
   qa:
-    serverName: qa-kube.thecombine.app
     profile: staging
     env_vars_required: true
+    override:
+      # override values for 'thecombine' chart
+      thecombine:
+        global:
+          serverName: qa-kube.thecombine.app
   prod:
-    serverName: thecombine.app
     profile: prod
     env_vars_required: true
     override:
-      frontend:
-        configCaptchaRequired: "true"
-        configCaptchaSiteKey: "6LdZIlkaAAAAAES4FZ5d01Shj5G4X0e2CHYg0D5t"
-      combineCertProxyList:
-        - nuc1.thecombine.app
-        - nuc2.thecombine.app
-      global:
-        awsS3Location: prod.thecombine.app
-      maintenence:
-        #######################################
-        # Backup Schedule
-        # Run every day at 03:15 UTC
-        backupSchedule: "15 03 * * *"
+      # override values for 'thecombine' chart
+      thecombine:
+        global:
+          serverName: thecombine.app
+        frontend:
+          configCaptchaRequired: "true"
+          configCaptchaSiteKey: "6LdZIlkaAAAAAES4FZ5d01Shj5G4X0e2CHYg0D5t"
+      # override values for 'cert-proxy-server' chart
+      cert-proxy-server:
+        global:
+          serverName: cert-proxy.thecombine.app
 
 # Set of profiles
 # Each key of 'profiles' defines one of the profiles used by the set of targets.
@@ -61,7 +68,7 @@ targets:
 # to define overrides for configuration values.
 
 profiles:
-  dev: # Profile for local development machines (not supported yet)
+  dev: # Profile for local development machines
     charts:
       - thecombine
   nuc: # Profile for a NUC or a machine whose TLS certificate will be created by another

--- a/deploy/scripts/setup_files/profiles/dev.yaml
+++ b/deploy/scripts/setup_files/profiles/dev.yaml
@@ -5,16 +5,23 @@
 # Profile: dev
 ################################################
 
-aws-login:
-  enabled: false
+charts:
+  thecombine:
+    aws-login:
+      enabled: false
 
-global:
-  imageRegistry: ""
-  imagePullPolicy: Never
+    frontend:
+      configCaptchaRequired: "true"
+      configCaptchaSiteKey: "6LdBKdIeAAAAAD6hEBDPa0zUMitfVfQvpkgjehNV"
 
-ingressClass: nginx
-imagePullPolicy: Never
+    global:
+      imageRegistry: ""
+      imagePullPolicy: Never
+      awsS3Location: dev.thecombine.app
 
-certManager:
-  enabled: true
-  certIssuer: self-signed
+    ingressClass: nginx
+    imagePullPolicy: Never
+
+    certManager:
+      enabled: true
+      certIssuer: self-signed

--- a/deploy/scripts/setup_files/profiles/nuc.yaml
+++ b/deploy/scripts/setup_files/profiles/nuc.yaml
@@ -5,13 +5,15 @@
 # Profile: nuc
 ################################################
 
-aws-login:
-  enabled: true
-  awsEcr:
-    cron: no
+charts:
+  thecombine:
+    aws-login:
+      enabled: true
+      awsEcr:
+        cron: no
 
-cert-proxy-client:
-  enabled: true
+    cert-proxy-client:
+      enabled: true
 
-certManager:
-  enabled: false
+    certManager:
+      enabled: false

--- a/deploy/scripts/setup_files/profiles/prod.yaml
+++ b/deploy/scripts/setup_files/profiles/prod.yaml
@@ -5,16 +5,25 @@
 # Profile: prod
 ################################################
 
-# Frontend configuration items:
-frontend:
-  configShowCertExpiration: false
-  configAnalyticsWriteKey: "j9EeK4oURluRSIKbaXCBKBxGCnT2WahB"
-
-# Maintenance configuration items
-maintenance:
-  #######################################
-  # Backup Schedule
-  # Run every day at 03:15 UTC
-  backupSchedule: "15 03 * * *"
-  # Maximum number of backups to keep on AWS S3 service
-  maxBackups: "3"
+charts:
+  thecombine:
+    # Frontend configuration items:
+    frontend:
+      configShowCertExpiration: false
+      configAnalyticsWriteKey: "j9EeK4oURluRSIKbaXCBKBxGCnT2WahB"
+    # Maintenance configuration items
+    maintenance:
+      #######################################
+      # Backup Schedule
+      # Run every day at 03:15 UTC
+      backupSchedule: "15 03 * * *"
+      # Maximum number of backups to keep on AWS S3 service
+      maxBackups: "3"
+    global:
+      awsS3Location: prod.thecombine.app
+  cert-proxy-server:
+    global:
+      awsS3Location: prod.thecombine.app
+    combineCertProxyList:
+      - nuc1.thecombine.app
+      - nuc2.thecombine.app


### PR DESCRIPTION
Address a set of small problems which prevent the cert proxy server from deploying properly:

- the global definition of `serverName` was used for both the application frontend and the combine-cert-proxy server.  This was addressed 2 ways:
   - changed the structure of the `overrides` in the configuration file to have separate override YAML for each chart, i.e.
      ```
      overrides:
         chart_name:
            override_variable_1: some_value
      ...
      ```
   - created a separate variable, `certProxyServerName`, for the combine-cert-proxy.  This variable is not in the `global` section because it does not need to be shared with subcharts
- The ingress template created an ingress resources for each of the nucs.  The template was missing the `---` document separator so a single resource was created with many duplicate fields.
- Fixed the web page content for the `nuc-proxy-server`.  Changed the configmap that has the web page content from `data` to `binaryData` to accommodate the image files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1624)
<!-- Reviewable:end -->
