### PR TITLE
Fix empty project bug on project creation

### DIFF
--- a/src/components/ProjectScreen/index.tsx
+++ b/src/components/ProjectScreen/index.tsx
@@ -14,7 +14,7 @@ export default function ProjectScreen(): ReactElement {
   useEffect(() => {
     dispatch(clearCurrentProject());
     dispatch(resetTreeAction());
-  });
+  }, [dispatch]);
 
   return (
     <Grid container justifyContent="center" spacing={2}>


### PR DESCRIPTION
The `ProjectScreen` component clears the current project on every render, but should only do so on initial render.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/2547)
<!-- Reviewable:end -->
