### PR TITLE
Update helm charts

### DIFF
--- a/deploy/helm/thecombine/charts/frontend/templates/deployment-frontend.yaml
+++ b/deploy/helm/thecombine/charts/frontend/templates/deployment-frontend.yaml
@@ -59,6 +59,13 @@ spec:
                 configMapKeyRef:
                   key: ENV_HTTP_ONLY
                   name: env-frontend
+            {{- if .Values.configAnalyticsWriteKey }}
+            - name: CONFIG_ANALYTICS_WRITE_KEY
+              valueFrom:
+                configMapKeyRef:
+                  key: CONFIG_ANALYTICS_WRITE_KEY
+                  name: env-frontend
+            {{- end }}
           ports:
             - containerPort: 80
             - containerPort: 443

--- a/deploy/helm/thecombine/templates/ingress-combine.yaml
+++ b/deploy/helm/thecombine/templates/ingress-combine.yaml
@@ -17,7 +17,11 @@ spec:
   tls:
   - hosts:
     - {{ .Values.global.serverName }}
+{{- if .Values.tlsSecretName }}
+    secretName: {{ .Values.tlsSecretName }}
+{{- else }}
     secretName: {{ replace "." "-" .Values.global.serverName }}-tls
+{{- end }}
   rules:
   - host: {{ .Values.global.serverName }}
     http:

--- a/deploy/helm/thecombine/values.yaml
+++ b/deploy/helm/thecombine/values.yaml
@@ -45,7 +45,7 @@ frontend:
   configShowCertExpiration: false
   configAnalyticsWriteKey: ""
   configCaptchaRequired: false
-  configCaptchaSiteKey: "None - from thecombine chart"
+  configCaptchaSiteKey: "None"
 
 # Maintenance configuration items
 maintenance:

--- a/deploy/scripts/setup_files/profiles/nuc.yaml
+++ b/deploy/scripts/setup_files/profiles/nuc.yaml
@@ -11,6 +11,8 @@ charts:
       enabled: true
       awsEcr:
         cron: no
+    global:
+      awsS3Location: prod.thecombine.app
 
     cert-proxy-client:
       enabled: true

--- a/deploy/scripts/setup_files/profiles/prod.yaml
+++ b/deploy/scripts/setup_files/profiles/prod.yaml
@@ -22,7 +22,7 @@ charts:
     global:
       awsS3Location: prod.thecombine.app
     certManager:
-      enabled: true
+      enabled: false
   cert-proxy-server:
     global:
       awsS3Location: prod.thecombine.app

--- a/deploy/scripts/setup_files/profiles/staging.yaml
+++ b/deploy/scripts/setup_files/profiles/staging.yaml
@@ -1,0 +1,17 @@
+---
+################################################
+# Profile specific configuration items
+#
+# Profile: prod
+################################################
+
+charts:
+  thecombine:
+    # Frontend configuration items:
+    frontend:
+      configShowCertExpiration: false
+      configAnalyticsWriteKey: "AoebaDJNjSlOMRUH87EaNjvwkQpfLoyy"
+    global:
+      awsS3Location: prod.thecombine.app
+    certManager:
+      enabled: false

--- a/deploy/scripts/setup_files/profiles/staging.yaml
+++ b/deploy/scripts/setup_files/profiles/staging.yaml
@@ -13,5 +13,6 @@ charts:
       configAnalyticsWriteKey: "AoebaDJNjSlOMRUH87EaNjvwkQpfLoyy"
     global:
       awsS3Location: prod.thecombine.app
+    tlsSecretName: thecombine-app-tls
     certManager:
       enabled: false

--- a/nginx/init/25-combine-runtime-config.sh
+++ b/nginx/init/25-combine-runtime-config.sh
@@ -64,10 +64,10 @@ for env_var in "${!env_map[@]}"; do
     jsField=${env_map[${env_var}]}
     jsValue=${!env_var}
     # check to see if $jsValue needs to be quoted
-    if quote_value ${jsValue} ; then
-      printf '   %s: "%s",\n' ${jsField} ${jsValue} >> $OUTFILE
+    if quote_value "${jsValue}" ; then
+      printf '   %s: "%s",\n' ${jsField} "${jsValue}" >> $OUTFILE
     else
-      printf '   %s: %s,\n' ${jsField} ${jsValue} >> $OUTFILE
+      printf '   %s: %s,\n' ${jsField} "${jsValue}" >> $OUTFILE
     fi
   fi
 done


### PR DESCRIPTION
This PR addresses the following issues with the Helm charts for _The Combine_:

- Update the default S3 bucket for the NUCs to be `prod.thecombine.app`
- Fix the generation of `config.js` on the frontend; the script to build `config.js` from environment variables did not work correctly if there were spaces in the value of the environment variable
- The analytics write key was missing from the environment variables for the frontend.  The value was being put into the configuration map, `env-frontend` but the definition of the frontend deployment never created the environment variable in the pod container.  In addition, the analytics write key for the QA server is now specified.
- Added option to specify the name of the secret for _The Combine's_ TLS certificate since the QA server's resource is provided by LTOps and does not match the one we normally generate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1653)
<!-- Reviewable:end -->
