### PR TITLE
Specify requested k8s resources for CPU & Memory

### DIFF
--- a/deploy/helm/cert-proxy-server/templates/deployment-cert-proxy-server.yaml
+++ b/deploy/helm/cert-proxy-server/templates/deployment-cert-proxy-server.yaml
@@ -61,9 +61,14 @@ spec:
             - name: CERT_PROXY_NAMESPACE
               value: {{ .Release.Namespace }}
           image: {{ include "cert-proxy-server.containerImage" . }}
-          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          imagePullPolicy: Always
           name: combine-cert-proxy
-          resources: {}
+          resources:
+            requests:
+              cpu:  2m
+              memory: 100M
+            limits:
+              memory: 150M
       restartPolicy: Always
 {{- if ne .Values.global.pullSecretName "None" }}
       imagePullSecrets:

--- a/deploy/helm/cert-proxy-server/templates/deployment-nuc-proxy.yaml
+++ b/deploy/helm/cert-proxy-server/templates/deployment-nuc-proxy.yaml
@@ -45,10 +45,15 @@ spec:
                   key: SERVER_NAME
                   name: {{ .Values.envNginxProxy }}
           image: nginx:1.21
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - containerPort: 80
-          resources: {}
+          resources:
+            requests:
+              cpu:  1m
+              memory: 10M
+            limits:
+              memory: 50M
           volumeMounts:
             - name: nginx-html
               mountPath: /usr/share/nginx/html

--- a/deploy/helm/thecombine/charts/backend/templates/deployment-backend.yaml
+++ b/deploy/helm/thecombine/charts/backend/templates/deployment-backend.yaml
@@ -79,7 +79,14 @@ spec:
                   name: env-backend-secrets
           ports:
             - containerPort: 5000
-          resources: {}
+          resources:
+            requests:
+              cpu: 5m
+              memory: 960Mi
+{{- if .Values.global.includeResourceLimits }}
+            limits:
+              memory: 4Gi
+{{- end }}
           volumeMounts:
             - mountPath: /home/app/.CombineFiles
               name: backend-data

--- a/deploy/helm/thecombine/charts/backend/values.yaml
+++ b/deploy/helm/thecombine/charts/backend/values.yaml
@@ -21,6 +21,8 @@ global:
   combineJwtSecretKey: "Override"
   combineSmtpUsername: "Override"
   combineSmtpPassword: "Override"
+  # Values for pulling container image from image registry
+  imagePullPolicy: "Override"
   imageTag: "latest"
   # Define the image registry to use (may be blank for local images)
   imageRegistry: ""

--- a/deploy/helm/thecombine/charts/database/templates/database.yaml
+++ b/deploy/helm/thecombine/charts/database/templates/database.yaml
@@ -48,7 +48,14 @@ spec:
           name: database
           ports:
             - containerPort: 27017
-          resources: {}
+          resources:
+            requests:
+              cpu:  25m
+              memory: 950Mi
+{{- if .Values.global.includeResourceLimits }}
+            limits:
+              memory: 2Gi
+{{- end }}
           volumeMounts:
             - mountPath: /data/db
               name: database-data

--- a/deploy/helm/thecombine/charts/database/values.yaml
+++ b/deploy/helm/thecombine/charts/database/values.yaml
@@ -6,6 +6,8 @@ global:
   # Update strategy should be "Recreate" or "Rolling Update"
   updateStrategy: Recreate
   pullSecretName: "None"
+  # Values for pulling container image from image registry
+  imagePullPolicy: "Override"
   imageTag: "latest"
   # Define the image registry to use (may be blank for local images)
   imageRegistry: ""

--- a/deploy/helm/thecombine/charts/frontend/templates/deployment-frontend.yaml
+++ b/deploy/helm/thecombine/charts/frontend/templates/deployment-frontend.yaml
@@ -74,7 +74,14 @@ spec:
           ports:
             - containerPort: 80
             - containerPort: 443
-          resources: {}
+          resources:
+            requests:
+              cpu:  1m
+              memory: 15M
+{{- if .Values.global.includeResourceLimits }}
+            limits:
+              memory: 40M
+{{- end }}
           volumeMounts:
             - mountPath: /usr/share/nginx/fonts
               name: font-data

