### PR TITLE
Fix determination of which words have been merged

### DIFF
--- a/src/goals/MergeDuplicates/Redux/MergeDupsActions.ts
+++ b/src/goals/MergeDuplicates/Redux/MergeDupsActions.ts
@@ -136,9 +136,11 @@ export function mergeAll() {
     }
 
     // Blacklist the set of words with updated ids.
-    const mergedIds = mergeWordsArray.map((mw) => mw.parent.id);
+    const mergedIds = new Set(
+      mergeWordsArray.flatMap((mw) => mw.children.map((c) => c.srcWordId))
+    );
     const unmergedIds = Object.keys(mergeTree.data.words).filter(
-      (id) => !mergedIds.includes(id)
+      (id) => !mergedIds.has(id)
     );
     const blacklistIds = [...unmergedIds, ...parentIds];
     if (blacklistIds.length > 1) {

--- a/src/goals/MergeDuplicates/Redux/tests/MergeDupsActions.test.tsx
+++ b/src/goals/MergeDuplicates/Redux/tests/MergeDupsActions.test.tsx
@@ -252,6 +252,34 @@ describe("MergeDupActions", () => {
       // No blacklist entry added for only 1 resulting word.
       expect(mockBlacklistAdd).not.toHaveBeenCalled();
     });
+    // Move all senses from B to A
+    it("moves all senses to other word", async () => {
+      const WA = newMergeTreeWord(vernA, {
+        ID1: [S1, S3],
+        ID2: [S2],
+        ID3: [S4],
+      });
+      const tree: MergeTree = { ...defaultTree, words: { WA } };
+      const store = setupStore({
+        ...preloadedState,
+        mergeDuplicateGoal: { ...defaultMergeState, data, tree },
+      });
+      await store.dispatch(mergeAll());
+
+      expect(mockMergeWords).toHaveBeenCalledTimes(1);
+      const parentA = wordAnyGuids(
+        vernA,
+        [senses["S1"], senses["S2"], senses["S4"]],
+        idA
+      );
+      const childA = { srcWordId: idA, getAudio: true };
+      const childB = { srcWordId: idB, getAudio: true };
+      const mockMerge = newMergeWords(parentA, [childA, childB]);
+      expect(mockMergeWords).toHaveBeenCalledWith([mockMerge]);
+
+      // No blacklist entry added for only 1 resulting word.
+      expect(mockBlacklistAdd).not.toHaveBeenCalled();
+    });
 
     // Performs a merge when a word is flagged
     it("adds a flag to a word", async () => {


### PR DESCRIPTION
Follow-up to #2869 

When determining updated ids for the merge blacklist, the identification of words that were merge missed words that had all their senses moved to other words. This pr fixes that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/2902)
<!-- Reviewable:end -->
