### PR TITLE
Prevent Vern/Sense Dialog button invisible overflow

### DIFF
--- a/src/components/DataEntry/DataEntryTable/NewEntry/StyledMenuItem.ts
+++ b/src/components/DataEntry/DataEntryTable/NewEntry/StyledMenuItem.ts
@@ -12,6 +12,7 @@ const StyledMenuItem = styled(MenuItem)(({ theme }) => ({
       color: theme.palette.common.white,
     },
   },
+  overflow: "clip",
 }));
 
 export default StyledMenuItem;


### PR DESCRIPTION
Sara M. reported that in Data Entry (when adding a new entry with a duplicate vernacular form to multiple existing entries), in the "Select an entry" `VernDialog`, clicking just outside the second button, even on the bottom of the first button, triggers the second button.

It turns out that our `StyledMenuItem` for the `VernDialog` and `SenseDialog` implicitly had `overflow: "hidden",`, so setting `overflow: "clip",` fixes the issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/2942)
<!-- Reviewable:end -->
