### PR TITLE
update installation of apt key for docker

### DIFF
--- a/deploy/ansible/roles/docker_install/tasks/main.yml
+++ b/deploy/ansible/roles/docker_install/tasks/main.yml
@@ -24,19 +24,27 @@
       - apt-transport-https
       - ca-certificates
       - curl
-      - gnupg-agent
-      - software-properties-common
+      - gnupg
+      - lsb-release
     state: present
   notify: reboot target
 
+- name: Create keyring directory
+  file:
+    path: /etc/apt/keyrings
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
 - name: Install Docker apt key
-  apt_key:
-    url: https://download.docker.com/linux/ubuntu/gpg
-    state: present
+  shell:
+    cmd: "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg"
+    creates: /etc/apt/keyrings/docker.gpg
 
 - name: Add Docker repository
   apt_repository:
-    repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+    repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
     state: present
     filename: docker
 


### PR DESCRIPTION
The Ansible module, `apt_key` and the `apt-key` keyring management system are deprecated.  These changes update the installation of `docker` to use the method recommended in the DEPRECATION section of the `apt-key(8)` man page.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/thecombine/1754)
<!-- Reviewable:end -->