--- a/deploy/helm/thecombine/charts/frontend/values.yaml
+++ b/deploy/helm/thecombine/charts/frontend/values.yaml
@@ -8,6 +8,8 @@ global:
   pullSecretName: aws-login-credentials
   # Update strategy should be "Recreate" or "Rolling Update"
   updateStrategy: Recreate
+  # Values for pulling container image from image registry
+  imagePullPolicy: "Override"
   imageTag: "latest"
   # Define the image registry to use (may be blank for local images)
   imageRegistry: ""

--- a/deploy/helm/thecombine/charts/maintenance/templates/cronjob-daily-backup.yaml
+++ b/deploy/helm/thecombine/charts/maintenance/templates/cronjob-daily-backup.yaml
@@ -30,7 +30,12 @@ spec:
               - deployment/maintenance
               - --
               - combine-backup-job.sh
-            resources: {}
+            resources:
+              requests:
+                cpu:  200m
+                memory: 150M
+              limits:
+                memory: 150M
             securityContext:
               capabilities: {}
             terminationMessagePath: /dev/termination-log

--- a/deploy/helm/thecombine/charts/maintenance/templates/deployment-maintenance.yaml
+++ b/deploy/helm/thecombine/charts/maintenance/templates/deployment-maintenance.yaml
@@ -103,7 +103,14 @@ spec:
                 configMapKeyRef:
                   key: local_font_url
                   name: env-maintenance
-          resources: {}
+          resources:
+            requests:
+              cpu:  200m
+              memory: 1200Mi
+{{- if .Values.global.includeResourceLimits }}
+            limits:
+              memory: 4Gi
+{{- end }}
           volumeMounts:
             - mountPath: {{ .Values.fontsDir }}
               name: font-data

--- a/deploy/helm/thecombine/charts/maintenance/values.yaml
+++ b/deploy/helm/thecombine/charts/maintenance/values.yaml
@@ -19,6 +19,8 @@ global:
   awsSecretAccessKey: "Override"
   pullSecretName: "None"
   awsS3Access: aws-s3-credentials
+  # Values for pulling container image from image registry
+  imagePullPolicy: "Override"
   imageTag: "latest"
   # Define the image registry to use (may be blank for local images)
   imageRegistry: ""

--- a/deploy/helm/thecombine/values.yaml
+++ b/deploy/helm/thecombine/values.yaml
@@ -39,6 +39,8 @@ global:
   # Update strategy should be "Recreate" or "Rolling Update"
   updateStrategy: Recreate
 
+  includeResourceLimits: false
+
 aws-login:
   enabled: true
 

--- a/deploy/scripts/setup_files/profiles/dev.yaml
+++ b/deploy/scripts/setup_files/profiles/dev.yaml
@@ -17,6 +17,7 @@ charts:
     global:
       imageRegistry: ""
       imagePullPolicy: Never
+      includeResourceLimits: false
       awsS3Location: dev.thecombine.app
 
     ingressClass: nginx

--- a/deploy/scripts/setup_files/profiles/prod.yaml
+++ b/deploy/scripts/setup_files/profiles/prod.yaml
@@ -32,6 +32,7 @@ charts:
       fontStorageAccessMode: ReadWriteMany
       imagePullPolicy: Always
       pullSecretName: None
+      includeResourceLimits: true
     certManager:
       enabled: false
   cert-proxy-server:

--- a/deploy/scripts/setup_files/profiles/staging.yaml
+++ b/deploy/scripts/setup_files/profiles/staging.yaml
@@ -15,6 +15,7 @@ charts:
       awsS3Location: prod.thecombine.app
       fontStorageAccessMode: ReadWriteMany
       imagePullPolicy: Always
+      includeResourceLimits: true
     tlsSecretName: thecombine-app-tls
     certManager:
       enabled: false


### PR DESCRIPTION
Adds CPU and memory resource requests for the Kubernetes deployments.  In the cases of the QA and Production servers, resource limits are specified as well.

The initial resource requests are set at approximately 120% of the quiescent levels.  The limits are rather broad and should be adjusted as RWC data become available.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3002)
<!-- Reviewable:end -->
