### PR TITLE
Update release scripts

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -44,3 +44,11 @@ jobs:
           image_tag: ${{ needs.build.outputs.image_tag }}
           kube_context: ${{ secrets.LTOPS_K8S_STAGING_CONTEXT }}
           update_cert_proxy: false
+      - name: Deploy The Combine Update
+        uses: ./.github/actions/combine-deploy-update
+        with:
+          image_registry: public.ecr.aws
+          image_registry_alias: "/thecombine"
+          image_tag: ${{ needs.build.outputs.image_tag }}
+          kube_context: ${{ secrets.LTOPS_K8S_PRODUCTION_CONTEXT }}
+          update_cert_proxy: true

--- a/deploy/scripts/setup_combine.py
+++ b/deploy/scripts/setup_combine.py
@@ -192,7 +192,10 @@ def main() -> None:
         config: Dict[str, Any] = yaml.safe_load(file)
 
     # Build the Chart.yaml files from templates
-    combine_charts.generate(get_release())
+    if args.image_tag != "latest":
+        combine_charts.generate(args.image_tag)
+    else:
+        combine_charts.generate(get_release())
 
     target = args.target
     while target not in config["targets"]:


### PR DESCRIPTION
This PR includes two updates to the release scripts:

1. the GitHub action to deploy a release was updated to update the production server as well as the QA server;
2. the `setup_combine.py` script was updated to use the `--tag` value for the version of the helm charts unless the value is `latest`; if the value is `latest` it will use the results from `get_release()` in `app_release.py`.  There are two reasons for this change:
   1. to have the chart version match the version of the software that is installed rather than the version of the git repository where the script was run; and
   2. to be able to install the helm charts without having the full git repository present, for example, from a Docker image that includes the scripts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1681)
<!-- Reviewable:end -->
