### PR TITLE
Change Harden Runner actions from audit to block

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -108,7 +108,7 @@ jobs:
       # For subfolders, currently a full checkout is required.
       # See: https://github.com/marketplace/actions/build-and-push-docker-images#path-context
       - name: Harden Runner
-        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5
+        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
           disable-sudo: true
           egress-policy: block

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -118,7 +118,6 @@ jobs:
             deb.debian.org:80
             github.com:443
             mcr.microsoft.com:443
-            mcr.microsoft.com/dotnet/sdk:443
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           fetch-depth: 0

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -111,7 +111,7 @@ jobs:
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5
         with:
           disable-sudo: true
-          egress-policy: block
+          egress-policy: audit
           allowed-endpoints: >
             api.nuget.org:443
             dc.services.visualstudio.com:443

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -118,8 +118,10 @@ jobs:
             deb.debian.org:80
             github.com:443
             mcr.microsoft.com:443
-            centralus.data.mcr.microsoft.com:443
             eastus.data.mcr.microsoft.com:443
+            centralus.data.mcr.microsoft.com:443
+            westcentralus.data.mcr.microsoft.com:443
+            westus.data.mcr.microsoft.com:443
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           fetch-depth: 0

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -19,8 +19,17 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            aka.ms:443
+            api.nuget.org:443
+            codecov.io:443
+            dc.services.visualstudio.com:443
+            dotnetcli.azureedge.net:443
+            github.com:443
+            storage.googleapis.com:443
+            uploader.codecov.io:443
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
       - name: Setup dotnet
         uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
@@ -59,7 +68,15 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            aka.ms:443
+            api.github.com:443
+            api.nuget.org:443
+            dc.services.visualstudio.com:443
+            dotnetcli.azureedge.net:443
+            github.com:443
 
       - name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
@@ -91,10 +108,16 @@ jobs:
       # For subfolders, currently a full checkout is required.
       # See: https://github.com/marketplace/actions/build-and-push-docker-images#path-context
       - name: Harden Runner
-        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
+        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.nuget.org:443
+            dc.services.visualstudio.com:443
+            deb.debian.org:80
+            github.com:443
+            mcr.microsoft.com:443
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           fetch-depth: 0

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -119,6 +119,7 @@ jobs:
             github.com:443
             mcr.microsoft.com:443
             centralus.data.mcr.microsoft.com:443
+            eastus.data.mcr.microsoft.com:443
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           fetch-depth: 0

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -118,6 +118,7 @@ jobs:
             deb.debian.org:80
             github.com:443
             mcr.microsoft.com:443
+            centralus.data.mcr.microsoft.com:443
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           fetch-depth: 0

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -118,6 +118,8 @@ jobs:
             deb.debian.org:80
             github.com:443
             mcr.microsoft.com:443
+            mcr.microsoft.com/dotnet/sdk:443
+            mcr.microsoft.com/dotnet/aspnet:443
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           fetch-depth: 0

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -119,7 +119,6 @@ jobs:
             github.com:443
             mcr.microsoft.com:443
             mcr.microsoft.com/dotnet/sdk:443
-            mcr.microsoft.com/dotnet/aspnet:443
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           fetch-depth: 0

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -111,7 +111,7 @@ jobs:
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
           allowed-endpoints: >
             api.nuget.org:443
             dc.services.visualstudio.com:443

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["csharp", "javascript", "python"]
+        language:
+          - name: csharp
+            endpoints: >
+              api.github.com:443
+              api.nuget.org:443
+              dc.services.visualstudio.com:443
+              github.com:443
+          - name: javascript
+            endpoints: >
+              api.github.com:443
+              github.com:443
+          - name: python
+            endpoints: >
+              api.github.com:443
+              files.pythonhosted.org:443
+              github.com:443
+              pypi.org:443
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Use only 'java' to analyze code written in Java, Kotlin or both
         # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
@@ -45,8 +61,9 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: ${{ matrix.language.endpoints }}
       - name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
 
@@ -54,7 +71,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@959cbb7472c4d4ad70cdfe6f4976053fe48ab394 # v2.1.37
         with:
-          languages: ${{ matrix.language }}
+          languages: ${{ matrix.language.name }}
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.
@@ -80,4 +97,4 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@959cbb7472c4d4ad70cdfe6f4976053fe48ab394 # v2.1.37
         with:
-          category: "/language:${{matrix.language}}"
+          category: "/language:${{matrix.language.name}}"

