### PR TITLE
Make a WithFont extension of <li> for Autocomplete renderOptions

### DIFF
--- a/src/components/DataEntry/DataEntryTable/EntryCellComponents/GlossWithSuggestions.tsx
+++ b/src/components/DataEntry/DataEntryTable/EntryCellComponents/GlossWithSuggestions.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement, useContext, useEffect } from "react";
 import { Key } from "ts-key-enum";
 
 import { WritingSystem } from "api/models";
-import { TextFieldWithFont } from "utilities/fontComponents";
+import { LiWithFont, TextFieldWithFont } from "utilities/fontComponents";
 import SpellCheckerContext from "utilities/spellCheckerContext";
 
 interface GlossWithSuggestionsProps {
@@ -75,6 +75,16 @@ export default function GlossWithSuggestions(
           lang={props.analysisLang.bcp47}
           variant={props.isNew ? "outlined" : "standard"}
         />
+      )}
+      renderOption={(liProps, option, { selected }) => (
+        <LiWithFont
+          {...liProps}
+          analysis
+          aria-selected={selected}
+          lang={props.analysisLang.bcp47}
+        >
+          {option}
+        </LiWithFont>
       )}
       onKeyPress={(e: React.KeyboardEvent) => {
         if (e.key === Key.Enter) {

--- a/src/components/DataEntry/DataEntryTable/EntryCellComponents/VernWithSuggestions.tsx
+++ b/src/components/DataEntry/DataEntryTable/EntryCellComponents/VernWithSuggestions.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement, useEffect } from "react";
 import { Key } from "ts-key-enum";
 
 import { WritingSystem } from "api/models";
-import { TextFieldWithFont } from "utilities/fontComponents";
+import { LiWithFont, TextFieldWithFont } from "utilities/fontComponents";
 
 interface VernWithSuggestionsProps {
   isNew?: boolean;
@@ -64,6 +64,11 @@ export default function VernWithSuggestions(
           variant={props.isNew ? "outlined" : "standard"}
           vernacular
         />
+      )}
+      renderOption={(liProps, option, { selected }) => (
+        <LiWithFont {...liProps} aria-selected={selected} vernacular>
+          {option}
+        </LiWithFont>
       )}
     />
   );

--- a/src/utilities/fontComponents.tsx
+++ b/src/utilities/fontComponents.tsx
@@ -15,11 +15,11 @@ import FontContext, { WithFontProps } from "utilities/fontContext";
 type TextFieldWithFontProps = TextFieldProps & WithFontProps;
 
 /**
- * TextField modified for use within a FontContext.
- * Input props are extended with 3 optional props:
- *   analysis: bool? (used to apply the default analysis font);
- *   lang: string? (bcp47 lang-tag for applying the appropriate analysis font);
- *   vernacular: bool? (used to apply the vernacular font).
+ * `TextField` modified for use within a `FontContext`.
+ * The props are extended with 3 optional props:
+ *   `analysis: bool?` (used to apply the default analysis font);
+ *   `lang: string?` (bcp47 lang-tag for applying the appropriate analysis font);
+ *   `vernacular: bool?` (used to apply the vernacular font).
  */
 export function TextFieldWithFont(props: TextFieldWithFontProps): ReactElement {
   const fontContext = useContext(FontContext);
@@ -42,11 +42,11 @@ export function TextFieldWithFont(props: TextFieldWithFontProps): ReactElement {
 type TypographyWithFontProps = TypographyProps & WithFontProps;
 
 /**
- * Typography modified for use within a FontContext.
- * Input props are extended with 3 optional props:
- *   analysis: bool? (used to apply the default analysis font);
- *   lang: string? (bcp47 lang-tag for applying the appropriate analysis font);
- *   vernacular: bool? (used to apply the vernacular font).
+ * `Typography` modified for use within a `FontContext`.
+ * The props are extended with 3 optional props:
+ *   `analysis: bool?` (used to apply the default analysis font);
+ *   `lang: string?` (bcp47 lang-tag for applying the appropriate analysis font);
+ *   `vernacular: bool?` (used to apply the vernacular font).
  */
 export function TypographyWithFont(
   props: TypographyWithFontProps
@@ -60,6 +60,34 @@ export function TypographyWithFont(
       style={fontContext.addFontToStyle(
         { analysis, lang, vernacular },
         typographyProps.style
+      )}
+    />
+  );
+}
+
+type LiWithFontProps = React.DetailedHTMLProps<
+  React.LiHTMLAttributes<HTMLLIElement>,
+  HTMLLIElement
+> &
+  WithFontProps;
+
+/**
+ * `li` modified for use within a `FontContext`.
+ * The props are extended with 3 optional props:
+ *   `analysis: bool?` (used to apply the default analysis font);
+ *   `lang: string?` (bcp47 lang-tag for applying the appropriate analysis font);
+ *   `vernacular: bool?` (used to apply the vernacular font).
+ */
+export function LiWithFont(props: LiWithFontProps) {
+  const fontContext = useContext(FontContext);
+  // Use spread to remove the custom props from what is passed into li.
+  const { analysis, lang, vernacular, ...liProps } = props;
+  return (
+    <li
+      {...liProps}
+      style={fontContext.addFontToStyle(
+        { analysis, lang, vernacular },
+        liProps.style
       )}
     />
   );


### PR DESCRIPTION
Fixes #2605

Figured it out using:
https://mui.com/material-ui/react-autocomplete/#githubs-picker
https://mui.com/material-ui/api/autocomplete/#Autocomplete-prop-renderOption
https://github.com/mui/material-ui/blob/master/packages/mui-material/src/Autocomplete/Autocomplete.js#L555-L571

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/2620)
<!-- Reviewable:end -->
