### PR TITLE
Update TS target to ES6 (which we already use)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "es5"
+    "target": "es6"
   },
   "exclude": ["*.dic.js"],
   "include": [".eslintrc.cjs", "src", "scripts"]


### PR DESCRIPTION
We're already using ES6 features (e.g., arrow functions and `let`/`const`), so this change just helps the IDE know what Typescript syntax is allowable.

Before this change, my IDE was complaining about the use of the `/u` RegEx ending in `src/utilities/spellChecker.ts`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3232)
<!-- Reviewable:end -->
