### PR TITLE
Allow $aws_backup with and without 's3://' at beginning

### DIFF
--- a/maintenance/scripts/combine-clean-aws.sh
+++ b/maintenance/scripts/combine-clean-aws.sh
@@ -66,9 +66,11 @@ while [[ $# -gt 0 ]] ; do
   esac
 done
 
-max_backups=${max_backups:=3}
+# Prepend 's3://' to $aws_bucket if it is needed.
+[[ $aws_bucket =~ ^s3:// ]] || aws_bucket=s3://${aws_bucket}
 
-AWS_BACKUPS=($(/usr/local/bin/aws s3 ls s3://${aws_bucket} --recursive | grep "${backup_filter}" | sed "s/[^\/]*\/\(.*\)/\1/" | sort))
+max_backups=${max_backups:=3}
+AWS_BACKUPS=($(/usr/local/bin/aws s3 ls ${aws_bucket} --recursive | grep "${backup_filter}" | sed "s/[^\/]*\/\(.*\)/\1/" | sort))
 NUM_BACKUPS=${#AWS_BACKUPS[@]}
 
 if [[ $VERBOSE -eq 1 ]] ; then
@@ -85,7 +87,7 @@ if [[ ${NUM_BACKUPS} -gt ${max_backups} ]] ; then
   loop_limit=$(( ${NUM_BACKUPS} - ${max_backups} ))
 
   for (( bu=0; bu < $loop_limit; bu++ )) ; do
-    cmd="/usr/local/bin/aws s3 rm s3://${aws_bucket}/${AWS_BACKUPS[${bu}]}"
+    cmd="/usr/local/bin/aws s3 rm ${aws_bucket}/${AWS_BACKUPS[${bu}]}"
     if [[ $DRYRUN -eq 1 ]] ; then
       echo "$cmd"
     else


### PR DESCRIPTION
When the installation of The Combine in the Kubernetes cluster moved from Ansible playbooks to a Helm chart, the way the AWS bucket is specified was changed but the script to clean up old backups was not updated.  In the Helm chart, the `aws_bucket` environment variable starts with `s3://`.

This PR updates the `combine-clean-aws.sh` scripts to work whether or not the `aws_bucket` environment variable begins with the AWS S3 URL prefix.

Closes #1657

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1658)
<!-- Reviewable:end -->
