### PR TITLE
[Landing Page] Fix broken User Guide button

### DIFF
--- a/src/components/LandingPage/LandingButtons.tsx
+++ b/src/components/LandingPage/LandingButtons.tsx
@@ -47,7 +47,7 @@ export default function LandingButtons(
           buttonId={`${idAffix}-login`}
         />
         <LandingButton
-          onClick={openUserGuide}
+          onClick={() => openUserGuide()}
           textId="userMenu.userGuide"
           buttonId={`${idAffix}-guide`}
         />


### PR DESCRIPTION
Fixes bug from (https://github.com/sillsdev/TheCombine/pull/2969) where the User Guide button on the landing page links to `https://qa-kube.thecombine.app/docs/[object%20Object]`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3066)
<!-- Reviewable:end -->
