### PR TITLE
Fix case-sensitive of Find a domain

### DIFF
--- a/Backend/Repositories/SemanticDomainRepository.cs
+++ b/Backend/Repositories/SemanticDomainRepository.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
 using MongoDB.Driver;
+using MongoDB.Bson;
 
 namespace BackendFramework.Repositories
 {
@@ -36,7 +37,7 @@ namespace BackendFramework.Repositories
         {
             var filterDef = new FilterDefinitionBuilder<SemanticDomainTreeNode>();
             var filter = filterDef.And(
-                filterDef.Eq(x => x.Name, name),
+                filterDef.Regex(x => x.Name, new BsonRegularExpression("/^" + name + "$/i")),
                 filterDef.Eq(x => x.Lang, lang));
             var domain = await _context.SemanticDomains.FindAsync(filter: filter);
             try

--- a/src/components/TreeView/TreeSearch.tsx
+++ b/src/components/TreeView/TreeSearch.tsx
@@ -103,7 +103,7 @@ export function useTreeSearch(props: TreeSearchProps): TreeSearchState {
       if (!isNaN(parseInt(input))) {
         domain = await getSemanticDomainTreeNode(input, lang);
       } else {
-        domain = await searchDomainByName(handleInputFormat(input));
+        domain = await searchDomainByName(input);
       }
       if (domain) {
         animateSuccessfulSearch(domain, event);
@@ -113,12 +113,6 @@ export function useTreeSearch(props: TreeSearchProps): TreeSearchState {
       // Did not find a domain through either numerical or textual search.
       setSearchError(true);
     }
-  }
-
-  // return string converted by input string, for backend searching
-  function handleInputFormat(input: string): string {
-    //String format: capitalize the first letter, lowercase for other letters
-    return input.charAt(0).toUpperCase() + input.slice(1).toLowerCase();
   }
 
   // Change the input on typing

--- a/src/components/TreeView/TreeSearch.tsx
+++ b/src/components/TreeView/TreeSearch.tsx
@@ -103,7 +103,7 @@ export function useTreeSearch(props: TreeSearchProps): TreeSearchState {
       if (!isNaN(parseInt(input))) {
         domain = await getSemanticDomainTreeNode(input, lang);
       } else {
-        domain = await searchDomainByName(input);
+        domain = await searchDomainByName(handleInputFormat(input));
       }
       if (domain) {
         animateSuccessfulSearch(domain, event);
@@ -113,6 +113,12 @@ export function useTreeSearch(props: TreeSearchProps): TreeSearchState {
       // Did not find a domain through either numerical or textual search.
       setSearchError(true);
     }
+  }
+
+  // return string converted by input string, for backend searching
+  function handleInputFormat(input: string): string {
+    //String format: capitalize the first letter, lowercase for other letters
+    return input.charAt(0).toUpperCase() + input.slice(1).toLowerCase();
   }
 
   // Change the input on typing


### PR DESCRIPTION
“Find a domain” search field at top of the domain tree should not be case-sensitive.
Add method to convert input string, then passing correct format string into the searching method

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/1814)
<!-- Reviewable:end -->
