### PR TITLE
Update user setup for MS .NET 8.0 images

### DIFF
--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -34,8 +34,9 @@ RUN apt-get update \
 RUN mkdir -p $HOME
 
 # Create an app user so the program doesn't run as root.
-RUN groupadd -r app && \
-  useradd -r -g app -d $HOME -s /sbin/nologin -c "Docker image user" app
+RUN groupmod --gid 999 app && \
+  usermod --uid 999 --gid app --home $HOME --shell /sbin/nologin \
+      --comment "Docker image user" app
 
 ## Set up application install directory.
 RUN mkdir $APP_HOME && \


### PR DESCRIPTION
For the .NET 8 Linux images, Microsoft added an app user and an app user group.  Therefore, when the build tries to create the group, it fails.  This PR replaces the `groupadd` and `useradd` commands with `groupmod` and `usermod` commands.  This allows us to set the UID & GID to 999 which is assumed by the maintenance scripts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3048)
<!-- Reviewable:end -->
