### PR TITLE
Update migration script

### DIFF
--- a/database/init/update-semantic-domains.sh
+++ b/database/init/update-semantic-domains.sh
@@ -1,4 +1,4 @@
 #! /usr/bin/bash
 
-mongoimport -d CombineDatabase -c SemanticDomainTree /data/semantic-domains/tree.json --mode=upsert --upsertFields=id,guid,lang
-mongoimport -d CombineDatabase -c SemanticDomains /data/semantic-domains/nodes.json --mode=upsert --upsertFields=id,guid,lang
+mongoimport -d CombineDatabase -c SemanticDomainTree /data/semantic-domains/tree.json --mode=merge --upsertFields=id,guid,lang
+mongoimport -d CombineDatabase -c SemanticDomains /data/semantic-domains/nodes.json --mode=merge --upsertFields=id,guid,lang


### PR DESCRIPTION
Update database migration script for updating `SemanticDomains` field of the `senses` in the `FrontierCollection` and the `WordsCollection`.

- Adds `_id` field for the MongoDB ObjectId for the document in the `SemanticDomains` collection.  If the semantic domain id and name do not match any of the domains in the collection, `null` is used;
- Changes the `guid` field from a `UUID` type to `str` type to match the `SemanticDomains` collection and the data model.
- Reverts the change to the script to update the `SemanticDomains` collection to use the `merge` mode instead of `upsert` so that only changed documents are updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1749)
<!-- Reviewable:end -->
