### PR TITLE
Fix download of kubectl by specific version version

### DIFF
--- a/.github/actions/combine-deploy-update/action.yml
+++ b/.github/actions/combine-deploy-update/action.yml
@@ -29,7 +29,7 @@ runs:
     - name: Install pre-requisites
       run: |
         cd
-        echo "Installing kubectl ${{ inputs.kubectl_version }}""
+        echo "Installing kubectl version '${{ inputs.kubectl_version }}'"
         curl -LO https://dl.k8s.io/release/${{ inputs.kubectl_version }}/linux/amd64/kubectl
         sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
         kubectl version --output=yaml

--- a/.github/actions/combine-deploy-update/action.yml
+++ b/.github/actions/combine-deploy-update/action.yml
@@ -29,6 +29,7 @@ runs:
     - name: Install pre-requisites
       run: |
         cd
+        echo "Installing kubectl ${{ inputs.kubectl_version }}""
         curl -LO https://dl.k8s.io/release/${{ inputs.kubectl_version }}/linux/amd64/kubectl
         sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
         kubectl version --output=yaml

--- a/.github/actions/combine-deploy-update/action.yml
+++ b/.github/actions/combine-deploy-update/action.yml
@@ -29,9 +29,7 @@ runs:
     - name: Install pre-requisites
       run: |
         cd
-        echo "Running: 'curl -LO https://dl.k8s.io/release/${{ inputs.kubectl_version }}/bin/linux/amd64/kubectl'"
         curl -LO https://dl.k8s.io/release/${{ inputs.kubectl_version }}/bin/linux/amd64/kubectl
-        ls -l kubectl
         sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
         kubectl version --output=yaml
       shell: bash

--- a/.github/actions/combine-deploy-update/action.yml
+++ b/.github/actions/combine-deploy-update/action.yml
@@ -29,8 +29,9 @@ runs:
     - name: Install pre-requisites
       run: |
         cd
-        echo "Installing kubectl version '${{ inputs.kubectl_version }}'"
+        echo "Running: 'curl -LO https://dl.k8s.io/release/${{ inputs.kubectl_version }}/linux/amd64/kubectl'"
         curl -LO https://dl.k8s.io/release/${{ inputs.kubectl_version }}/linux/amd64/kubectl
+        ls -l kubectl
         sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
         kubectl version --output=yaml
       shell: bash

--- a/.github/actions/combine-deploy-update/action.yml
+++ b/.github/actions/combine-deploy-update/action.yml
@@ -17,6 +17,9 @@ inputs:
   kube_context:
     description: "Context for the kubectl commands"
     required: true
+  kubectl_version:
+    description: "Version of kubectl to install on the runner"
+    required: true
   update_cert_proxy:
     description: "Specification for whether the combine-cert-proxy should be updated."
     required: true
@@ -26,12 +29,10 @@ runs:
     - name: Install pre-requisites
       run: |
         cd
-        curl -LO https://dl.k8s.io/release/$KUBECTL_VERSION/linux/amd64/kubectl
+        curl -LO https://dl.k8s.io/release/${{ inputs.kubectl_version }}/linux/amd64/kubectl
         sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
         kubectl version --output=yaml
       shell: bash
-      env:
-        KUBECTL_VERSION: ${{ vars.KUBECTL_VERSION }}
     - name: Deploy updated images
       run: echo "Update images with version ${{ inputs.image_tag }}"
       shell: bash

--- a/.github/actions/combine-deploy-update/action.yml
+++ b/.github/actions/combine-deploy-update/action.yml
@@ -29,8 +29,8 @@ runs:
     - name: Install pre-requisites
       run: |
         cd
-        echo "Running: 'curl -LO https://dl.k8s.io/release/${{ inputs.kubectl_version }}/linux/amd64/kubectl'"
-        curl -LO https://dl.k8s.io/release/${{ inputs.kubectl_version }}/linux/amd64/kubectl
+        echo "Running: 'curl -LO https://dl.k8s.io/release/${{ inputs.kubectl_version }}/bin/linux/amd64/kubectl'"
+        curl -LO https://dl.k8s.io/release/${{ inputs.kubectl_version }}/bin/linux/amd64/kubectl
         ls -l kubectl
         sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
         kubectl version --output=yaml

--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - fix-kubectl-version
 
 permissions:
   contents: read
@@ -104,4 +105,5 @@ jobs:
           image_registry: ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
           image_tag: ${{ needs.build.outputs.image_tag }}
           kube_context: ${{ secrets.LTOPS_K8S_STAGING_CONTEXT }}
+          kubectl_version: ${{ vars.KUBECTL_VERSION }}
           update_cert_proxy: false

--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -95,7 +95,7 @@ jobs:
   deploy_update:
     needs: build
     # Only push to the QA server when built on the master branch
-    if: ${{ github.ref_name == 'master' }}
+    # if: ${{ github.ref_name == 'master' }}
     runs-on: [self-hosted, thecombine]
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - fix-kubectl-version
 
 permissions:
   contents: read
@@ -95,7 +94,7 @@ jobs:
   deploy_update:
     needs: build
     # Only push to the QA server when built on the master branch
-    # if: ${{ github.ref_name == 'master' }}
+    if: ${{ github.ref_name == 'master' }}
     runs-on: [self-hosted, thecombine]
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -77,4 +77,5 @@ jobs:
           image_registry_alias: "/thecombine"
           image_tag: ${{ needs.build.outputs.image_tag }}
           kube_context: ${{ secrets.LTOPS_K8S_PRODUCTION_CONTEXT }}
+          kubectl_version: ${{ vars.KUBECTL_VERSION }}
           update_cert_proxy: true


### PR DESCRIPTION
In order to fix the last attempt to specify the `kubectl` version through a GitHub Actions variable, the following changes are proposed:

- add an input value to `.github/actions/combine-deploy-update/action.yml`.  Since the action is run as a `composite` on our self-hosted runner, it GitHub Action variables are not accessible and need to be passed in as inputs.
- update `.github/workflows/deploy_qa.yml` and `.github/workflows/deploy_release.yml` to pass the GitHub Action variable for the `kubectl` version into the action abobe.
- fix the path for the `kubectl` download

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/2489)
<!-- Reviewable:end -->
