### PR TITLE
Remove docker installation

### DIFF
--- a/deploy/roles/docker_install/defaults/main.yml
+++ b/deploy/roles/docker_install/defaults/main.yml
@@ -4,19 +4,4 @@ credential_helper_version: v0.6.3
 
 # Kubernetes/minikube is validated on Docker 19.03.x
 docker_packages:
-  - docker-ce
-  - docker-ce-cli
   - containerd.io
-
-docker_pinned_pkgs:
-  - pkg: docker-ce
-    version: "5:20.10.*"
-  - pkg: docker-ce-cli
-    version: "5:20.10.*"
-  - pkg: docker-ce-rootless-extras
-    version: "5:20.10.*"
-
-combine_use_syslog: false
-combine_log_directory: /var/log/combine
-docker_log_file: docker.log
-container_log_file: app.log

--- a/deploy/roles/docker_install/handlers/main.yml
+++ b/deploy/roles/docker_install/handlers/main.yml
@@ -1,18 +1,3 @@
 ---
 - name: reboot target
   reboot:
-
-- name: restart docker
-  service:
-    name: docker
-    state: restarted
-
-- name: restart rsyslog
-  service:
-    name: rsyslog
-    state: restarted
-
-- name: update packages
-  apt:
-    update_cache: yes
-    upgrade: "yes"

--- a/deploy/roles/docker_install/tasks/main.yml
+++ b/deploy/roles/docker_install/tasks/main.yml
@@ -18,7 +18,7 @@
     cache_valid_time: 600
   changed_when: false
 
-- name: Install docker pre-requisites
+- name: Install pre-requisite packages
   apt:
     name:
       - apt-transport-https
@@ -40,99 +40,8 @@
     state: present
     filename: docker
 
-- name: Pin Docker to validated version
-  template:
-    src: apt-preferences.j2
-    dest: "/etc/apt/preferences.d/{{ item.pkg }}-pin"
-    owner: root
-    group: root
-    mode: 0644
-  with_items: "{{ docker_pinned_pkgs }}"
-  notify: update packages
-
-- name: Install Docker Engine
+- name: Install Docker Packages
   apt:
     name: "{{ docker_packages }}"
     update_cache: yes
   notify: reboot target
-
-- name: Enable Docker service
-  service:
-    name: docker
-    enabled: yes
-    state: started
-
-- name: Create directory for TheCombine logs
-  file:
-    path: "{{ combine_log_directory }}"
-    state: directory
-    owner: syslog
-    group: adm
-    mode: 0775
-  when: combine_use_syslog
-
-  # Create the configuration file for logging the Docker events.  Note that
-  # the default logging configuration is 50-default.conf.  Since "30" < "50",
-  # the docker configuration will be processed first and the stop command at
-  # the end of the file ("& ~") will prevent the log message from being duplicated
-  # in /var/log/syslog.  If it becomes useful to have the messages in
-  # /var/log/syslog as well, change the configuration file name to one that is
-  # > "50".
-- name: Setup rsyslog to log to separate file
-  template:
-    src: combine-log.conf.j2
-    dest: /etc/rsyslog.d/30-docker.conf
-    owner: root
-    group: root
-    mode: 0644
-  when: combine_use_syslog
-  notify: restart rsyslog
-
-- name: Configure Default Docker Logging
-  template:
-    src: daemon.json.j2
-    dest: /etc/docker/daemon.json
-    owner: root
-    group: root
-    mode: 0600
-  notify: restart docker
-
-- name: Configure Combine Log Rotation
-  template:
-    src: logrotate.conf.j2
-    dest: /etc/logrotate.d/docker
-    owner: root
-    group: root
-    mode: 0644
-  when: combine_use_syslog
-
-- name: check for docker-compose version
-  command: docker-compose --version
-  register: compose_version
-  changed_when: false
-  failed_when: false
-
-- name: Install Docker Compose
-  get_url:
-    url: "https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-{{ ansible_system }}-{{ ansible_architecture }}"
-    dest: "/usr/local/bin/docker-compose"
-    owner: root
-    group: root
-    mode: 0755
-  when: compose_version.rc != 0 or docker_compose_version not in compose_version.stdout
-
-- name: Create link for /usr/bin/docker-compose
-  file:
-    src: "/usr/local/bin/docker-compose"
-    dest: "/usr/bin/docker-compose"
-    state: link
-    owner: root
-    group: root
-    mode: 0777
-
-- name: Add user to docker group
-  user:
-    name: "{{ ansible_user_id }}"
-    groups:
-      - docker
-    append: yes

--- a/deploy/roles/k8s_install/tasks/main.yml
+++ b/deploy/roles/k8s_install/tasks/main.yml
@@ -4,12 +4,6 @@
     name: "{{ k8s_required_pkgs }}"
 
 # configure kubernetes user
-- name: adding existing user '{{ k8s_user }}' to group docker
-  user:
-    name: "{{ k8s_user }}"
-    groups: docker
-    append: yes
-
 - name: Install Kubernetes Engine
   include_tasks:
     file: "{{ k8s_engine }}.yml"

--- a/deploy/scripts/setup_files/profiles/prod.yaml
+++ b/deploy/scripts/setup_files/profiles/prod.yaml
@@ -21,6 +21,8 @@ charts:
       maxBackups: "3"
     global:
       awsS3Location: prod.thecombine.app
+    certManager:
+      enabled: true
   cert-proxy-server:
     global:
       awsS3Location: prod.thecombine.app


### PR DESCRIPTION
Since Kubernetes 1.20, Docker and Docker Compose are not required on the target systems; only the `containerd.io` package is required to run containers.

This PR removes the following installation tasks:
- install `docker-ce` and `docker-ce-cli`
- download and install of `docker-compose`
- setup logging with `rsyslog`

In addition, this PR includes a fix to the helm charts for the production server - it enables `certManager` to create a TLS certificate using LetsEncrypt.