### PR TITLE
convert audio to wav during a lift export

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           dotnet-version: ${{ matrix.dotnet }}
       - name: Install ffmpeg
-        uses: FedericoCarboni/setup-ffmpeg@0772ab98049eccf3c09d0a23208a5f1f8045a6de # v2.0.0
+        uses: FedericoCarboni/setup-ffmpeg@v2 # v2.0.0
 
       # Coverage.
       - name: run coverage tests

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -40,6 +40,8 @@ jobs:
         uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
         with:
           dotnet-version: ${{ matrix.dotnet }}
+      - name: Install ffmpeg
+        uses: FedericoCarboni/setup-ffmpeg@0772ab98049eccf3c09d0a23208a5f1f8045a6de # v2.0.0
 
       # Coverage.
       - name: run coverage tests

--- a/Backend.Tests/Controllers/LiftControllerTests.cs
+++ b/Backend.Tests/Controllers/LiftControllerTests.cs
@@ -266,11 +266,11 @@ namespace Backend.Tests.Controllers
             new("RWC.zip", "es", new List<string>(), 132),
             new("Sena.zip", "seh", new List<string>(), 1462),
             new(
-                "SingleEntryLiftWithSound.zip", "ptn", new List<string> { "short.mp3" }, 1,
+                "SingleEntryLiftWithSound.zip", "ptn", new List<string> { "short.wav" }, 1,
                 "50398a34-276a-415c-b29e-3186b0f08d8b" /*guid of the lone entry*/,
                 "e44420dd-a867-4d71-a43f-e472fd3a8f82" /*id of its first sense*/),
             new(
-                "SingleEntryLiftWithTwoSound.zip", "ptn", new List<string> { "short.mp3", "short1.mp3" }, 1,
+                "SingleEntryLiftWithTwoSound.zip", "ptn", new List<string> { "short.wav", "short1.wav" }, 1,
                 "50398a34-276a-415c-b29e-3186b0f08d8b" /*guid of the lone entry*/,
                 "e44420dd-a867-4d71-a43f-e472fd3a8f82" /*id of its first sense*/)
         };