--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -34,10 +34,11 @@ jobs:
             dc.services.visualstudio.com:443
             deb.debian.org:80
             mcr.microsoft.com:443
+            centralus.data.mcr.microsoft.com:443
+            eastus.data.mcr.microsoft.com:443
             archive.ubuntu.com:80
             security.ubuntu.com:80
             api.github.com:443
-
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           fetch-depth: 0

--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -11,49 +11,31 @@ jobs:
         component:
           - name: frontend
             endpoints: >
-              ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
-              api.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
-              auth.docker.io:443
               files.pythonhosted.org:443
-              github.com:443
               production.cloudflare.docker.com:443
               pypi.org:443
               registry-1.docker.io:443
               registry.npmjs.org:443
-              sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
           - name: backend
             endpoints: >
-              ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
-              api.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
               api.nuget.org:443
               dc.services.visualstudio.com:443
               deb.debian.org:80
-              github.com:443
               mcr.microsoft.com:443
-              sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
           - name: maintenance
             endpoints: >
-              ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
-              api.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
               api.github.com:443
               archive.ubuntu.com:80
-              auth.docker.io:443
               files.pythonhosted.org:443
-              github.com:443
               production.cloudflare.docker.com:443
               pypi.org:443
               registry-1.docker.io:443
               security.ubuntu.com:80
-              sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
           - name: database
             endpoints: >
-              ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
-              api.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
-              auth.docker.io:443
-              github.com:443
               production.cloudflare.docker.com:443
               registry-1.docker.io:443
-              sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
+
     runs-on: ubuntu-latest
     outputs:
       image_tag: ${{ steps.build_combine.outputs.image_tag }}
@@ -63,8 +45,13 @@ jobs:
         with:
           disable-sudo: true
           egress-policy: block
-          allowed-endpoints: ${{ matrix.component.endpoint}}
-
+          allowed-endpoints: >
+            ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
+            api.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
+            auth.docker.io:443
+            github.com:443
+            ${{ matrix.component.endpoint}}
+            sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           fetch-depth: 0

--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -18,25 +18,25 @@ jobs:
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
           allowed-endpoints: >
             ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
             api.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
-            api.github.com:443
-            api.nuget.org:443
-            archive.ubuntu.com:80
             auth.docker.io:443
-            dc.services.visualstudio.com:443
-            deb.debian.org:80
             files.pythonhosted.org:443
             github.com:443
-            mcr.microsoft.com:443
             production.cloudflare.docker.com:443
             pypi.org:443
             registry-1.docker.io:443
             registry.npmjs.org:443
-            security.ubuntu.com:80
             sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
+            api.nuget.org:443
+            dc.services.visualstudio.com:443
+            deb.debian.org:80
+            mcr.microsoft.com:443
+            archive.ubuntu.com:80
+            security.ubuntu.com:80
+            api.github.com:443
 
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:

--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -15,7 +15,7 @@ jobs:
       image_tag: ${{ steps.build_combine.outputs.image_tag }}
     steps:
       - name: Harden Runner (Frontend)
-        if: matrix.component == frontend
+        if: matrix.component == "frontend"
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
           disable-sudo: true
@@ -33,7 +33,7 @@ jobs:
             registry.npmjs.org:443
             sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
       - name: Harden Runner (Backend)
-        if: matrix.component == backend
+        if: matrix.component == "backend"
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
           disable-sudo: true
@@ -50,7 +50,7 @@ jobs:
             mcr.microsoft.com:443
             sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
       - name: Harden Runner (Database)
-        if: matrix.component == database
+        if: matrix.component == "database"
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
           disable-sudo: true
@@ -65,7 +65,7 @@ jobs:
             registry-1.docker.io:443
             sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
       - name: Harden Runner (Maintenance)
-        if: matrix.component == maintenance
+        if: matrix.component == "maintenance"
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
           disable-sudo: true

--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -50,7 +50,7 @@ jobs:
             api.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
             auth.docker.io:443
             github.com:443
-            ${{ matrix.component.endpoint}}
+            ${{ matrix.component.endpoints }}
             sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:

--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -14,8 +14,7 @@ jobs:
     outputs:
       image_tag: ${{ steps.build_combine.outputs.image_tag }}
     steps:
-      - name: Harden Runner (Frontend)
-        if: matrix.component == "frontend"
+      - name: Harden Runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
           disable-sudo: true
@@ -23,64 +22,19 @@ jobs:
           allowed-endpoints: >
             ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
             api.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
-            auth.docker.io:443
             api.github.com:443
