### PR TITLE
Fix sha256 sum for aspnet-core image

### DIFF
--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -11,7 +11,7 @@ COPY . ./
 RUN dotnet publish -c Release -o build
 
 # Build runtime image.
-FROM bitnami/aspnet-core@sha256:1fa0ee4f642f484066b236a4cb8629cafbbc21c485939b0da52f6d0e9b36f3f7
+FROM bitnami/aspnet-core:6@sha256:bc4961b75bd2ff35ac89f891709db7faf6bda017873ce6d04a22110813df9a44
 
 ENV ASPNETCORE_URLS=http://+:5000
 ENV COMBINE_IS_IN_CONTAINER=1


### PR DESCRIPTION
When pinning the `aspnet-core` image to a specific commit, the sha256 sum that was used to build the Backend was incorrect.  It was the sha256 sum for `aspnet-core:7` instead of `aspnet-core:6`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/1828)
<!-- Reviewable:end -->
