### PR TITLE
Fix db scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ database/semantic_domains/*
 _*.yml
 _*.yaml
 _*.j2
+deploy/scripts/setup_files/**/dev_*.yaml
 
 # Emacs backup files (this is Jim's fault)
 *~

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,6 +1,6 @@
 FROM mongo:5.0
 
-WORKDIR /app
+WORKDIR /
 
 RUN mkdir /data/semantic-domains
 

--- a/deploy/helm/thecombine/charts/database/templates/database.yaml
+++ b/deploy/helm/thecombine/charts/database/templates/database.yaml
@@ -30,7 +30,12 @@ spec:
     matchLabels:
       combine-component: database
   strategy:
-    type: Recreate
+    type: {{ .Values.global.updateStrategy }}
+{{- if eq "RollingUpdate" .Values.global.updateStrategy  }}
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+{{- end }}
   template:
     metadata:
       creationTimestamp: null
@@ -48,6 +53,10 @@ spec:
             - mountPath: /data/db
               name: database-data
       restartPolicy: Always
+{{- if ne .Values.global.pullSecretName "None" }}
+      imagePullSecrets:
+         - name: {{ .Values.global.pullSecretName }}
+{{- end }}
       volumes:
         - name: database-data
           persistentVolumeClaim:

--- a/deploy/helm/thecombine/charts/maintenance/templates/cronjob-daily-backup.yaml
+++ b/deploy/helm/thecombine/charts/maintenance/templates/cronjob-daily-backup.yaml
@@ -11,7 +11,7 @@ spec:
     metadata:
       creationTimestamp: null
     spec:
-      ttlSecondsAfterFinished: 300
+      ttlSecondsAfterFinished: 86400
       template:
         metadata:
           creationTimestamp: null

--- a/maintenance/scripts/combine_restore.py
+++ b/maintenance/scripts/combine_restore.py
@@ -101,10 +101,12 @@ def main() -> None:
             for i, backup_entry in enumerate(aws_backup_list):
                 print(f"{i+1}: {backup_entry[1]} ({backup_entry[0]})")
 
-            backup_num = int(
-                input("Enter the number of the backup you would like to restore (0 = None):")
+            response = input(
+                "Enter the number of the backup you would like to restore (0 = None):"
             )
-            if backup_num == 0:
+            if response:
+                backup_num = int(response)
+            if not response or backup_num == 0:
                 print("No backup selected.  Exiting.")
                 sys.exit(0)
             backup = aws_backup_list[backup_num - 1][1]

--- a/maintenance/scripts/combine_restore.py
+++ b/maintenance/scripts/combine_restore.py
@@ -125,10 +125,11 @@ def main() -> None:
         if not db_pod:
             print("Cannot find the database container.", file=sys.stderr)
             sys.exit(1)
+        db_files_subdir = os.environ["db_files_subdir"]
         combine.kubectl(
             [
                 "cp",
-                os.environ["db_files_subdir"],
+                db_files_subdir,
                 f"{db_pod}:/",
             ]
         )
@@ -140,6 +141,7 @@ def main() -> None:
                 "--drop",
                 "--gzip",
                 "--quiet",
+                f"--dir=/{db_files_subdir}",
             ],
         )
         combine.exec(
@@ -147,7 +149,7 @@ def main() -> None:
             [
                 "rm",
                 "-rf",
-                os.environ["db_files_subdir"],
+                f"/{db_files_subdir}",
             ],
         )
 


### PR DESCRIPTION
Updates to database image and the restore script:
- Set `WORKING_DIR` to `/` in the `database` image
- Update restore script to specify directory for backup files to be restored
- Add image pull secret specification to database deployment (needed to run non-released images)
- Changed specification for `daily-backup` cron job so that the pods that ran the job and their associated logs are available for 24 hours