### PR TITLE
Add id to second upload step

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -61,6 +61,7 @@ jobs:
           fail_ci_if_error: true
       - name: Upload coverage report - take 2 (if the first attempt fails)
         if: steps.uploadCoverage.outcome == 'failure'
+        id: uploadCoverage2
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
         with:
           files: Backend.Tests/coverage.cobertura.xml

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -55,6 +55,7 @@ jobs:
           fail_ci_if_error: true
       - name: Upload coverage report - take 2 (if the first attempt fails)
         if: steps.uploadCoverage.outcome == 'failure'
+        id: uploadCoverage2
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
         with:
           files: coverage/clover.xml


### PR DESCRIPTION
Follow-up to #2457, which (without clear reason) allows a workflow to pass if the second coverage upload fails. For example: https://github.com/sillsdev/TheCombine/actions/runs/5820154814/job/15779946575