### PR TITLE
[Speaker] Allow consent audio to be deleted

### DIFF
--- a/src/components/ProjectUsers/SpeakerConsentListItemIcon.tsx
+++ b/src/components/ProjectUsers/SpeakerConsentListItemIcon.tsx
@@ -76,7 +76,7 @@ function PlayConsentListItemIcon(props: ConsentIconProps): ReactElement {
   return (
     <ListItemIcon data-testid={ListItemIconId.PlayAudio}>
       <AudioPlayer
-        audio={{ ...newPronunciation(props.speaker.id), protected: true }}
+        audio={newPronunciation(props.speaker.id)}
         deleteAudio={handleDeleteAudio}
         pronunciationUrl={getConsentUrl(props.speaker)}
         size="small"


### PR DESCRIPTION
But don't allow speakers to be associated with consent audio (accomplished by the `AudioPlayer` component with the `updateAudioSpeaker` prop undefined).

Follow-up to #2795 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/2873)
<!-- Reviewable:end -->