-            github.com:443
+            api.nuget.org:443
+            archive.ubuntu.com:80
+            auth.docker.io:443
+            dc.services.visualstudio.com:443
+            deb.debian.org:80
             files.pythonhosted.org:443
+            github.com:443
+            mcr.microsoft.com:443
             production.cloudflare.docker.com:443
             pypi.org:443
             registry-1.docker.io:443
             registry.npmjs.org:443
-            sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
-      - name: Harden Runner (Backend)
-        if: matrix.component == "backend"
-        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
-            api.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
-            auth.docker.io:443
-            api.github.com:443
-            github.com:443
-            api.nuget.org:443
-            dc.services.visualstudio.com:443
-            deb.debian.org:80
-            mcr.microsoft.com:443
-            sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
-      - name: Harden Runner (Database)
-        if: matrix.component == "database"
-        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
-            api.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
-            auth.docker.io:443
-            api.github.com:443
-            github.com:443
-            production.cloudflare.docker.com:443
-            registry-1.docker.io:443
-            sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
-      - name: Harden Runner (Maintenance)
-        if: matrix.component == "maintenance"
-        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
-            api.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
-            auth.docker.io:443
-            api.github.com:443
-            github.com:443
-            archive.ubuntu.com:80
-            files.pythonhosted.org:443
-            production.cloudflare.docker.com:443
-            pypi.org:443
-            registry-1.docker.io:443
             security.ubuntu.com:80
             sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
 

--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -15,7 +15,7 @@ jobs:
       image_tag: ${{ steps.build_combine.outputs.image_tag }}
     steps:
       - name: Harden Runner (Frontend)
-        if: ${{ matrix.component == "frontend"}}
+        if: matrix.component == frontend
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
           disable-sudo: true
@@ -33,7 +33,7 @@ jobs:
             registry.npmjs.org:443
             sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
       - name: Harden Runner (Backend)
-        if: ${{ matrix.component == "backend"}}
+        if: matrix.component == backend
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
           disable-sudo: true
@@ -50,7 +50,7 @@ jobs:
             mcr.microsoft.com:443
             sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
       - name: Harden Runner (Database)
-        if: ${{ matrix.component == "database"}}
+        if: matrix.component == database
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
           disable-sudo: true
@@ -65,7 +65,7 @@ jobs:
             registry-1.docker.io:443
             sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
       - name: Harden Runner (Maintenance)
-        if: ${{ matrix.component == "maintenance"}}
+        if: matrix.component == maintenance
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
           disable-sudo: true

--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -18,7 +18,7 @@ jobs:
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
           disable-sudo: true
-          egress-policy: block
+          egress-policy: audit
           allowed-endpoints: >
             ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
             api.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443

--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -2,13 +2,58 @@ name: "Deploy Update to QA Server"
 
 on:
   push:
-    branches: [master]
+    branches: [master, harden-runners]
 
 jobs:
   build:
     strategy:
       matrix:
-        component: [frontend, backend, maintenance, database]
+        component:
+          - name: frontend
+            endpoints: >
+              ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
+              api.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
+              auth.docker.io:443
+              files.pythonhosted.org:443
+              github.com:443
+              production.cloudflare.docker.com:443
+              pypi.org:443
+              registry-1.docker.io:443
+              registry.npmjs.org:443
+              sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
+          - name: backend
+            endpoints: >
+              ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
+              api.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
+              api.nuget.org:443
+              dc.services.visualstudio.com:443
+              deb.debian.org:80
+              github.com:443
+              mcr.microsoft.com:443
+              sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
+          - name: maintenance
+            endpoints: >
+              ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
+              api.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
+              api.github.com:443
+              archive.ubuntu.com:80
+              auth.docker.io:443
+              files.pythonhosted.org:443
+              github.com:443
+              production.cloudflare.docker.com:443
+              pypi.org:443
+              registry-1.docker.io:443
+              security.ubuntu.com:80
+              sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
+          - name: database
+            endpoints: >
+              ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
+              api.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
+              auth.docker.io:443
+              github.com:443
+              production.cloudflare.docker.com:443
+              registry-1.docker.io:443
+              sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
     runs-on: ubuntu-latest
     outputs:
       image_tag: ${{ steps.build_combine.outputs.image_tag }}
@@ -16,7 +61,9 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: ${{ matrix.component.endpoint}}
 
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
@@ -29,7 +76,7 @@ jobs:
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
-          build_component: ${{ matrix.component }}
+          build_component: ${{ matrix.component.name }}
   clean_ecr_repo:
     needs: build
     env:
