### PR TITLE
Store and convert WebM/PCM recordings as WAV files

### DIFF
--- a/.github/actions/combine-build/action.yml
+++ b/.github/actions/combine-build/action.yml
@@ -55,15 +55,11 @@ runs:
         password: ${{ inputs.aws_secret_access_key }}
 
     - name: Build The Combine
+      uses: FedericoCarboni/setup-ffmpeg@v2
       run: >
         deploy/scripts/build.py
+        --ffmpeg -i input.avi output.mkv
         --components ${{ inputs.build_component }}
         --tag ${{ env.IMAGE_TAG }}
         --repo ${{ inputs.image_registry }}${{ inputs.image_registry_alias}}
       shell: bash
-
-    - name: Setup FFmpeg
-      uses: FedericoCarboni/setup-ffmpeg@v2
-      id: setup-ffmpeg
-      run: ffmpeg -i input.avi output.mkv
-

--- a/.github/actions/combine-build/action.yml
+++ b/.github/actions/combine-build/action.yml
@@ -61,3 +61,9 @@ runs:
         --tag ${{ env.IMAGE_TAG }}
         --repo ${{ inputs.image_registry }}${{ inputs.image_registry_alias}}
       shell: bash
+
+    - name: Setup FFmpeg
+      uses: FedericoCarboni/setup-ffmpeg@v2
+      id: setup-ffmpeg
+      run: ffmpeg -i input.avi output.mkv
+

--- a/Backend/BackendFramework.csproj
+++ b/Backend/BackendFramework.csproj
@@ -36,5 +36,7 @@
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="SIL.WritingSystems" Version="12.0.0" />
+    <PackageReference Include="Xabe.FFmpeg" Version="5.2.6" />
+    <PackageReference Include="Xabe.FFmpeg.Downloader" Version="5.2.6" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR fixes [Dictionary view can't play audio files from The Combine (.webm)
](https://jira.sil.org/browse/LT-20864)

Currently, the WebM files recorded with The Combine containing PCM audio are not compatible with Geckofx and FLEx Dictionary View.

Changing the WebM files to WAV files using FFmpeg produces files that are playable in all views.

WebM containers with _Opus_ codec are also playable in FLEx Dictionary View; a simple codec change would also fix the problem. But, to preserve the current lossless PCM-encoded recording, we can record in WebM/PCM on the web and then convert to WAV/PCM just before uploading.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/2083)
<!-- Reviewable:end -->
