### PR TITLE
Refactor asyncronous handling of merge list

### DIFF
--- a/Backend.Tests/Services/MergeServiceTests.cs
+++ b/Backend.Tests/Services/MergeServiceTests.cs
@@ -112,16 +112,16 @@ namespace Backend.Tests.Services
         [Test]
         public void MergeWordsMultipleTest()
         {
-            var mergeWordsA = new MergeWords { Parent = Util.RandomWord(ProjId) };
-            var mergeWordsB = new MergeWords { Parent = Util.RandomWord(ProjId) };
-            var mergeWordsList = new List<MergeWords> { mergeWordsA, mergeWordsB };
+            int wordCount = 100;
+            var randWords = Util.RandomWordList(wordCount, ProjId);
+            var mergeWordsList = randWords.Select(word => new MergeWords { Parent = word }).ToList();
             var newWords = _mergeService.Merge(ProjId, mergeWordsList).Result;
 
-            Assert.That(newWords, Has.Count.EqualTo(2));
+            Assert.That(newWords, Has.Count.EqualTo(wordCount));
             Assert.AreNotEqual(newWords.First().Id, newWords.Last().Id);
 
             var frontier = _wordRepo.GetFrontier(ProjId).Result;
-            Assert.That(frontier, Has.Count.EqualTo(2));
+            Assert.That(frontier, Has.Count.EqualTo(wordCount));
             Assert.AreNotEqual(frontier.First().Id, frontier.Last().Id);
             Assert.Contains(frontier.First(), newWords);
             Assert.Contains(frontier.Last(), newWords);

--- a/Backend.Tests/Util.cs
+++ b/Backend.Tests/Util.cs
@@ -35,9 +35,11 @@ namespace Backend.Tests
         public static List<Word> RandomWordList(int length, string? projId = null)
         {
             var wordList = new List<Word>();
-            foreach (var _ in Range(0, length))
+            foreach (var i in Range(0, length))
             {
-                wordList.Add(RandomWord(projId));
+                var word = RandomWord(projId);
+                word.Vernacular += i;
+                wordList.Add(word);
             }
             return wordList;
         }

--- a/Backend/Services/MergeService.cs
+++ b/Backend/Services/MergeService.cs
@@ -72,10 +72,8 @@ namespace BackendFramework.Services
         /// <returns> List of new words added. </returns>
         public async Task<List<Word>> Merge(string projectId, List<MergeWords> mergeWordsList)
         {
-            var newWords = new List<Word>();
-            await Task.WhenAll(mergeWordsList.Where(m => !m.DeleteOnly)
-                                             .Select(m => MergePrepParent(projectId, m)
-                                             .ContinueWith(task => newWords.Add(task.Result))));
+            var keptWords = mergeWordsList.Where(m => !m.DeleteOnly);
+            var newWords = keptWords.Select(m => MergePrepParent(projectId, m).Result).ToList();
             await Task.WhenAll(mergeWordsList.Select(m => MergeDeleteChildren(projectId, m)));
             return await _wordRepo.Create(newWords);
         }


### PR DESCRIPTION
Resolves #1818 

Without these changes to `Backend/Services/MergeServices.cs`, the backend test consistently fails when `wordCount=10000`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/1819)
<!-- Reviewable:end -->
