### PR TITLE
Fix setting of server list for the cert proxy server

### DIFF
--- a/deploy/helm/cert-proxy-server/templates/ingress-nuc.yaml
+++ b/deploy/helm/cert-proxy-server/templates/ingress-nuc.yaml
@@ -1,4 +1,4 @@
-{{- range .Values.combineCertProxyList }}
+{{- range regexSplit "\\s+" .Values.combineCertProxyList -1 }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/deploy/scripts/setup_files/profiles/prod.yaml
+++ b/deploy/scripts/setup_files/profiles/prod.yaml
@@ -26,6 +26,4 @@ charts:
   cert-proxy-server:
     global:
       awsS3Location: prod.thecombine.app
-    combineCertProxyList:
-      - nuc1.thecombine.app
-      - nuc2.thecombine.app
+    combineCertProxyList: nuc1.thecombine.app nuc2.thecombine.app


### PR DESCRIPTION
An error was introduced when porting the Kubernetes installation from Ansible to Helm. The variable .Values.combineCertProxyList is used in two ways:

- iterate over the servers in the list to create an ingress for each server, and
- create an environment variable for the combine-cert-proxy deployment. The deployment monitors watches for changes to secrets, if the secret is for a server in the environment variable, then the secret is pushed to AWS S3.

For the first use, the variable must be a list. In the second use, when the environment variable is set from a list, it has brackets ( [ ] ) around the list which prevents the deployment from detecting any changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1638)
<!-- Reviewable:end -->
