### PR TITLE
[WordCard] Remove odd gap between header and content

### DIFF
--- a/src/components/WordCard/index.tsx
+++ b/src/components/WordCard/index.tsx
@@ -83,7 +83,7 @@ export default function WordCard(props: WordCardProps): ReactElement {
     <Card
       sx={{ backgroundColor: (t) => t.palette.grey[300], minWidth: "200px" }}
     >
-      <CardHeader action={action} title={title} />
+      <CardHeader action={action} sx={{ paddingBottom: 0 }} title={title} />
       <CardContent>
         {/* Expanded audio, note, flag */}
         {full && (


### PR DESCRIPTION
Before:
![Screenshot 2024-04-22 174008](https://github.com/sillsdev/TheCombine/assets/6411521/20f65804-59c4-4806-bceb-420c424012a1)

After:
![Screenshot 2024-04-22 173946](https://github.com/sillsdev/TheCombine/assets/6411521/32b66988-45a9-493f-a705-5feafd475f5d)
