### PR TITLE
Add codecov token to upload actions

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -78,6 +78,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            cli.codecov.io:443
             codecov.io:443
             github.com:443
             storage.googleapis.com:443
@@ -91,6 +92,7 @@ jobs:
       - name: Upload coverage report
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           files: coverage.cobertura.xml
           flags: backend

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -88,6 +88,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            cli.codecov.io:443
             codecov.io:443
             github.com:443
             storage.googleapis.com:443
@@ -101,6 +102,7 @@ jobs:
       - name: Upload coverage report
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           files: cobertura-coverage.xml
           flags: frontend


### PR DESCRIPTION
As of 7 April 2024, Codecov uploads started failing when using `codecov/codecov-action@v3`.

According to codecov/codecov-action issue [#1359](https://github.com/codecov/codecov-action/issues/1359), `v3` is now requiring an upload token.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3047)
<!-- Reviewable:end -->