@@ -339,7 +339,9 @@ namespace Backend.Tests.Controllers
             Assert.That(Directory.Exists(Path.Combine(exportedProjDir, "audio")));
             foreach (var audioFile in roundTripObj.AudioFiles)
             {
-                Assert.That(File.Exists(Path.Combine(exportedProjDir, "audio", audioFile)));
+                var path = Path.Combine(exportedProjDir, "audio", audioFile);
+                Assert.That(File.Exists(path),
+                    $"The file {audioFile} can not be found at this path: {path}");
             }
             Assert.That(Directory.Exists(Path.Combine(exportedProjDir, "WritingSystems")));
             Assert.That(File.Exists(Path.Combine(

--- a/Backend.Tests/Controllers/LiftControllerTests.cs
+++ b/Backend.Tests/Controllers/LiftControllerTests.cs
@@ -266,11 +266,11 @@ namespace Backend.Tests.Controllers
             new("RWC.zip", "es", new List<string>(), 132),
             new("Sena.zip", "seh", new List<string>(), 1462),
             new(
-                "SingleEntryLiftWithSound.zip", "ptn", new List<string> { "short.wav" }, 1,
+                "SingleEntryLiftWithSound.zip", "ptn", new List<string> { "short.mp3" }, 1,
                 "50398a34-276a-415c-b29e-3186b0f08d8b" /*guid of the lone entry*/,
                 "e44420dd-a867-4d71-a43f-e472fd3a8f82" /*id of its first sense*/),
             new(
-                "SingleEntryLiftWithTwoSound.zip", "ptn", new List<string> { "short.wav", "short1.wav" }, 1,
+                "SingleEntryLiftWithTwoSound.zip", "ptn", new List<string> { "short.mp3", "short1.mp3" }, 1,
                 "50398a34-276a-415c-b29e-3186b0f08d8b" /*guid of the lone entry*/,
                 "e44420dd-a867-4d71-a43f-e472fd3a8f82" /*id of its first sense*/)
         };
@@ -339,9 +339,7 @@ namespace Backend.Tests.Controllers
             Assert.That(Directory.Exists(Path.Combine(exportedProjDir, "audio")));
             foreach (var audioFile in roundTripObj.AudioFiles)
             {
-                var path = Path.Combine(exportedProjDir, "audio", audioFile);
-                Assert.That(File.Exists(path),
-                    $"The file {audioFile} can not be found at this path: {path}");
+                Assert.That(File.Exists(Path.Combine(exportedProjDir, "audio", audioFile)));
             }
             Assert.That(Directory.Exists(Path.Combine(exportedProjDir, "WritingSystems")));
             Assert.That(File.Exists(Path.Combine(

--- a/Backend/BackendFramework.csproj
+++ b/Backend/BackendFramework.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.19.1" />
     <PackageReference Include="MailKit" Version="4.0.0" />
+    <PackageReference Include="Xabe.FFmpeg" Version="5.2.6"/>
 
     <!-- SIL Maintained Dependencies. -->
     <PackageReference Include="icu.net" Version="2.9.0" />

--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -27,7 +27,7 @@ ENV APP_FILES=${HOME}/.CombineFiles
 RUN apt-get update \
   && apt-get install -y \
   # icu.net dependency: libdl.so
-  libc6-dev \
+  libc6-dev ffmpeg \
   && rm -rf /var/lib/apt/lists/*
 
 # Create the home directory for the new app user.

--- a/Backend/Services/LiftService.cs
+++ b/Backend/Services/LiftService.cs
@@ -452,16 +452,22 @@ namespace BackendFramework.Services
             {
                 var lexPhonetic = new LexPhonetic();
                 var src = FileStorage.GenerateAudioFilePath(projectId, audioFile);
-                var dest = Path.ChangeExtension(Path.Combine(path, audioFile), ".wav");
+                var dest = Path.Combine(path, audioFile);
 
-                if (File.Exists(src))
+                if (!File.Exists(src)) continue;
+                if (Path.GetExtension(dest).Equals(".webm", StringComparison.OrdinalIgnoreCase))
                 {
+                    dest = Path.ChangeExtension(dest, ".wav");
                     await FFmpeg.Conversions.New().Start($"-y -i \"{src}\" \"{dest}\"");
-
-                    var proMultiText = new LiftMultiText { { "href", dest } };
-                    lexPhonetic.MergeIn(MultiText.Create(proMultiText));
-                    entry.Pronunciations.Add(lexPhonetic);
                 }
+                else
+                {
+                    File.Copy(src, dest, true);
+                }
+
+                var proMultiText = new LiftMultiText { { "href", dest } };
+                lexPhonetic.MergeIn(MultiText.Create(proMultiText));
+                entry.Pronunciations.Add(lexPhonetic);
             }
         }
 


### PR DESCRIPTION
This change makes it so that all audio files exported have their container changed to `wav`, currently files recorded in the browser are saved in a `webm` format with an encoding that FLEx doesn't support when in a `webm`, but if we convert it to a `wav` then it'll work just fine and preserve any high quality audio.

All tests pass, though I had to make an adjustment as the audio file names will be `wav` files instead of `mp3`. An alternative would be to only convert `webm` files to `wav` and leave everything else as is, however we may run into more issues in the future with other file formats. We know that `wav` works so it makes sense for now to just keep this change simple in my opinion. If there's a reason that we don't want to convert all files to `wav` let me know and we can adjust it.

In order for the unit tests to pass (which run outside of docker), I had to add a new step `backend.yml` to install `ffmpeg` before we run the unit tests. That file may need to be merged into master before it effects the checks in this PR, but I'm not sure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/2143)
<!-- Reviewable:end -->
