### PR TITLE
Mongo 5 prep

### DIFF
--- a/maintenance/scripts/combine_app.py
+++ b/maintenance/scripts/combine_app.py
@@ -114,7 +114,7 @@ class CombineApp:
         """
         db_results = self.exec(
             self.get_pod_id(CombineApp.Component.Database),
-            ["/usr/bin/mongo", "--quiet", "CombineDatabase", "--eval", cmd],
+            ["/usr/bin/mongosh", "--quiet", "CombineDatabase", "--eval", cmd],
         )
         result_str = self.object_id_to_str(db_results.stdout)
         if result_str != "":
@@ -129,7 +129,7 @@ class CombineApp:
         cmd = f"db.{collection}.find({query}, {projection}).toArray()"
         db_results = self.exec(
             self.get_pod_id(CombineApp.Component.Database),
-            ["/usr/bin/mongo", "--quiet", "CombineDatabase", "--eval", cmd],
+            ["/usr/bin/mongosh", "--quiet", "CombineDatabase", "--eval", cmd],
         )
         result_str = self.object_id_to_str(db_results.stdout)
         if result_str != "":

--- a/scripts/dropDB.ts
+++ b/scripts/dropDB.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "child_process";
 
-const cmd = spawnSync("mongo", [
+const cmd = spawnSync("mongosh", [
   "-eval",
   "db.getSiblingDB('CombineDatabase').dropDatabase()",
 ]);

--- a/scripts/setAdminUser.ts
+++ b/scripts/setAdminUser.ts
@@ -8,7 +8,11 @@ if (args.length > 0) {
   const user = args[0];
   const updateCommand = `db.UsersCollection.updateOne({username: "${user}"}, {$set: {isAdmin: true}});`;
 
-  const cmd = spawnSync("mongo", ["--eval", updateCommand, "CombineDatabase"]);
+  const cmd = spawnSync("mongosh", [
+    "--eval",
+    updateCommand,
+    "CombineDatabase",
+  ]);
   console.log(`stderr: ${cmd.stderr.toString()}`);
   console.log(`stdout: ${cmd.stdout.toString()}`);
 } else {

--- a/scripts/setupMongo.ts
+++ b/scripts/setupMongo.ts
@@ -1,4 +1,4 @@
-import * as makeDir from "make-dir";
+import makeDir from "make-dir";
 
 const directory = "./mongo_database";
 


### PR DESCRIPTION
The `mongo` shell is depricated (https://www.mongodb.com/docs/manual/release-notes/5.0-compatibility/#deprecations); replacing with `mongosh`.