### PR TITLE
[AudioPlayer] Catch 2-finger mousepad tap as right click

### DIFF
--- a/src/components/Pronunciations/AudioPlayer.tsx
+++ b/src/components/Pronunciations/AudioPlayer.tsx
@@ -11,7 +11,9 @@ import {
 } from "@mui/material";
 import {
   CSSProperties,
+  MouseEvent,
   ReactElement,
+  TouchEvent,
   useCallback,
   useEffect,
   useState,
@@ -124,12 +126,14 @@ export default function AudioPlayer(props: PlayerProps): ReactElement {
     document.removeEventListener("contextmenu", preventEventOnce, false);
   }
 
-  function handleTouch(event: any): void {
+  /** If audio can be deleted or speaker changed, a touchscreen press should open an
+   * options menu instead of the context menu. */
+  function handleTouch(e: TouchEvent<HTMLButtonElement>): void {
     if (canChangeSpeaker || canDeleteAudio) {
       // Temporarily disable context menu since some browsers
       // interpret a long-press touch as a right-click.
       disableContextMenu();
-      setAnchor(event.currentTarget);
+      setAnchor(e.currentTarget);
     }
   }
 
@@ -140,11 +144,19 @@ export default function AudioPlayer(props: PlayerProps): ReactElement {
     setSpeakerDialog(false);
   }
 
+  /** If speaker can be changed, a right click should open the speaker menu instead of
+   * the context menu. */
   function handleOnAuxClick(): void {
     if (canChangeSpeaker) {
-      // Temporarily disable context menu triggered by right-click.
       disableContextMenu();
       setSpeakerDialog(true);
+    }
+  }
+
+  /** Catch a multi-finger mousepad tap as a right click. */
+  function handleOnMouseDown(e: MouseEvent<HTMLButtonElement>): void {
+    if (e.buttons > 1) {
+      handleOnAuxClick();
     }
   }
 
@@ -176,6 +188,7 @@ export default function AudioPlayer(props: PlayerProps): ReactElement {
           tabIndex={-1}
           onAuxClick={handleOnAuxClick}
           onClick={deleteOrTogglePlay}
+          onMouseDown={handleOnMouseDown}
           onTouchStart={handleTouch}
           onTouchEnd={enableContextMenu}
           aria-label="play"


### PR DESCRIPTION
User can change speaker of an audio recording by right-clicking on the AudioPlayer green triangle icon. However, a multi-finger click/tap on a mousepad was overlooked.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/2943)
<!-- Reviewable:end -->