@@ -40,8 +87,12 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
+            github.com:443
+            sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@ada05fa00eac74e104ada01f6aea80724f57afba # v1-node16
@@ -54,12 +105,8 @@ jobs:
   deploy_update:
     needs: build
     runs-on: [self-hosted, thecombine]
+    if: ${{ github.ref_name == 'master' }}
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
-        with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
       - name: Deploy The Combine Update
         uses: ./.github/actions/combine-deploy-update

--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -34,8 +34,10 @@ jobs:
             dc.services.visualstudio.com:443
             deb.debian.org:80
             mcr.microsoft.com:443
-            centralus.data.mcr.microsoft.com:443
             eastus.data.mcr.microsoft.com:443
+            centralus.data.mcr.microsoft.com:443
+            westcentralus.data.mcr.microsoft.com:443
+            westus.data.mcr.microsoft.com:443
             archive.ubuntu.com:80
             security.ubuntu.com:80
             api.github.com:443

--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -24,7 +24,6 @@ jobs:
               mcr.microsoft.com:443
           - name: maintenance
             endpoints: >
-              api.github.com:443
               archive.ubuntu.com:80
               files.pythonhosted.org:443
               production.cloudflare.docker.com:443
@@ -49,6 +48,7 @@ jobs:
             ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
             api.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
             auth.docker.io:443
+            api.github.com:443
             github.com:443
             ${{ matrix.component.endpoints }}
             sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443

--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -8,38 +8,14 @@ jobs:
   build:
     strategy:
       matrix:
-        component:
-          - name: frontend
-            endpoints: >
-              files.pythonhosted.org:443
-              production.cloudflare.docker.com:443
-              pypi.org:443
-              registry-1.docker.io:443
-              registry.npmjs.org:443
-          - name: backend
-            endpoints: >
-              api.nuget.org:443
-              dc.services.visualstudio.com:443
-              deb.debian.org:80
-              mcr.microsoft.com:443
-          - name: maintenance
-            endpoints: >
-              archive.ubuntu.com:80
-              files.pythonhosted.org:443
-              production.cloudflare.docker.com:443
-              pypi.org:443
-              registry-1.docker.io:443
-              security.ubuntu.com:80
-          - name: database
-            endpoints: >
-              production.cloudflare.docker.com:443
-              registry-1.docker.io:443
+        component: [frontend, backend, maintenance, database]
 
     runs-on: ubuntu-latest
     outputs:
       image_tag: ${{ steps.build_combine.outputs.image_tag }}
     steps:
-      - name: Harden Runner
+      - name: Harden Runner (Frontend)
+        if: ${{ matrix.component == "frontend"}}
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
           disable-sudo: true
@@ -50,8 +26,64 @@ jobs:
             auth.docker.io:443
             api.github.com:443
             github.com:443
-            ${{ matrix.component.endpoints }}
+            files.pythonhosted.org:443
+            production.cloudflare.docker.com:443
+            pypi.org:443
+            registry-1.docker.io:443
+            registry.npmjs.org:443
             sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
+      - name: Harden Runner (Backend)
+        if: ${{ matrix.component == "backend"}}
+        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
+            api.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
+            auth.docker.io:443
+            api.github.com:443
+            github.com:443
+            api.nuget.org:443
+            dc.services.visualstudio.com:443
+            deb.debian.org:80
+            mcr.microsoft.com:443
+            sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
+      - name: Harden Runner (Database)
+        if: ${{ matrix.component == "database"}}
+        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
+            api.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
+            auth.docker.io:443
+            api.github.com:443
+            github.com:443
+            production.cloudflare.docker.com:443
+            registry-1.docker.io:443
+            sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
+      - name: Harden Runner (Maintenance)
+        if: ${{ matrix.component == "maintenance"}}
+        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
+            api.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
+            auth.docker.io:443
+            api.github.com:443
+            github.com:443
+            archive.ubuntu.com:80
+            files.pythonhosted.org:443
+            production.cloudflare.docker.com:443
+            pypi.org:443
+            registry-1.docker.io:443
+            security.ubuntu.com:80
+            sts.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
+
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           fetch-depth: 0
@@ -63,7 +95,7 @@ jobs:
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
-          build_component: ${{ matrix.component.name }}
+          build_component: ${{ matrix.component }}
   clean_ecr_repo:
     needs: build
     env:

--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -2,7 +2,7 @@ name: "Deploy Update to QA Server"
 
 on:
   push:
