### PR TITLE
Update gh actions

### DIFF
--- a/.github/actions/combine-deploy-update/action.yml
+++ b/.github/actions/combine-deploy-update/action.yml
@@ -18,6 +18,7 @@ runs:
   steps:
     - name: Install pre-requisites
       run: |
+        cd
         curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
         sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
         kubectl version

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -40,7 +40,7 @@ jobs:
       - run: dotnet-format --check
 
   CodeQL_build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -66,7 +66,7 @@ jobs:
         uses: github/codeql-action/analyze@v1
 
   docker_build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       # For subfolders, currently a full checkout is required.
       # See: https://github.com/marketplace/actions/build-and-push-docker-images#path-context

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet: ["6.0.x"]
+        dotnet: ["6.0.4"]
     steps:
       - uses: actions/checkout@v2
       - name: Setup dotnet

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet: ["6.0.4"]
+        dotnet: ["6.0.202"]
     steps:
       - uses: actions/checkout@v2
       - name: Setup dotnet

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -40,7 +40,7 @@ jobs:
       - run: dotnet-format --check
 
   CodeQL_build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -49,7 +49,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "6.0"
+          dotnet-version: "6.0.202"
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1
         with:
@@ -66,7 +66,7 @@ jobs:
         uses: github/codeql-action/analyze@v1
 
   docker_build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       # For subfolders, currently a full checkout is required.
       # See: https://github.com/marketplace/actions/build-and-push-docker-images#path-context

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -1,5 +1,5 @@
 # Docker multi-stage build.
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:6.0.202 AS builder
 WORKDIR /app
 
 # Copy csproj and restore (fetch dependencies) as distinct layers.
@@ -11,7 +11,7 @@ COPY . ./
 RUN dotnet publish -c Release -o build
 
 # Build runtime image.
-FROM mcr.microsoft.com/dotnet/aspnet:6.0
+FROM mcr.microsoft.com/dotnet/aspnet:6.0.202
 
 ENV ASPNETCORE_URLS=http://+:5000
 ENV COMBINE_IS_IN_CONTAINER=1

--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -1,5 +1,5 @@
 # Docker multi-stage build.
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:6.0.202 AS builder
 WORKDIR /app
 
 # Copy csproj and restore (fetch dependencies) as distinct layers.

--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -1,5 +1,5 @@
 # Docker multi-stage build.
-FROM mcr.microsoft.com/dotnet/sdk:6.0.202 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS builder
 WORKDIR /app
 
 # Copy csproj and restore (fetch dependencies) as distinct layers.
@@ -11,7 +11,7 @@ COPY . ./
 RUN dotnet publish -c Release -o build
 
 # Build runtime image.
-FROM mcr.microsoft.com/dotnet/aspnet:6.0.202
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
 
 ENV ASPNETCORE_URLS=http://+:5000
 ENV COMBINE_IS_IN_CONTAINER=1


### PR DESCRIPTION
Update the GitHub Actions as follows:
- Pin `dotnet/sdk` to `6.0.202` where referenced.  This applies to the GitHub Actions as well as the file `./Backend/Dockerfile`
- Remove lint/type checking of python code against Python 3.8.  All containers are using 3.10.  The user guide continues to be built using 3.9.
- Change to the home directory as the first step for the self-hosted runner when deploying to the production or QA server so that we are working from a known spot.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1661)
<!-- Reviewable:end -->
