### PR TITLE
Add local.thecombine.app to list of certificates for offline use

### DIFF
--- a/deploy/scripts/setup_files/profiles/prod.yaml
+++ b/deploy/scripts/setup_files/profiles/prod.yaml
@@ -40,4 +40,4 @@ charts:
     global:
       awsS3Location: prod.thecombine.app
       pullSecretName: None
-    combineCertProxyList: nuc1.thecombine.app nuc2.thecombine.app nuc3.thecombine.app
+    combineCertProxyList: nuc1.thecombine.app nuc2.thecombine.app nuc3.thecombine.app local.thecombine.app


### PR DESCRIPTION
Configure the production Kubernetes cluster to create a certificate for `local.thecombine.app`.  This is intended to be available for users who manage an installation of _The Combine_ on their own hardware.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/2825)
<!-- Reviewable:end -->
