### PR TITLE
[GHA] Update OSSF URL in Harden Runner

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -42,7 +42,7 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             api.osv.dev:443
-            api.securityscorecards.dev:443
+            api.scorecard.dev:443
             auth.docker.io:443
             bestpractices.coreinfrastructure.org:443
             fulcio.sigstore.dev:443


### PR DESCRIPTION
The `master` branch fails the `Scorecards supply-chain security / Scorecards analysis (push)` check since #3222, because of `Bump ossf/scorecard-action from 2.3.1 to 2.3.3`. The URL was updated in 2.3.3 (https://github.com/ossf/scorecard-action/pull/1376).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3224)
<!-- Reviewable:end -->
