### PR TITLE
Don't mutate the input in the Font Context constructor

### DIFF
--- a/src/utilities/fontContext.ts
+++ b/src/utilities/fontContext.ts
@@ -26,7 +26,7 @@ export class ProjectFonts {
       return;
     }
 
-    proj.analysisWritingSystems.reverse().forEach((ws) => {
+    [...proj.analysisWritingSystems].reverse().forEach((ws) => {
       const font = ws.font.replaceAll(" ", "");
       if (font) {
         this.langMap[ws.bcp47] = font;

--- a/src/utilities/fontContext.ts
+++ b/src/utilities/fontContext.ts
@@ -26,6 +26,7 @@ export class ProjectFonts {
       return;
     }
 
+    // Don't .reverse() the array directly, as that may improperly mutate a state.
     [...proj.analysisWritingSystems].reverse().forEach((ws) => {
       const font = ws.font.replaceAll(" ", "");
       if (font) {

--- a/src/utilities/fontContext.ts
+++ b/src/utilities/fontContext.ts
@@ -26,10 +26,9 @@ export class ProjectFonts {
       return;
     }
 
-    // Don't .reverse() the array directly, as that may improperly mutate a state.
-    [...proj.analysisWritingSystems].reverse().forEach((ws) => {
+    proj.analysisWritingSystems.forEach((ws) => {
       const font = ws.font.replaceAll(" ", "");
-      if (font) {
+      if (font && !(ws.bcp47 in this.langMap)) {
         this.langMap[ws.bcp47] = font;
         if (ws.rtl) {
           this.rtlLangs[ws.bcp47] = true;


### PR DESCRIPTION
The `.reverse()` was being applied directly to something in the Redux state, causing the order of the project analysis languages to flip (just in the frontend, not in the database) on every refresh.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/2550)
<!-- Reviewable:end -->
