### PR TITLE
Fix build for QA deployment

### DIFF
--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -26,6 +26,7 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            *.data.mcr.microsoft.com:443
             ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
             api.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
             api.github.com:443
@@ -39,6 +40,7 @@ jobs:
             dotnetcli.azureedge.net:443
             files.pythonhosted.org:443
             github.com:443
+            mcr.microsoft.com:443
             pipelines.actions.githubusercontent.com:443
             production.cloudflare.docker.com:443
             pypi.org:443

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -22,8 +22,23 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@128a63446a954579617e875aaab7d2978154e969 # v2.4.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
+          egress-policy: audit
+          allowed-endpoints: >
+            *.data.mcr.microsoft.com:443
+            api.ecr-public.us-east-1.amazonaws.com:443
+            api.github.com:443
+            api.nuget.org:443
+            archive.ubuntu.com:80
+            auth.docker.io:443
+            files.pythonhosted.org:443
+            github.com:443
+            mcr.microsoft.com:443
+            production.cloudflare.docker.com:443
+            public.ecr.aws:443
+            pypi.org:443
+            registry-1.docker.io:443
+            registry.npmjs.org:443
+            sts.us-east-1.amazonaws.com:443
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Build The Combine
         id: build_combine


### PR DESCRIPTION
Update the GitHub action to build the QA images to allow pulling of images from microsoft.com.

In addition, initial `allowed-endpoints` are specified for building releases for the production server.  `egress-policy` is left at `audit` until the results of this change can be reviewed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/2195)
<!-- Reviewable:end -->
