### PR TITLE
Update @mui/x-date-pickers and Project Schedule settings

### DIFF
--- a/docs/user_guide/assets/licenses/frontend_licenses.txt
+++ b/docs/user_guide/assets/licenses/frontend_licenses.txt
@@ -1388,6 +1388,31 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
+@mui/x-date-pickers 6.18.7
+MIT
+MIT License
+
+Copyright (c) 2020 Material-UI SAS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
 @popperjs/core 2.11.8
 MIT
 The MIT License (MIT)

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@microsoft/signalr": "^8.0.0",
         "@mui/icons-material": "^5.14.19",
         "@mui/material": "^5.14.16",
+        "@mui/x-date-pickers": "^6.18.7",
         "@redux-devtools/extension": "^3.2.5",
         "@reduxjs/toolkit": "^1.9.5",
         "@segment/analytics-next": "^1.55.0",
@@ -4301,6 +4302,72 @@
         "react-dom": ">=18.0.0"
       }
     },
+    "node_modules/@material-table/core/node_modules/@mui/x-date-pickers": {
+      "version": "5.0.20",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-5.0.20.tgz",
+      "integrity": "sha512-ERukSeHIoNLbI1C2XRhF9wRhqfsr+Q4B1SAw2ZlU7CWgcG8UBOxgqRKDEOVAIoSWL+DWT6GRuQjOKvj6UXZceA==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.9",
+        "@date-io/core": "^2.15.0",
+        "@date-io/date-fns": "^2.15.0",
+        "@date-io/dayjs": "^2.15.0",
+        "@date-io/luxon": "^2.15.0",
+        "@date-io/moment": "^2.15.0",
+        "@mui/utils": "^5.10.3",
+        "@types/react-transition-group": "^4.4.5",
+        "clsx": "^1.2.1",
+        "prop-types": "^15.7.2",
+        "react-transition-group": "^4.4.5",
+        "rifm": "^0.12.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.4.1",
+        "@mui/system": "^5.4.1",
+        "date-fns": "^2.25.0",
+        "dayjs": "^1.10.7",
+        "luxon": "^1.28.0 || ^2.0.0 || ^3.0.0",
+        "moment": "^2.29.1",
+        "react": "^17.0.2 || ^18.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@material-table/core/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@matt-block/react-recaptcha-v2": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@matt-block/react-recaptcha-v2/-/react-recaptcha-v2-2.0.1.tgz",
@@ -4656,25 +4723,20 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/@mui/x-date-pickers": {
-      "version": "5.0.20",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-5.0.20.tgz",
-      "integrity": "sha512-ERukSeHIoNLbI1C2XRhF9wRhqfsr+Q4B1SAw2ZlU7CWgcG8UBOxgqRKDEOVAIoSWL+DWT6GRuQjOKvj6UXZceA==",
+      "version": "6.18.7",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-6.18.7.tgz",
+      "integrity": "sha512-4NoapaCT3jvEk2cuAUjG0ReZvTEk1i4dGDz94Gt1Oc08GuC1AuzYRwCR1/1tdmbDynwkR8ilkKL6AyS3NL1H4A==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@date-io/core": "^2.15.0",
-        "@date-io/date-fns": "^2.15.0",
-        "@date-io/dayjs": "^2.15.0",
-        "@date-io/luxon": "^2.15.0",
-        "@date-io/moment": "^2.15.0",
-        "@mui/utils": "^5.10.3",
-        "@types/react-transition-group": "^4.4.5",
-        "clsx": "^1.2.1",
-        "prop-types": "^15.7.2",
-        "react-transition-group": "^4.4.5",
-        "rifm": "^0.12.1"
+        "@babel/runtime": "^7.23.2",
+        "@mui/base": "^5.0.0-beta.22",
+        "@mui/utils": "^5.14.16",
+        "@types/react-transition-group": "^4.4.8",
+        "clsx": "^2.0.0",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4683,14 +4745,17 @@
       "peerDependencies": {
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
-        "@mui/material": "^5.4.1",
-        "@mui/system": "^5.4.1",
+        "@mui/material": "^5.8.6",
+        "@mui/system": "^5.8.0",
         "date-fns": "^2.25.0",
+        "date-fns-jalali": "^2.13.0-0",
         "dayjs": "^1.10.7",
-        "luxon": "^1.28.0 || ^2.0.0 || ^3.0.0",
-        "moment": "^2.29.1",
-        "react": "^17.0.2 || ^18.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0"
+        "luxon": "^3.0.2",
+        "moment": "^2.29.4",
+        "moment-hijri": "^2.1.2",
+        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
       },
       "peerDependenciesMeta": {
         "@emotion/react": {
@@ -4702,6 +4767,9 @@
         "date-fns": {
           "optional": true
         },
+        "date-fns-jalali": {
+          "optional": true
+        },
         "dayjs": {
           "optional": true
         },
@@ -4710,15 +4778,13 @@
         },
         "moment": {
           "optional": true
+        },
+        "moment-hijri": {
+          "optional": true
+        },
+        "moment-jalaali": {
+          "optional": true
         }
-      }
-    },
-    "node_modules/@mui/x-date-pickers/node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@microsoft/signalr": "^8.0.0",
     "@mui/icons-material": "^5.14.19",
     "@mui/material": "^5.14.16",
