### PR TITLE
Update URL and host config for local kubernetes cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,20 +657,6 @@ maintenance-7f4b5b89b8-rhgk9   1/1     Running   0          10m
 
 ### Connecting to Your Cluster
 
-#### Network Hosts Configuration
-
-The cluster's ingress controller uses the hostname `thecombine.local` to _The Combine_. To direct traffic for this host
-to the ingress controller, add:
-
-```textfile
-127.0.0.1  thecombine.local
-```
-
-to your network hosts file:
-
-- Windows: `%windir%\System32\drivers\etc\hosts`
-- Linux/macOS: `/etc/hosts`
-
 #### Setup Port Forwarding
 
 _Rancher Desktop only!_
@@ -686,9 +672,8 @@ Note that the port forwarding is not persistent; you need to set it up whenever 
 
 #### Connecting to _The Combine_
 
-Once your host configuration has been setup, you can connect to _The Combine_ by entering the URL
-`https://thecombine.local` in the address bar of your web browser. (`https://thecombine.local:<portnumber>` for _Rancher
-Desktop_)
+You can connect to _The Combine_ by entering the URL `https://thecombine.localhost` in the address bar of your web
+browser. (`https://thecombine.localhost:<portnumber>` for _Rancher Desktop_)
 
 Notes:
 


### PR DESCRIPTION
Update the instructions for setting up _The Combine_ on a local Kubernetes cluster in `README.md`.  Specifically:

1. Changed the URL for _The Combine_ from `https://thecombine.local` to `https://thecombine.localhost`.  This URL change was made sometime ago since Google Chrome, Chromium Derivatives, and Firefox automatically map `*.localhost` to 127.0.0.1.
2. Removed instructions for updating the host machine's host configuration file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/2271)
<!-- Reviewable:end -->
