### PR TITLE
[MergeDups] Restore removal of redundant audio

### DIFF
--- a/Backend/Services/MergeService.cs
+++ b/Backend/Services/MergeService.cs
@@ -34,22 +34,27 @@ namespace BackendFramework.Services
             parent.ProjectId = projectId;
             parent.History = new List<string>();
 
-            // Add child to history.
             foreach (var childSource in mergeWords.Children)
             {
+                // Add child to history.
                 parent.History.Add(childSource.SrcWordId);
+
                 if (childSource.GetAudio)
                 {
-                    var child = await _wordRepo.GetWord(projectId, childSource.SrcWordId);
-                    if (child is null)
+                    // Add child's audio.
+                    var child = await _wordRepo.GetWord(projectId, childSource.SrcWordId)
+                        ?? throw new KeyNotFoundException($"Unable to locate word: ${childSource.SrcWordId}");
+                    child.Audio.ForEach(pro =>
                     {
-                        throw new KeyNotFoundException($"Unable to locate word: ${childSource.SrcWordId}");
-                    }
-                    parent.Audio.AddRange(child.Audio);
+                        if (parent.Audio.All(p => p.FileName != pro.FileName))
+                        {
+                            parent.Audio.Add(pro);
+                        }
+                    });
                 }
             }
 
-            // Remove duplicates.
+            // Remove history duplicates.
             parent.History = parent.History.Distinct().ToList();
             return parent;
         }


### PR DESCRIPTION
Redundant audio removal was mistakenly taken out in #2795---I thought it wasn't necessary and was wrong.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/2890)
<!-- Reviewable:end -->