+    "@mui/x-date-pickers": "^6.18.7",
     "@redux-devtools/extension": "^3.2.5",
     "@reduxjs/toolkit": "^1.9.5",
     "@segment/analytics-next": "^1.55.0",

--- a/src/components/App/AppLoggedIn.tsx
+++ b/src/components/App/AppLoggedIn.tsx
@@ -4,6 +4,7 @@ import { Theme, ThemeProvider, createTheme } from "@mui/material/styles";
 import { ReactElement, useEffect, useMemo, useState } from "react";
 import { Route, Routes } from "react-router-dom";
 
+import DatePickersLocalizationProvider from "components/App/DatePickersLocalizationProvider";
 import SignalRHub from "components/App/SignalRHub";
 import AppBar from "components/AppBar/AppBarComponent";
 import PageNotFound from "components/PageNotFound/component";
@@ -72,7 +73,7 @@ export default function AppWithBar(): ReactElement {
       : theme;
 
   return (
-    <>
+    <DatePickersLocalizationProvider>
       <SignalRHub />
       <AppBar />
       <FontContext.Provider value={projFonts}>
@@ -113,6 +114,6 @@ export default function AppWithBar(): ReactElement {
           </Routes>
         </ThemeProvider>
       </FontContext.Provider>
-    </>
+    </DatePickersLocalizationProvider>
   );
 }

--- a/src/components/App/DatePickersLocalizationProvider.tsx
+++ b/src/components/App/DatePickersLocalizationProvider.tsx
@@ -16,8 +16,8 @@ export default function DatePickersLocalizationProvider(props: {
   return (
     <LocalizationProvider
       // If i18n.language changes, user must log and and back in
-      // for the change to take effect in @mui/x-date-pickers components
-      adapterLocale={i18n.language}
+      // for the change to take effect in @mui/x-date-pickers components.
+      adapterLocale={i18n.language || undefined}
       dateAdapter={AdapterDayjs}
     >
       {props.children}

--- a/src/components/App/DatePickersLocalizationProvider.tsx
+++ b/src/components/App/DatePickersLocalizationProvider.tsx
@@ -15,7 +15,7 @@ export default function DatePickersLocalizationProvider(props: {
 }): ReactElement {
   return (
     <LocalizationProvider
-      // If i18n.language changes, user must log and and back in
+      // If i18n.language changes, user must log out and back in
       // for the change to take effect in @mui/x-date-pickers components.
       adapterLocale={i18n.language || undefined}
       dateAdapter={AdapterDayjs}

--- a/src/components/App/DatePickersLocalizationProvider.tsx
+++ b/src/components/App/DatePickersLocalizationProvider.tsx
@@ -1,0 +1,26 @@
+import { LocalizationProvider } from "@mui/x-date-pickers";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+// Import for each non-en uiWritingSystem lang in src/types/writingSystem.ts:
+import "dayjs/locale/ar";
+import "dayjs/locale/es";
+import "dayjs/locale/fr";
+import "dayjs/locale/pt";
+import "dayjs/locale/zh";
+import { ReactElement, ReactNode } from "react";
+
+import i18n from "i18n";
+
+export default function DatePickersLocalizationProvider(props: {
+  children: ReactNode;
+}): ReactElement {
+  return (
+    <LocalizationProvider
+      // If i18n.language changes, user must log and and back in
+      // for the change to take effect in @mui/x-date-pickers components
+      adapterLocale={i18n.language}
+      dateAdapter={AdapterDayjs}
+    >
+      {props.children}
+    </LocalizationProvider>
+  );
+}

--- a/src/components/App/DatePickersLocalizationProvider.tsx
+++ b/src/components/App/DatePickersLocalizationProvider.tsx
@@ -15,7 +15,7 @@ export default function DatePickersLocalizationProvider(props: {
 }): ReactElement {
   return (
     <LocalizationProvider
-      // If i18n.language changes, user must log out and back in
+      // If i18n.language changes, user must refresh or log out and back in
       // for the change to take effect in @mui/x-date-pickers components.
       adapterLocale={i18n.language || undefined}
       dateAdapter={AdapterDayjs}

--- a/src/components/ProjectSettings/ProjectSchedule/CalendarView.tsx
+++ b/src/components/ProjectSettings/ProjectSchedule/CalendarView.tsx
@@ -1,31 +1,15 @@
 import { Icon } from "@mui/material";
-import { DateCalendar, PickersDay, PickersDayProps } from "@mui/x-date-pickers";
+import { DateCalendar } from "@mui/x-date-pickers";
 import dayjs, { Dayjs } from "dayjs";
 import { ReactElement } from "react";
+
+import ProjectPickersDay from "components/ProjectSettings/ProjectSchedule/ProjectPickersDay";
 
 interface CalendarViewProps {
   projectSchedule: Date[];
 }
 
 export default function CalendarView(props: CalendarViewProps): ReactElement {
-  // Custom renderer for DateCalendar
-  function customDayRenderer(
-    day: Dayjs,
-    _selectedDays: Array<Dayjs | null>,
-    pickersDayProps: PickersDayProps<Dayjs>
-  ): ReactElement {
-    const date = day.toDate();
-    const selected =
-      props.projectSchedule &&
-      props.projectSchedule.findIndex(
-        (d) =>
-          d.getDate() === date.getDate() &&
-          d.getMonth() === date.getMonth() &&
-          d.getFullYear() === date.getFullYear()
-      ) >= 0;
-    return <PickersDay {...pickersDayProps} selected={selected} />;
-  }
-
   function handleCalendarView(monthToRender?: Dayjs[]): ReactElement[] {
     if (!monthToRender) {
       return [];
@@ -34,15 +18,18 @@ export default function CalendarView(props: CalendarViewProps): ReactElement {
     return monthToRender.map((tempDayjs) => (
       <DateCalendar
         key={tempDayjs.toISOString()}
-        slots={{ leftArrowIcon: Icon, rightArrowIcon: Icon }}
         readOnly
         disabled
         referenceDate={tempDayjs}
         maxDate={tempDayjs}
         minDate={tempDayjs}
-        onChange={() => {}}
         disableHighlightToday
-        //renderDay={customDayRenderer}
+        slots={{
+          day: ProjectPickersDay,
+          leftArrowIcon: Icon,
+          rightArrowIcon: Icon,
+        }}
+        slotProps={{ day: { days: props.projectSchedule } as any }}
       />
     ));
   }

--- a/src/components/ProjectSettings/ProjectSchedule/CalendarView.tsx
+++ b/src/components/ProjectSettings/ProjectSchedule/CalendarView.tsx
@@ -1,11 +1,5 @@
 import { Icon } from "@mui/material";
-import {
-  CalendarPicker,
-  PickersDay,
-  PickersDayProps,
-} from "@mui/x-date-pickers";
-import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
-import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { DateCalendar, PickersDay, PickersDayProps } from "@mui/x-date-pickers";
 import dayjs, { Dayjs } from "dayjs";
 import { ReactElement } from "react";
 
@@ -14,7 +8,7 @@ interface CalendarViewProps {
 }
 
 export default function CalendarView(props: CalendarViewProps): ReactElement {
-  // Custom renderer for CalendarPicker
+  // Custom renderer for DateCalendar
   function customDayRenderer(
     day: Dayjs,
     _selectedDays: Array<Dayjs | null>,
@@ -38,18 +32,17 @@ export default function CalendarView(props: CalendarViewProps): ReactElement {
     }
 
     return monthToRender.map((tempDayjs) => (
-      <CalendarPicker
+      <DateCalendar
         key={tempDayjs.toISOString()}
-        components={{ LeftArrowIcon: Icon, RightArrowIcon: Icon }}
+        slots={{ leftArrowIcon: Icon, rightArrowIcon: Icon }}
         readOnly
         disabled
-        defaultCalendarMonth={tempDayjs}
+        referenceDate={tempDayjs}
         maxDate={tempDayjs}
         minDate={tempDayjs}
         onChange={() => {}}
-        date={null}
         disableHighlightToday
-        renderDay={customDayRenderer}
+        //renderDay={customDayRenderer}
       />
     ));
   }
@@ -60,9 +53,5 @@ export default function CalendarView(props: CalendarViewProps): ReactElement {
     return Array.from(new Set(months)).sort().map(dayjs);
   }
 
-  return (
-    <LocalizationProvider dateAdapter={AdapterDayjs}>
-      {handleCalendarView(getScheduledMonths(props.projectSchedule))}
-    </LocalizationProvider>
-  );
+  return <>{handleCalendarView(getScheduledMonths(props.projectSchedule))}</>;
 }

--- a/src/components/ProjectSettings/ProjectSchedule/DateScheduleEdit.tsx
+++ b/src/components/ProjectSettings/ProjectSchedule/DateScheduleEdit.tsx
@@ -1,11 +1,5 @@
 import { Button, Grid } from "@mui/material";
-import {
-  CalendarPicker,
-  PickersDay,
-  PickersDayProps,
-} from "@mui/x-date-pickers";
-import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
-import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { DateCalendar, PickersDay, PickersDayProps } from "@mui/x-date-pickers";
 import { Dayjs } from "dayjs";
 import { ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -28,7 +22,7 @@ export default function DateScheduleEdit(
   );
   const { t } = useTranslation();
 
-  // Custom renderer for CalendarPicker
+  // Custom renderer for DateCalendar
   function customDayRenderer(
     day: Dayjs,
     _selectedDays: Array<Dayjs | null>,
@@ -79,12 +73,11 @@ export default function DateScheduleEdit(
   }
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <CalendarPicker
+    <>
+      <DateCalendar
         onChange={handleCalendarChange}
-        date={null}
         disableHighlightToday
-        renderDay={customDayRenderer}
+        //renderDay={customDayRenderer}
       />
       <Grid container justifyContent="flex-end" spacing={2}>
         <Grid item marginTop={1} style={{ width: 100 }}>
@@ -109,6 +102,6 @@ export default function DateScheduleEdit(
           </LoadingButton>
         </Grid>
       </Grid>
-    </LocalizationProvider>
+    </>
   );
 }

--- a/src/components/ProjectSettings/ProjectSchedule/DateScheduleEdit.tsx
+++ b/src/components/ProjectSettings/ProjectSchedule/DateScheduleEdit.tsx
@@ -1,11 +1,12 @@
 import { Button, Grid } from "@mui/material";
-import { DateCalendar, PickersDay, PickersDayProps } from "@mui/x-date-pickers";
-import { Dayjs } from "dayjs";
+import { DateCalendar } from "@mui/x-date-pickers";
+import dayjs, { Dayjs } from "dayjs";
 import { ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Project } from "api/models";
 import { LoadingButton } from "components/Buttons";
+import ProjectPickersDay from "components/ProjectSettings/ProjectSchedule/ProjectPickersDay";
 
 interface DateScheduleEditProps {
   close: () => void;
@@ -21,23 +22,6 @@ export default function DateScheduleEdit(
     props.projectSchedule
   );
   const { t } = useTranslation();
-
-  // Custom renderer for DateCalendar
-  function customDayRenderer(
-    day: Dayjs,
-    _selectedDays: Array<Dayjs | null>,
-    pickersDayProps: PickersDayProps<Dayjs>
-  ): ReactElement {
-    const date = day.toDate();
-    const selected =
-      projectSchedule.findIndex(
-        (d) =>
-          d.getDate() === date.getDate() &&
-          d.getMonth() === date.getMonth() &&
-          d.getFullYear() === date.getFullYear()
-      ) >= 0;
-    return <PickersDay {...pickersDayProps} selected={selected} />;
-  }
 
   async function handleSubmit(): Promise<void> {
     // update the schedule to the project setting
@@ -75,12 +59,18 @@ export default function DateScheduleEdit(
   return (
     <>
       <DateCalendar
-        onChange={handleCalendarChange}
+        defaultValue={
+          props.projectSchedule.length
+            ? dayjs(props.projectSchedule[0])
+            : undefined
+        }
         disableHighlightToday
-        //renderDay={customDayRenderer}
+        onChange={handleCalendarChange}
+        slots={{ day: ProjectPickersDay }}
+        slotProps={{ day: { days: projectSchedule } as any }}
       />
       <Grid container justifyContent="flex-end" spacing={2}>
-        <Grid item marginTop={1} style={{ width: 100 }}>
+        <Grid item marginTop={1}>
           <Button
             variant="contained"
             onClick={() => props.close()}
@@ -89,7 +79,7 @@ export default function DateScheduleEdit(
             {t("buttons.cancel")}
           </Button>
         </Grid>
-        <Grid item marginTop={1} style={{ width: 100 }}>
+        <Grid item marginTop={1}>
           <LoadingButton
             buttonProps={{
               id: "DateSelectorSubmitButton",

--- a/src/components/ProjectSettings/ProjectSchedule/DateSelector.tsx
+++ b/src/components/ProjectSettings/ProjectSchedule/DateSelector.tsx
@@ -1,5 +1,4 @@
 import { Button, Grid } from "@mui/material";
-import TextField from "@mui/material/TextField";
 import { DatePicker } from "@mui/x-date-pickers/DatePicker";
 import { Dayjs } from "dayjs";
 import { enqueueSnackbar } from "notistack";
@@ -66,18 +65,15 @@ export default function DateSelector(props: DateSelectorProps): ReactElement {
         label={t("projectSettings.schedule.startDate")}
         value={startDate}
         onChange={(newValue) => setStartDate(newValue)}
-        //slots={{ day: TextField }}
-        //renderInput={(params) => <TextField {...params} />}
       />
       <span>&nbsp;&nbsp;</span>
       <DatePicker
         label={t("projectSettings.schedule.endDate")}
         value={endDate}
         onChange={(newValue) => setEndDate(newValue)}
-        //renderInput={(params) => <TextField {...params} />}
       />
       <Grid container justifyContent="flex-end" spacing={2}>
-        <Grid item marginTop={1} style={{ width: 100 }}>
+        <Grid item marginTop={1}>
           <Button
             variant="contained"
             onClick={() => props.close()}
@@ -86,7 +82,7 @@ export default function DateSelector(props: DateSelectorProps): ReactElement {
             {t("buttons.cancel")}
           </Button>
         </Grid>
-        <Grid item marginTop={1} style={{ width: 100 }}>
+        <Grid item marginTop={1}>
           <LoadingButton
             disabled={!startDate || !endDate}
             buttonProps={{

--- a/src/components/ProjectSettings/ProjectSchedule/DateSelector.tsx
+++ b/src/components/ProjectSettings/ProjectSchedule/DateSelector.tsx
@@ -1,8 +1,6 @@
 import { Button, Grid } from "@mui/material";
 import TextField from "@mui/material/TextField";
-import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { DatePicker } from "@mui/x-date-pickers/DatePicker";
-import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { Dayjs } from "dayjs";
 import { enqueueSnackbar } from "notistack";
 import { ReactElement, useState } from "react";
@@ -63,19 +61,20 @@ export default function DateSelector(props: DateSelectorProps): ReactElement {
   }
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs}>
+    <>
       <DatePicker
         label={t("projectSettings.schedule.startDate")}
         value={startDate}
         onChange={(newValue) => setStartDate(newValue)}
-        renderInput={(params) => <TextField {...params} />}
+        //slots={{ day: TextField }}
+        //renderInput={(params) => <TextField {...params} />}
       />
       <span>&nbsp;&nbsp;</span>
       <DatePicker
         label={t("projectSettings.schedule.endDate")}
         value={endDate}
         onChange={(newValue) => setEndDate(newValue)}
-        renderInput={(params) => <TextField {...params} />}
+        //renderInput={(params) => <TextField {...params} />}
       />
       <Grid container justifyContent="flex-end" spacing={2}>
         <Grid item marginTop={1} style={{ width: 100 }}>
@@ -101,6 +100,6 @@ export default function DateSelector(props: DateSelectorProps): ReactElement {
           </LoadingButton>
         </Grid>
       </Grid>
-    </LocalizationProvider>
+    </>
   );
 }

--- a/src/components/ProjectSettings/ProjectSchedule/ProjectPickersDay.tsx
+++ b/src/components/ProjectSettings/ProjectSchedule/ProjectPickersDay.tsx
@@ -1,0 +1,24 @@
+import { PickersDay, PickersDayProps } from "@mui/x-date-pickers";
+import { Dayjs } from "dayjs";
+import { ReactElement } from "react";
+
+interface ProjectPickersDayProps extends PickersDayProps<Dayjs> {
+  days?: Date[];
+}
+
+export default function ProjectPickersDay(
+  props: ProjectPickersDayProps
+): ReactElement {
+  const { days, ...pickersDayProps } = props;
+  const date = pickersDayProps.day.toDate();
+  const selected = days
+    ? days.findIndex(
+        (d) =>
+          d.getDate() === date.getDate() &&
+          d.getMonth() === date.getMonth() &&
+          d.getFullYear() === date.getFullYear()
+      ) > -1
+    : false;
+
+  return <PickersDay {...pickersDayProps} selected={selected} />;
+}

--- a/src/components/ProjectSettings/ProjectSchedule/ProjectPickersDay.tsx
+++ b/src/components/ProjectSettings/ProjectSchedule/ProjectPickersDay.tsx
@@ -7,9 +7,10 @@ interface ProjectPickersDayProps extends PickersDayProps<Dayjs> {
 }
 
 /** A customized (`@mui/x-date-pickers`) `PickersDay` component.
- * To select multiple dates in the `DateCalendar` component, add the following props:
+ * To select multiple dates in the `DateCalendar` component,
+ * add `ProjectPickersDay` to the `DateCalendar` props as follows:
  *   `slots={{ day: ProjectPickersDay }}`
- *   `slotProps={{ day: { days: <<array of selected dates>> } as any }}` */
+ *   `slotProps={{ day: { days: <array of selected dates> } as any }}` */
 export default function ProjectPickersDay(
   props: ProjectPickersDayProps
 ): ReactElement {

--- a/src/components/ProjectSettings/ProjectSchedule/ProjectPickersDay.tsx
+++ b/src/components/ProjectSettings/ProjectSchedule/ProjectPickersDay.tsx
@@ -6,6 +6,10 @@ interface ProjectPickersDayProps extends PickersDayProps<Dayjs> {
   days?: Date[];
 }
 
+/** A customized (`@mui/x-date-pickers`) `PickersDay` component.
+ * To select multiple dates in the `DateCalendar` component, add the following props:
+ *   `slots={{ day: ProjectPickersDay }}`
+ *   `slotProps={{ day: { days: <<array of selected dates>> } as any }}` */
 export default function ProjectPickersDay(
   props: ProjectPickersDayProps
 ): ReactElement {

--- a/src/components/ProjectSettings/ProjectSchedule/index.tsx
+++ b/src/components/ProjectSettings/ProjectSchedule/index.tsx
@@ -1,7 +1,5 @@
 import { CalendarMonth, DateRange, EventRepeat } from "@mui/icons-material";
 import { Button, Grid, Typography } from "@mui/material";
-import { LocalizationProvider } from "@mui/x-date-pickers";
-import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { ReactElement, useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import Modal from "react-modal";
@@ -33,6 +31,10 @@ export default function ProjectSchedule(
 
   const { t } = useTranslation();
 
+  useEffect(() => {
+    Modal.setAppElement("body");
+  }, []);
+
   /** Remove all elements from workshopSchedule in project settings */
   async function handleRemoveAll(): Promise<void> {
     await props.updateProject({ ...props.project, workshopSchedule: [] });
@@ -54,7 +56,7 @@ export default function ProjectSchedule(
   }, [fetchSchedule, props.project.id, showEdit, showRemove, showSelector]);
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs}>
+    <>
       <Grid
         container
         direction="column"
@@ -137,7 +139,7 @@ export default function ProjectSchedule(
         <Typography>{t("projectSettings.schedule.removeAll")}</Typography>
 
         <Grid container justifyContent="flex-end" spacing={2}>
-          <Grid item marginTop={1} style={{ width: 100 }}>
+          <Grid item marginTop={1}>
             <Button
               variant="contained"
               onClick={() => setShowRemove(false)}
@@ -146,7 +148,7 @@ export default function ProjectSchedule(
               {t("buttons.cancel")}
             </Button>
           </Grid>
-          <Grid item marginTop={1} style={{ width: 100 }}>
+          <Grid item marginTop={1}>
             <Button
               variant="contained"
               onClick={() => handleRemoveAll()}
@@ -157,6 +159,6 @@ export default function ProjectSchedule(
           </Grid>
         </Grid>
       </Modal>
-    </LocalizationProvider>
+    </>
   );
 }

--- a/src/components/ProjectSettings/ProjectSchedule/index.tsx
+++ b/src/components/ProjectSettings/ProjectSchedule/index.tsx
@@ -1,5 +1,7 @@
 import { CalendarMonth, DateRange, EventRepeat } from "@mui/icons-material";
 import { Button, Grid, Typography } from "@mui/material";
+import { LocalizationProvider } from "@mui/x-date-pickers";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { ReactElement, useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import Modal from "react-modal";
@@ -52,7 +54,7 @@ export default function ProjectSchedule(
   }, [fetchSchedule, props.project.id, showEdit, showRemove, showSelector]);
 
   return (
-    <>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Grid
         container
         direction="column"
@@ -155,6 +157,6 @@ export default function ProjectSchedule(
           </Grid>
         </Grid>
       </Modal>
-    </>
+    </LocalizationProvider>
   );
 }

--- a/src/components/ProjectSettings/tests/index.test.tsx
+++ b/src/components/ProjectSettings/tests/index.test.tsx
@@ -1,3 +1,5 @@
+import { LocalizationProvider } from "@mui/x-date-pickers";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import "@testing-library/jest-dom";
 import { act, cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -57,9 +59,11 @@ const updateProjSettings = async (hasSchedule = false): Promise<void> => {
     // For this update to trigger a permissions refresh, project.id must change.
     // This is accomplished by randomProject() in createMockStore().
     render(
-      <Provider store={createMockStore(hasSchedule)}>
-        <ProjectSettings />
-      </Provider>
+      <LocalizationProvider dateAdapter={AdapterDayjs}>
+        <Provider store={createMockStore(hasSchedule)}>
+          <ProjectSettings />
+        </Provider>
+      </LocalizationProvider>
     );
   });
 };
@@ -88,9 +92,11 @@ beforeAll(async () => {
   resetMocks();
   await act(async () => {
     render(
-      <Provider store={createMockStore()}>
-        <ProjectSettings />
-      </Provider>
+      <LocalizationProvider dateAdapter={AdapterDayjs}>
+        <Provider store={createMockStore()}>
+          <ProjectSettings />
+        </Provider>
+      </LocalizationProvider>
     );
   });
 });


### PR DESCRIPTION
This is prerequisite for installing `material-react-table` for #2875

Changes:
- install `@mui/x-date-pickers` (v6)
  - update frontend license report
- replace English-stuck component-specific `LocalizationProvider` wrappers with one `DatePickersLocalizationProvider` in `AppLoggedIn`
  - use current `i18next` language in `DatePickersLocalizationProvider`
  - add `LocalizationProvider` to the `ProjectSettings` tests (now necessary for the schedule settings with `mui/x-date-pickers` components without their own providers)
- replace deprecated `CalendarPicker` with `DateCalendar`
  - remove unnecessary `date` and `onChange` props
  - update prop `defaultCalendarMonth` to `referenceDate`
  - replace deprecated `renderDay` with corresponding usage of `slots` and `slotProps`
  - extract two instances of `customDayRenderer` for a common `ProjectPickersDay` component
- remove `style={{ width: 100 }}` from button-holding `Grid`s (sizing that assumed English ui)
- add `useEffect` with `Modal.setAppElement("body");` to prevent a console error

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/2876)
<!-- Reviewable:end -->
