### PR TITLE
Rollback axios package to 0.27.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@matt-block/react-recaptcha-v2": "^1.0.6",
         "@microsoft/signalr": "^6.0.7",
         "@segment/analytics-next": "^1.40.0",
-        "axios": "^1.3.3",
+        "axios": "^0.27.2",
         "crypto-js": "^4.1.1",
         "http-status-codes": "^2.1.4",
         "i18next": "^21.6.16",
@@ -9314,13 +9314,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.3.tgz",
-      "integrity": "sha512-eYq77dYIFS77AQlhzEL937yUBSepBfPIe8FcgEDN35vMNZKMrs81pgnyrQpwfy4NF4b4XWX1Zgx7yX+25w8QJA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/axios/node_modules/form-data": {
@@ -18901,11 +18900,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",
@@ -28817,13 +28811,12 @@
       "dev": true
     },
     "axios": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.3.tgz",
-      "integrity": "sha512-eYq77dYIFS77AQlhzEL937yUBSepBfPIe8FcgEDN35vMNZKMrs81pgnyrQpwfy4NF4b4XWX1Zgx7yX+25w8QJA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "requires": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       },
       "dependencies": {
         "form-data": {
@@ -35859,11 +35852,6 @@
           "dev": true
         }
       }
-    },
-    "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@matt-block/react-recaptcha-v2": "^1.0.6",
     "@microsoft/signalr": "^6.0.7",
     "@segment/analytics-next": "^1.40.0",
-    "axios": "^1.3.3",
+    "axios": "^0.27.2",
     "http-status-codes": "^2.1.4",
     "i18next": "^21.6.16",
     "i18next-browser-languagedetector": "^6.1.4",
@@ -180,7 +180,9 @@
     }
   },
   "jest": {
-    "transformIgnorePatterns": ["/node_modules/(!${axios})"]
+    "transformIgnorePatterns": [
+      "/node_modules/(!${axios})"
+    ]
   },
   "prettier": {
     "overrides": [


### PR DESCRIPTION
Updating the `axios` npm package to 1.x.x breaks the audio recording functionality.  When attempting to upload an audio recording, a _400-Bad Request_ error is returned.  It says it is a null file.

This PR rolls back the version of the `axios` package to the latest working version.

Issue #1930 created.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/1931)
<!-- Reviewable:end -->
