### PR TITLE
Set empty nodes to null instead of empty object, {}

### DIFF
--- a/deploy/scripts/semantic_domains.py
+++ b/deploy/scripts/semantic_domains.py
@@ -106,9 +106,9 @@ class SemanticDomainTreeNode(SemanticDomain):
             "lang": self.lang,
             "name": self.name,
             "id": self.id,
-            "parent": {} if self.parent is None else self.parent.to_dict(),
-            "prev": {} if self.prev is None else self.prev.to_dict(),
-            "next": {} if self.next is None else self.next.to_dict(),
+            "parent": None if self.parent is None else self.parent.to_dict(),
+            "prev": None if self.prev is None else self.prev.to_dict(),
+            "next": None if self.next is None else self.next.to_dict(),
             "children": children,
         }
         return json.dumps(data, indent=4)


### PR DESCRIPTION
Change the script that generates the import data for the SemanticDomainTree collection in the database so that missing parent, next, or previous nodes are set to `null` instead of `{}`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1731)
<!-- Reviewable:end -->
