### PR TITLE
[README] Add 'Getting Started' step to load sem doms

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A rapid word collection tool. See the [User Guide](https://sillsdev.github.io/Th
       2. [Linux Python Installation](#linux-python-installation)
       3. [macOS Python Installation](#macos-python-installation)
       4. [Python Packages](#python-packages)
+   4. [Load Semantic Domains](#load-semantic-domains)
 2. [Available Scripts](#available-scripts)
    1. [Running in Development](#running-in-development)
    2. [Using OpenAPI](#using-openapi)
@@ -270,6 +271,10 @@ To upgrade the pinned dependencies for the Maintenance container:
 cd maintenance
 python -m piptools compile --upgrade requirements.in
 ```
+
+### Load Semantic Domains
+
+Data Entry will not work in The Combine unless the semantic domains have been loaded into the database. Follow the instuctions in [Import Semantic Domains](#import-semantic-domains) below to import the domains from at least one of the semantic domains XML files (which each contain domain data in English and one other language.)
 
 ## Available Scripts
 


### PR DESCRIPTION
Resolves #3159 

To review this pr, check out the [README in this branch](https://github.com/sillsdev/TheCombine/tree/readme-get-started?tab=readme-ov-file#the-combine):
* Does the placement of the new step make sense in the README?
* Is the instruction clear, concise, correct, and without spelling/grammar errors?
* Do the links work?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3230)
<!-- Reviewable:end -->
