### PR TITLE
[DataEntryTable] Use preventDefault in TextField

### DIFF
--- a/src/components/DataEntry/DataEntryTable/EntryCellComponents/GlossWithSuggestions.tsx
+++ b/src/components/DataEntry/DataEntryTable/EntryCellComponents/GlossWithSuggestions.tsx
@@ -71,6 +71,7 @@ export default class GlossWithSuggestions extends React.Component<GlossWithSugge
         )}
         onKeyPress={(e: React.KeyboardEvent) => {
           if (e.key === Key.Enter || e.key === Key.Tab) {
+            e.preventDefault();
             this.props.handleEnterAndTab(e);
           }
         }}

--- a/src/components/DataEntry/DataEntryTable/EntryCellComponents/VernWithSuggestions.tsx
+++ b/src/components/DataEntry/DataEntryTable/EntryCellComponents/VernWithSuggestions.tsx
@@ -54,6 +54,7 @@ export default class VernWithSuggestions extends React.Component<VernWithSuggest
           }}
           onKeyPress={(e: React.KeyboardEvent) => {
             if (e.key === Key.Enter || e.key === Key.Tab) {
+              e.preventDefault();
               this.props.handleEnterAndTab(e);
             }
           }}


### PR DESCRIPTION
Resolves #1711 by preventing Safari's default of triggering the Exit button when the "return" key is pressed within a TextField. This solution does not identify the root of that wonky behavior, but does avoid it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1712)
<!-- Reviewable:end -->
