### PR TITLE
[Recorder] Add backstops for if cursor departs button

### DIFF
--- a/src/components/Pronunciations/AudioRecorder.tsx
+++ b/src/components/Pronunciations/AudioRecorder.tsx
@@ -25,11 +25,19 @@ export default function AudioRecorder(props: RecorderProps): ReactElement {
   const recorder = useContext(RecorderContext);
   const { t } = useTranslation();
 
-  function startRecording(): void {
+  async function startRecording(): Promise<void> {
+    // Prevent starting a recording before a previous one is finished.
+    await stopRecording();
+
     recorder.startRecording();
   }
 
   async function stopRecording(): Promise<void> {
+    // Prevent triggering this function if no recording is active.
+    if (!recorder.isRecording()) {
+      return;
+    }
+
     if (props.onClick) {
       props.onClick();
     }

--- a/src/components/Pronunciations/Recorder.ts
+++ b/src/components/Pronunciations/Recorder.ts
@@ -14,6 +14,10 @@ export default class Recorder {
       .catch((err) => this.onError(err));
   }
 
+  isRecording(): boolean {
+    return this.recordRTC?.getState() === "recording";
+  }
+
   startRecording(): void {
     this.recordRTC?.reset();
     this.recordRTC?.startRecording();

--- a/src/components/Pronunciations/RecorderIcon.tsx
+++ b/src/components/Pronunciations/RecorderIcon.tsx
@@ -64,6 +64,7 @@ export default function RecorderIcon(props: RecorderIconProps): ReactElement {
         aria-label="record"
         disabled={props.disabled}
         id={recordButtonId}
+        onBlur={toggleIsRecordingToFalse}
         onPointerDown={toggleIsRecordingToTrue}
         onPointerUp={toggleIsRecordingToFalse}
         onTouchEnd={handleTouchEnd}


### PR DESCRIPTION
Mostly fixes #3073 

Pro: If the record button is clicked/pressed while a previous recording is still active, that previous recording is finished before a new one is started.
Con: If the record button is clicked/tapped just to end a recording that is still going, a second recording blip will also be created (but at least that is easily deleted).

Pro: If focus shifts away from the button, that will also activate the end of the recording. This works if a user clicks elsewhere.
Con: This doesn't always work if the user taps/presses elsewhere, because the initial recording touch doesn't consistently shift focus to the button in the first place.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3077)
<!-- Reviewable:end -->
