### PR TITLE
Configure whether languages should be installed on a per chart basis

### DIFF
--- a/deploy/scripts/setup_combine.py
+++ b/deploy/scripts/setup_combine.py
@@ -347,7 +347,8 @@ def main() -> None:
                     ]
                 )
 
-            add_language_overrides(this_config, chart=chart, langs=args.langs)
+            if config["charts"][chart]["install_langs"]:
+                add_language_overrides(this_config, chart=chart, langs=args.langs)
 
             add_override_values(
                 this_config,

--- a/deploy/scripts/setup_files/combine_config.yaml
+++ b/deploy/scripts/setup_files/combine_config.yaml
@@ -117,6 +117,7 @@ profiles:
 charts:
   thecombine:
     namespace: thecombine
+    install_langs: true
     secrets:
       - config_item: awsAccount
         env_var: AWS_ACCOUNT
@@ -134,6 +135,7 @@ charts:
         env_var: COMBINE_SMTP_PASSWORD
   create-admin-user:
     namespace: thecombine
+    install_langs: false
     secrets:
       - config_item: awsAccount
         env_var: AWS_ACCOUNT
@@ -153,6 +155,7 @@ charts:
         env_var: COMBINE_ADMIN_EMAIL
   cert-proxy-server:
     namespace: combine-cert-proxy
+    install_langs: false
     secrets:
       - config_item: awsAccount
         env_var: AWS_ACCOUNT


### PR DESCRIPTION
`setup_combine.py` accepts a `--langs`|`-l` option to specify languages to install on the target system.  The script then tried to apply these languages to all charts instead of just the `combine` chart.

This adds a configuration field for each chart to specify whether the language overrides should be added to the chart configuration files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/2548)
<!-- Reviewable:end -->
