### PR TITLE
Fix the delete icon causing the backend not found

### DIFF
--- a/src/components/DataEntry/DataEntryTable/DataEntryTable.tsx
+++ b/src/components/DataEntry/DataEntryTable/DataEntryTable.tsx
@@ -176,7 +176,6 @@ export class DataEntryTable extends React.Component<
     }
 
     const word = await backend.getWord(wordId);
-    await backend.updateWord(word);
 
     this.addToDisplay({ word, senseIndex: 0 }, insertIndex);
   }


### PR DESCRIPTION
While clicking the delete icon when entering words 
Frontend’s word ID did not match the FrontierCollection 
Fix by removing the Incorrect update

The problem is When updateWord API called both word's in the  FrontierCollection and WordsCollection are updated, However, the frontend copy is NOT updated. So that when the delete icon is clicked deleteWord API is not able to find the word by the wrong _id. 
The updateWord API is Not necessary at this point

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/1943)
<!-- Reviewable:end -->
