### PR TITLE
[ReviewEntries] Turn off return-to-first-page-when-row-is-edited

### DIFF
--- a/src/goals/ReviewEntries/ReviewEntriesTable/index.tsx
+++ b/src/goals/ReviewEntries/ReviewEntriesTable/index.tsx
@@ -317,6 +317,7 @@ export default function ReviewEntriesTable(props: {
   const table = useMaterialReactTable({
     columns,
     data,
+    autoResetPageIndex: false,
     columnFilterDisplayMode: "popover",
     enableColumnActions: false,
     enableColumnDragging: false,


### PR DESCRIPTION
Fixes #3147 

Disable `autoResetPageIndex` (https://www.material-react-table.com/docs/guides/pagination#customize-pagination-behavior), which resets the table to the first page when editing/filtering/sorting. (It would be nice to have the latter two, but not at the expense of the first one.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3158)
<!-- Reviewable:end -->
