### PR TITLE
Fix console warning re undefined option

### DIFF
--- a/src/components/ProjectScreen/CreateProject/CreateProjectComponent.tsx
+++ b/src/components/ProjectScreen/CreateProject/CreateProjectComponent.tsx
@@ -165,7 +165,7 @@ export class CreateProject extends React.Component<
     }
 
     const menuItems = [
-      <MenuItem key={vernIdNone}>
+      <MenuItem key={vernIdNone} value={vernIdNone}>
         {this.props.t("createProject.languageSelect")}
       </MenuItem>,
     ];
@@ -195,7 +195,11 @@ export class CreateProject extends React.Component<
     };
 
     return (
-      <Select displayEmpty id="create-proj-select-vern" onChange={onChange}>
+      <Select
+        defaultValue={vernIdNone}
+        id="create-proj-select-vern"
+        onChange={onChange}
+      >
         {menuItems}
       </Select>
     );


### PR DESCRIPTION
Fixes the following (introduced in #2306):
In `CreateProject`, after loading a LIFT file, when selecting a vernacular language from the drop-down menu, the console gives this:
```
react_devtools_backend_compact.js:2367
Warning: A component is changing an uncontrolled input to be controlled.
This is likely caused by the value changing from undefined to a defined value, which should not happen.
Decide between using a controlled or uncontrolled input element for the lifetime of the component.
More info: https://reactjs.org/link/controlled-components
    at input
    at http://localhost:3000/static/js/bundle.js:20558:66
    at SelectInput (http://localhost:3000/static/js/bundle.js:37716:27)
    at http://localhost:3000/static/js/bundle.js:20558:66
    at div
    at http://localhost:3000/static/js/bundle.js:20558:66
    at InputBase (http://localhost:3000/static/js/bundle.js:32687:83)
    at OutlinedInput (http://localhost:3000/static/js/bundle.js:35996:82)
    at http://localhost:3000/static/js/bundle.js:20558:66
    at Select (http://localhost:3000/static/js/bundle.js:37329:82)
    at div
    at http://localhost:3000/static/js/bundle.js:20558:66
    at CardContent (http://localhost:3000/static/js/bundle.js:27153:82)
    at form
    at div
    at http://localhost:3000/static/js/bundle.js:20558:66
    at Paper (http://localhost:3000/static/js/bundle.js:36341:83)
    at http://localhost:3000/static/js/bundle.js:20558:66
    at Card (http://localhost:3000/static/js/bundle.js:27284:82)
    at CreateProject (http://localhost:3000/static/js/src_components_App_AppLoggedIn_tsx.chunk.js:2445:5)
    at I18nextWithTranslation (http://localhost:3000/static/js/bundle.js:115875:31)
    at ConnectFunction (http://localhost:3000/static/js/bundle.js:89358:114)
    at div
    at http://localhost:3000/static/js/bundle.js:20558:66
    at Grid (http://localhost:3000/static/js/bundle.js:30725:87)
    at div
    at http://localhost:3000/static/js/bundle.js:20558:66
    at Grid (http://localhost:3000/static/js/bundle.js:30725:87)
    at ProjectScreen (http://localhost:3000/static/js/src_components_App_AppLoggedIn_tsx.chunk.js:3127:79)
    at Route (http://localhost:3000/static/js/bundle.js:91995:29)
    at Switch (http://localhost:3000/static/js/bundle.js:92164:29)
    at AppWithBar (http://localhost:3000/static/js/src_components_App_AppLoggedIn_tsx.chunk.js:1143:51)
    at InnerLoadable (http://localhost:3000/static/js/bundle.js:22127:34)
    at LoadableWithChunkExtractor
    at Loadable
    at RequireAuth (http://localhost:3000/static/js/bundle.js:16093:76)
    at Route (http://localhost:3000/static/js/bundle.js:91995:29)
    at Switch (http://localhost:3000/static/js/bundle.js:92164:29)
    at Suspense
    at div
    at App
    at PersistGate (http://localhost:3000/static/js/bundle.js:97931:5)
    at Router (http://localhost:3000/static/js/bundle.js:91667:30)
    at Provider (http://localhost:3000/static/js/bundle.js:89089:5)
    at SnackbarProvider (http://localhost:3000/static/js/bundle.js:64712:24)
    at ThemeProvider (http://localhost:3000/static/js/bundle.js:42561:5)
    at ThemeProvider (http://localhost:3000/static/js/bundle.js:42940:5)
    at ThemeProvider (http://localhost:3000/static/js/bundle.js:40780:14)
    at StyledEngineProvider (http://localhost:3000/static/js/bundle.js:42736:5)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/2334)
<!-- Reviewable:end -->
