### PR TITLE
Correct reCAPTCHA key for thecombine.localhost

### DIFF
--- a/deploy/scripts/setup_files/profiles/dev.yaml
+++ b/deploy/scripts/setup_files/profiles/dev.yaml
@@ -12,7 +12,7 @@ charts:
 
     frontend:
       configCaptchaRequired: "true"
-      configCaptchaSiteKey: "6LdBKdIeAAAAAD6hEBDPa0zUMitfVfQvpkgjehNV"
+      configCaptchaSiteKey: "6Le6BL0UAAAAAMjSs1nINeB5hqDZ4m3mMg3k67x3"
 
     global:
       imageRegistry: ""


### PR DESCRIPTION
This is a residual from PR #1739.

PR #1739 changed the server name for local builds from `thecombine.local` to `thecombine.localhost`.  This change updates the reCAPTCHA site key to match the `localhost` domain instead of `local`.

The server name had been changed to `thecombine.localhost` because the Chrome and Firefox browsers redirect traffic addressed to `*.localhost` to the loopback address, `127.0.0.1`.  By making the default server name for development `thecombine.localhost`, developers do not need to edit their hosts file to specify that `thecombine.local` is at the loopback address.