### PR TITLE
Add Hardware Monitoring to NUC installations

### DIFF
--- a/deploy/ansible/group_vars/nuc/main.yml
+++ b/deploy/ansible/group_vars/nuc/main.yml
@@ -46,3 +46,9 @@ ap_ssid: "{{ansible_hostname}}_ap"
 ap_passphrase: "Combine2020"
 ap_gateway: "10.10.10.1"
 ap_hostname: "{{ansible_hostname}}"
+
+################################################
+# hardware monitoring settings
+################################################
+include_hw_monitoring: yes
+history_days: 60

--- a/deploy/ansible/group_vars/server/main.yml
+++ b/deploy/ansible/group_vars/server/main.yml
@@ -27,3 +27,8 @@ ingress_namespace: ingress-nginx
 # WiFi access point settings
 ################################################
 has_wifi: no
+
+################################################
+# hardware monitoring settings
+################################################
+include_hw_monitoring: no

--- a/deploy/ansible/playbook_kube_install.yaml
+++ b/deploy/ansible/playbook_kube_install.yaml
@@ -28,6 +28,11 @@
         name: wifi_ap
       when: has_wifi
 
+    - name: Enable hardware monitoring
+      import_role:
+        name: monitor_hardware
+      when: include_hw_monitoring
+
     - name: Configure Network Interfaces
       import_role:
         name: network_config

--- a/deploy/ansible/roles/monitor_hardware/defaults/main.yml
+++ b/deploy/ansible/roles/monitor_hardware/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# Default values for monitor_hardware role
+
+# How long to keep log files (in days).
+history_days: 60

--- a/deploy/ansible/roles/monitor_hardware/handlers/main.yml
+++ b/deploy/ansible/roles/monitor_hardware/handlers/main.yml
@@ -1,0 +1,13 @@
+---
+#########################
+# Handlers for setting
+# up hardware monitoring
+#########################
+
+- name: restart target
+  reboot:
+
+- name: restart sysstat service
+  service:
+    name: sysstat
+    state: restarted

--- a/deploy/ansible/roles/monitor_hardware/tasks/main.yml
+++ b/deploy/ansible/roles/monitor_hardware/tasks/main.yml
@@ -1,0 +1,34 @@
+---
+##################################
+# Setup sysstat to monitor target
+# hardware.
+##################################
+
+- name: Install sensor package
+  apt:
+    name:
+      - lm-sensors
+      - sysstat
+  notify: restart target
+
+- name: Enable monitoring
+  lineinfile:
+    path: /etc/sysstat/sysstat
+    regexp: "^#*SADC_OPTIONS="
+    state: present
+    line: SADC_OPTIONS="-D -S DISK,POWER"
+  notify: restart sysstat service
+
+- name: Set history
+  lineinfile:
+    path: /etc/sysstat/sysstat
+    regexp: "^#*HISTORY="
+    state: present
+    line: HISTORY={{ history_days }}
+  notify: restart sysstat service
+
+- name: Start monitoring service
+  service:
+    name: sysstat
+    enabled: yes
+    state: started

--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -4,27 +4,27 @@
 #
 #    pip-compile requirements.in
 #
-ansible==6.0.0
+ansible==6.5.0
     # via -r requirements.in
-ansible-core==2.13.1
+ansible-core==2.13.5
     # via ansible
 cachetools==5.2.0
     # via google-auth
-certifi==2022.6.15
+certifi==2022.9.24
     # via
     #   kubernetes
     #   requests
-cffi==1.15.0
+cffi==1.15.1
     # via cryptography
-charset-normalizer==2.0.12
+charset-normalizer==2.1.1
     # via requests
-cryptography==37.0.2
+cryptography==38.0.1
     # via
     #   ansible-core
     #   pyopenssl
-google-auth==2.8.0
+google-auth==2.12.0
     # via kubernetes
-idna==3.3
+idna==3.4
     # via requests
 jinja2==3.1.2
     # via
@@ -33,11 +33,11 @@ jinja2==3.1.2
     #   jinja2-base64-filters
 jinja2-base64-filters==0.1.4
     # via -r requirements.in
-kubernetes==23.6.0
+kubernetes==24.2.0
     # via -r requirements.in
 markupsafe==2.1.1
     # via jinja2
-oauthlib==3.2.0
+oauthlib==3.2.1
     # via requests-oauthlib
 packaging==21.3
     # via ansible-core
@@ -49,7 +49,7 @@ pyasn1-modules==0.2.8
     # via google-auth
 pycparser==2.21
     # via cffi
-pyopenssl==22.0.0
+pyopenssl==22.1.0
     # via -r requirements.in
 pyparsing==3.0.9
     # via packaging
@@ -60,7 +60,7 @@ pyyaml==6.0
     #   -r requirements.in
     #   ansible-core
     #   kubernetes
-requests==2.28.0
+requests==2.28.1
     # via
     #   kubernetes
     #   requests-oauthlib
@@ -68,18 +68,18 @@ requests-oauthlib==1.3.1
     # via kubernetes
 resolvelib==0.8.1
     # via ansible-core
-rsa==4.8
+rsa==4.9
     # via google-auth
 six==1.16.0
     # via
     #   google-auth
     #   kubernetes
     #   python-dateutil
-urllib3==1.26.9
+urllib3==1.26.12
     # via
     #   kubernetes
     #   requests
-websocket-client==1.3.3
+websocket-client==1.4.1
     # via kubernetes
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/deploy/scripts/build.py
+++ b/deploy/scripts/build.py
@@ -121,7 +121,7 @@ project_dir = Path(__file__).resolve().parent.parent.parent
 """Absolute path to the checked out repository."""
 
 
-# Pre-build functions for the different build components
+# Pre-build/post-build functions for the different build components
 def build_semantic_domains() -> None:
     """Create the semantic domain definition files."""
     source_dir = project_dir / "deploy" / "scripts" / "semantic_domains" / "xml"

--- a/maintenance/requirements.txt
+++ b/maintenance/requirements.txt
@@ -16,7 +16,7 @@ charset-normalizer==2.1.1
     # via requests
 cryptography==38.0.1
     # via pyopenssl
-google-auth==2.11.1
+google-auth==2.12.0
     # via kubernetes
 humanfriendly==10.0
     # via -r requirements.in


### PR DESCRIPTION
Add a role the Ansible scripts that add hardware monitoring, specifically, Temperature, to the setup of the NUC devices.

The monitoring values are not displayed in _The Combine_ User Interface.  They are added to aid diagnosis of problems in the field.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1745)
<!-- Reviewable:end -->
