### PR TITLE
[README] Remove unhelpful action badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # The Combine
 
-[![Frontend Actions Status][github-actions-frontend-badge]][github-actions]
+[![Frontend Actions Status][github-actions-frontend-badge]][github-actions-frontend]
 [![Frontend Coverage][frontend-codecov-badge]][codecov-frontend]
 
-[![Backend Actions Status][github-actions-backend-badge]][github-actions]
+[![Backend Actions Status][github-actions-backend-badge]][github-actions-backend]
 [![Backend Coverage][backend-codecov-badge]][codecov-backend]
 
-[![CodeQL Actions Status][github-actions-codeql-badge]][github-actions]
-[![Python Actions Status][github-actions-python-badge]][github-actions]
-[![OSSF Scorecard][github-actions-ossf-badge]][github-actions]
+[![CodeQL Actions Status][github-actions-codeql-badge]][github-actions-codeql]
+[![Python Actions Status][github-actions-python-badge]][github-actions-python]
+[![OSSF Scorecard][ossf-scorecard-badge]][ossf-scorecard]
 
 [![GitHub release][github-release-badge]][github-version] [![GitHub version][github-version-badge]][github-version]
 [![GitHub][github-license-badge]][github-license] [![GitHub contributors][github-contribs-badge]][github-contribs]
@@ -25,10 +25,13 @@
 [backend-codecov-badge]: https://codecov.io/gh/sillsdev/TheCombine/branch/master/graph/badge.svg?flag=backend
 [github-actions-python-badge]: https://github.com/sillsdev/TheCombine/workflows/python/badge.svg
 [github-actions-codeql-badge]: https://github.com/sillsdev/TheCombine/workflows/CodeQL/badge.svg
-[github-actions-ossf-badge]:
-  https://github.com/sillsdev/TheCombine/workflows/Scorecards%20supply-chain%20security/badge.svg
+[ossf-scorecard-badge]: https://api.scorecard.dev/projects/github.com/sillsdev/TheCombine/badge
 [localization-ui-badge]: https://img.shields.io/badge/User%20Interface-Ar%20En%20Es%20Fr%20Pt%20Zh-blue
-[github-actions]: https://github.com/sillsdev/TheCombine/actions
+[github-actions-frontend]: https://github.com/sillsdev/TheCombine/actions/workflows/frontend.yml
+[github-actions-backend]: https://github.com/sillsdev/TheCombine/actions/workflows/backend.yml
+[github-actions-codeql]: https://github.com/sillsdev/TheCombine/actions/workflows/codeql.yml
+[github-actions-python]: https://github.com/sillsdev/TheCombine/actions/workflows/python.yml
+[ossf-scorecard]: https://scorecard.dev/viewer/?uri=github.com/sillsdev/TheCombine
 [localization-sd-badge]:
   https://img.shields.io/badge/Semantic%20Domains-Ar%20En%20Es%20Fr%20Hi%20Id%20Ml%20My%20Pt%20Ru%20Sw%20Zh-blue
 [localization-ug-badge]: https://img.shields.io/badge/User%20Guide-En%20Es%20Zh-blue

--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@
 [![Backend Actions Status][github-actions-backend-badge]][github-actions-backend]
 [![Backend Coverage][backend-codecov-badge]][codecov-backend]
 
-[![CodeQL Actions Status][github-actions-codeql-badge]][github-actions-codeql]
-[![Python Actions Status][github-actions-python-badge]][github-actions-python]
-[![OSSF Scorecard][ossf-scorecard-badge]][ossf-scorecard]
-
 [![GitHub release][github-release-badge]][github-version] [![GitHub version][github-version-badge]][github-version]
 [![GitHub][github-license-badge]][github-license] [![GitHub contributors][github-contribs-badge]][github-contribs]
 
@@ -23,15 +19,9 @@
 [codecov-backend]: https://app.codecov.io/gh/sillsdev/TheCombine/tree/master/Backend
 [github-actions-backend-badge]: https://github.com/sillsdev/TheCombine/workflows/backend/badge.svg
 [backend-codecov-badge]: https://codecov.io/gh/sillsdev/TheCombine/branch/master/graph/badge.svg?flag=backend
-[github-actions-python-badge]: https://github.com/sillsdev/TheCombine/workflows/python/badge.svg
-[github-actions-codeql-badge]: https://github.com/sillsdev/TheCombine/workflows/CodeQL/badge.svg
-[ossf-scorecard-badge]: https://api.scorecard.dev/projects/github.com/sillsdev/TheCombine/badge
 [localization-ui-badge]: https://img.shields.io/badge/User%20Interface-Ar%20En%20Es%20Fr%20Pt%20Zh-blue
 [github-actions-frontend]: https://github.com/sillsdev/TheCombine/actions/workflows/frontend.yml
 [github-actions-backend]: https://github.com/sillsdev/TheCombine/actions/workflows/backend.yml
-[github-actions-codeql]: https://github.com/sillsdev/TheCombine/actions/workflows/codeql.yml
-[github-actions-python]: https://github.com/sillsdev/TheCombine/actions/workflows/python.yml
-[ossf-scorecard]: https://scorecard.dev/viewer/?uri=github.com/sillsdev/TheCombine
 [localization-sd-badge]:
   https://img.shields.io/badge/Semantic%20Domains-Ar%20En%20Es%20Fr%20Hi%20Id%20Ml%20My%20Pt%20Ru%20Sw%20Zh-blue
 [localization-ug-badge]: https://img.shields.io/badge/User%20Guide-En%20Es%20Zh-blue
@@ -277,7 +267,9 @@ python -m piptools compile --upgrade requirements.in
 
 ### Load Semantic Domains
 
-Data Entry will not work in The Combine unless the semantic domains have been loaded into the database. Follow the instuctions in [Import Semantic Domains](#import-semantic-domains) below to import the domains from at least one of the semantic domains XML files (which each contain domain data in English and one other language.)
+Data Entry will not work in The Combine unless the semantic domains have been loaded into the database. Follow the
+instuctions in [Import Semantic Domains](#import-semantic-domains) below to import the domains from at least one of the
+semantic domains XML files (which each contain domain data in English and one other language.)
 
 ## Available Scripts
 


### PR DESCRIPTION
[Before](https://github.com/sillsdev/TheCombine/tree/master?tab=readme-ov-file#the-combine), the links were all to the same general actions page and the scorecard badge always said passing even when it failed:
![Screenshot 2024-07-10 141538](https://github.com/sillsdev/TheCombine/assets/6411521/1a36f373-9d43-4b31-96fc-c13ee7c48a9f)

[After](https://github.com/sillsdev/TheCombine/tree/badges?tab=readme-ov-file#the-combine), the links go to specific relevant actions and the unhelpful action badges are removed:
![Screenshot 2024-07-10 141521](https://github.com/sillsdev/TheCombine/assets/6411521/4f4ace64-eeae-423e-8c07-0e3c6416e0ad)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3225)
<!-- Reviewable:end -->