-    branches: [master, harden-runners]
+    branches: [master]
 
 jobs:
   build:
@@ -79,7 +79,6 @@ jobs:
   deploy_update:
     needs: build
     runs-on: [self-hosted, thecombine]
-    if: ${{ github.ref_name == 'master' }}
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
       - name: Deploy The Combine Update

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -38,11 +38,6 @@ jobs:
     needs: build
     runs-on: [self-hosted, thecombine]
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
-        with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           fetch-depth: 0

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -63,6 +63,7 @@ jobs:
           allowed-endpoints: >
             github.com:443
             registry-1.docker.io:443
+            auth.docker.io:443
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           fetch-depth: 0

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -61,9 +61,13 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
-            github.com:443
-            registry-1.docker.io:443
             auth.docker.io:443
+            files.pythonhosted.org:443
+            github.com:443
+            production.cloudflare.docker.com:443
+            pypi.org:443
+            registry-1.docker.io:443
+            registry.npmjs.org:443
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           fetch-depth: 0

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -61,12 +61,8 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
-            files.pythonhosted.org:443
             github.com:443
-            production.cloudflare.docker.com:443
-            pypi.org:443
             registry-1.docker.io:443
-            registry.npmjs.org:443
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           fetch-depth: 0

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -17,7 +17,7 @@ jobs:
         node-version: [16]
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5
+        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
           disable-sudo: true
           egress-policy: block
@@ -56,7 +56,7 @@ jobs:
     if: ${{ github.event.type }} == "PullRequest"
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5
+        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
           disable-sudo: true
           egress-policy: block

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -17,10 +17,16 @@ jobs:
         node-version: [16]
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
+        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            codecov.io:443
+            github.com:443
+            registry.npmjs.org:443
+            storage.googleapis.com:443
+            uploader.codecov.io:443
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
@@ -50,10 +56,17 @@ jobs:
     if: ${{ github.event.type }} == "PullRequest"
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
+        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            files.pythonhosted.org:443
+            github.com:443
+            production.cloudflare.docker.com:443
+            pypi.org:443
+            registry-1.docker.io:443
+            registry.npmjs.org:443
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           fetch-depth: 0

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -15,7 +15,7 @@ jobs:
       # For subfolders, currently a full checkout is required.
       # See: https://github.com/marketplace/actions/build-and-push-docker-images#path-context
       - name: Harden Runner
-        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5
+        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
           disable-sudo: true
           egress-policy: block

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -15,10 +15,19 @@ jobs:
       # For subfolders, currently a full checkout is required.
       # See: https://github.com/marketplace/actions/build-and-push-docker-images#path-context
       - name: Harden Runner
-        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
+        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            archive.ubuntu.com:80
+            auth.docker.io:443
+            files.pythonhosted.org:443
+            github.com:443
+            production.cloudflare.docker.com:443
+            pypi.org:443
+            registry-1.docker.io:443
+            security.ubuntu.com:80
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           fetch-depth: 0

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10"]
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5
+        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
           disable-sudo: true
           egress-policy: block

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,10 +17,14 @@ jobs:
         python-version: ["3.8", "3.9", "3.10"]
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
+        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            files.pythonhosted.org:443
+            github.com:443
+            pypi.org:443
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912 # v4.4.0

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5
+        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
           disable-sudo: true
           egress-policy: block

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -32,10 +32,19 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
+        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            api.osv.dev:443
+            bestpractices.coreinfrastructure.org:443
+            fulcio.sigstore.dev:443
+            github.com:443
+            index.docker.io:443
+            mcr.microsoft.com:443
+            sigstore-tuf-root.storage.googleapis.com:443
       - name: "Checkout code"
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:


### PR DESCRIPTION
Update the GitHub actions for _The Combine_ update the `step-security/harden-runner` actions as follows:

- change the `egress-policy` from `audit` to `block`;
- set `disable-sudo` to `true`;
- add the `allowed-endpoints` recommended by the StepSecurity audit runs;
- remove the `step-security/harden-runner` step for actions run on a self-hosted runner (self-hosted runners are not supported by `harden-runner`)

Note:
- The `harden-runner` action logs the following error during the _Post Harden Runner_ phase:
   ```
   Error: StepSecurity Harden Runner: Overwrite detected for /etc/systemd/resolved.conf
   ```
   
   This is a known issue.  It does not cause the step to fail and can be ignored.  See the discussion in [step-security/harden-runner](https://github.com/step-security/harden-runner/discussions/230)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/1813)
<!-- Reviewable:end -->
