### PR TITLE
Add ability to list images in the repo(s)

### DIFF
--- a/scripts/clean_aws_repo.py
+++ b/scripts/clean_aws_repo.py
@@ -59,7 +59,8 @@ def parse_args() -> Namespace:
         Notes:
 
          - The repo names must be specified BEFORE the --remove or --keep options.
-         - You must specify --untagged and/or --remove options.
+         - If neither --untagged nor --remove options is specified, then {os.path.basename(__file__)}
+           will list the images (same as specifying '--list').
 
         """,
         formatter_class=RawFormatter,
@@ -77,6 +78,7 @@ def parse_args() -> Namespace:
         nargs="+",
         help="List of tags to keep that would otherwise be removed",
     )
+    parser.add_argument("--list", action="store_true", help="List images in the repo.  No images are deleted.")
     parser.add_argument(
         "--remove",
         dest="rm_pattern",
@@ -142,13 +144,8 @@ def main() -> None:
     """Clean out old images in the AWS ECR repository."""
     args = parse_args()
 
-    # Verify that either '--untagged' or '--remove' are specified
-    if not args.untagged and (args.rm_pattern is None or len(args.rm_pattern) == 0):
-        print("Nothing to do.  Run:")
-        prog_name = os.path.basename(__file__)
-        print(f"   {prog_name} --help")
-        print("for usage instructions.")
-        exit(0)
+    # Verify that either '--untagged' or '--remove' or '--list' are specified
+    list_images = args.list or (not args.untagged and (args.rm_pattern is None or len(args.rm_pattern) == 0))
 
     rm_pattern: Optional[str] = None
     if args.rm_pattern is not None:
@@ -179,6 +176,8 @@ def main() -> None:
                     # 'latest' is a special tag - always points to most recent
                     # untagged image.  Delete this image by digest name but only
                     # if untagged images are to be deleted
+                    if list_images:
+                        print(f"tag {tag}")
                     if tag == "latest":
                         if args.untagged:
                             image_ids.append(f"imageDigest={image_struct['imageDigest']}")
@@ -191,23 +190,26 @@ def main() -> None:
                 # No tags exist for this image
                 if args.untagged:
                     image_ids.append(f'imageDigest={image_struct["imageDigest"]}')
-        # Remove all the specified image(s) in blocks of 100 (AWS limit)
-        # See https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_BatchDeleteImage.html
-        if len(image_ids) > 0:
-            aws_delete_limit = 100
-            for i in range(0, len(image_ids), aws_delete_limit):
-                aws_cmd = build_aws_cmd(
-                    args.profile,
-                    repo,
-                    "batch-delete-image",
-                    ["--image-ids"] + image_ids[i : i + aws_delete_limit],
-                )
-                if args.dry_run:
-                    print(f"AWS Command: {aws_cmd}")
-                else:
-                    run_aws_cmd(aws_cmd, args.verbose)
-        elif args.verbose:
-            print("No images/tags were deleted.")
+                if list_images:
+                    print(f'digest {image_struct["imageDigest"]}')
+        if not list_images:
+            # Remove all the specified image(s) in blocks of 100 (AWS limit)
+            # See https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_BatchDeleteImage.html
+            if len(image_ids) > 0:
+                aws_delete_limit = 100
+                for i in range(0, len(image_ids), aws_delete_limit):
+                    aws_cmd = build_aws_cmd(
+                        args.profile,
+                        repo,
+                        "batch-delete-image",
+                        ["--image-ids"] + image_ids[i : i + aws_delete_limit],
+                    )
+                    if args.dry_run:
+                        print(f"AWS Command: {aws_cmd}")
+                    else:
+                        run_aws_cmd(aws_cmd, args.verbose)
+            elif args.verbose:
+                print("No images/tags were deleted.")
 
 
 if __name__ == "__main__":

--- a/scripts/clean_aws_repo.py
+++ b/scripts/clean_aws_repo.py
@@ -59,8 +59,9 @@ def parse_args() -> Namespace:
         Notes:
 
          - The repo names must be specified BEFORE the --remove or --keep options.
-         - If neither --untagged nor --remove options is specified, then {os.path.basename(__file__)}
-           will list the images (same as specifying '--list').
+         - If neither --untagged nor --remove options is specified, then
+           {os.path.basename(__file__)} will list the images.  This is the same
+           behavior as specifying '--list'.
 
         """,
         formatter_class=RawFormatter,
@@ -78,7 +79,9 @@ def parse_args() -> Namespace:
         nargs="+",
         help="List of tags to keep that would otherwise be removed",
     )
-    parser.add_argument("--list", action="store_true", help="List images in the repo.  No images are deleted.")
+    parser.add_argument(
+        "--list", action="store_true", help="List images in the repo.  No images are deleted."
+    )
     parser.add_argument(
         "--remove",
         dest="rm_pattern",
@@ -145,7 +148,9 @@ def main() -> None:
     args = parse_args()
 
     # Verify that either '--untagged' or '--remove' or '--list' are specified
-    list_images = args.list or (not args.untagged and (args.rm_pattern is None or len(args.rm_pattern) == 0))
+    list_images = args.list or (
+        not args.untagged and (args.rm_pattern is None or len(args.rm_pattern) == 0)
+    )
 
     rm_pattern: Optional[str] = None
     if args.rm_pattern is not None:
@@ -194,7 +199,8 @@ def main() -> None:
                     print(f'digest {image_struct["imageDigest"]}')
         if not list_images:
             # Remove all the specified image(s) in blocks of 100 (AWS limit)
-            # See https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_BatchDeleteImage.html
+            # See:
+            # https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_BatchDeleteImage.html
             if len(image_ids) > 0:
                 aws_delete_limit = 100
                 for i in range(0, len(image_ids), aws_delete_limit):


### PR DESCRIPTION
When `clean_aws_repo.py` is run manually, it is helpful to know what tags are available when creating the patterns for removing old images.  This adds a `--list` option to just list the tags and untagged images without removing any images from the specified repo(s).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1654)
<!-- Reviewable:end -->
