### PR TITLE
Specify kubectl version as GHA variable

### DIFF
--- a/.github/actions/combine-deploy-update/action.yml
+++ b/.github/actions/combine-deploy-update/action.yml
@@ -26,9 +26,9 @@ runs:
     - name: Install pre-requisites
       run: |
         cd
-        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+        curl -LO https://dl.k8s.io/release/${{ vars.KUBECTL_VERSION }}/linux/amd64/kubectl
         sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-        kubectl version --short
+        kubectl version --output=yaml
       shell: bash
     - name: Deploy updated images
       run: echo "Update images with version ${{ inputs.image_tag }}"


### PR DESCRIPTION
The CD script to deploy to the QA and Production servers was failing because the `kubectl` command used to log the Kubernetes versions was using a deprecated option that has now been removed.  The PR makes the following changes to address this issue:

- instead of downloading the latest version of `kubectl`, it now downloads a specific version.  This also helps to avoid warnings that "version difference between client and server exceeds the supported minor version skew of +/-1".  The `kubectl` version is specified as a repository variable in the GitHub project settings.
- changes the output format from `--short` to `yaml`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/2485)
<!-- Reviewable:end -->