### PR TITLE
Configure VSCode to warn on commits to master, main

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -68,5 +68,6 @@
     "thecombine",
     "upsert",
     "venv"
-  ]
+  ],
+  "git.branchProtection": ["master", "main"]
 }


### PR DESCRIPTION
This adds a warning when committing through VSCode's "Source Control" panel (not when committing via a cli opened in VSCode).

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/2450)
<!-- Reviewable:end -->
