### PR TITLE
[DataEntryTable] Use current analysis lang with sense glosses

### DIFF
--- a/src/components/DataEntry/DataEntryTable/NewEntry/SenseDialog.tsx
+++ b/src/components/DataEntry/DataEntryTable/NewEntry/SenseDialog.tsx
@@ -60,7 +60,7 @@ export function SenseList(props: SenseListProps): ReactElement {
 
   const menuItem = (sense: Sense): ReactElement => {
     const word: Word = { ...props.selectedWord, senses: [sense] };
-    const gloss = firstGlossText(sense);
+    const gloss = firstGlossText(sense, props.analysisLang);
     return (
       <StyledMenuItem
         id={sense.guid}

--- a/src/components/DataEntry/DataEntryTable/RecentEntry.tsx
+++ b/src/components/DataEntry/DataEntryTable/RecentEntry.tsx
@@ -41,11 +41,13 @@ export function RecentEntry(props: RecentEntryProps): ReactElement {
     sense.glosses.push(newGloss("", props.analysisLang.bcp47));
   }
   const [editing, setEditing] = useState(false);
-  const [gloss, setGloss] = useState(firstGlossText(sense));
+  const [gloss, setGloss] = useState(
+    firstGlossText(sense, props.analysisLang.bcp47)
+  );
   const [vernacular, setVernacular] = useState(props.entry.vernacular);
 
   const updateGlossField = (gloss: string): void => {
-    setEditing(gloss !== firstGlossText(sense));
+    setEditing(gloss !== firstGlossText(sense, props.analysisLang.bcp47));
     setGloss(gloss);
   };
   const updateVernField = (vern: string): void => {
@@ -54,7 +56,7 @@ export function RecentEntry(props: RecentEntryProps): ReactElement {
   };
 
   function conditionallyUpdateGloss(): void {
-    if (firstGlossText(sense) !== gloss) {
+    if (firstGlossText(sense, props.analysisLang.bcp47) !== gloss) {
       props.updateGloss(props.rowIndex, gloss);
     }
   }

--- a/src/components/DataEntry/DataEntryTable/index.tsx
+++ b/src/components/DataEntry/DataEntryTable/index.tsx
@@ -161,6 +161,8 @@ export function updateEntryGloss(
   const newSense: Sense = { ...sense };
   let glossIndex = sense.glosses.findIndex((g) => g.language === analysisLang);
   if (glossIndex === -1) {
+    // It there's no gloss in the current analysis language, then it's the first gloss
+    // that was shown in the RecentEntry that's now being updated.
     glossIndex = 0;
   }
   newSense.glosses = sense.glosses.map((g, i) =>

--- a/src/components/DataEntry/DataEntryTable/tests/index.test.tsx
+++ b/src/components/DataEntry/DataEntryTable/tests/index.test.tsx
@@ -246,7 +246,7 @@ describe("DataEntryTable", () => {
   describe("updateEntryGloss", () => {
     it("throws error when entry doesn't have sense with specified guid", () => {
       const entry: WordAccess = { word: newWord(), senseGuid: "gibberish" };
-      expect(() => updateEntryGloss(entry, "def", "semDomId", "")).toThrow();
+      expect(() => updateEntryGloss(entry, "def", "semDomId", "en")).toThrow();
     });
 
     it("directly updates a sense with no other semantic domains", () => {
@@ -260,9 +260,9 @@ describe("DataEntryTable", () => {
       const expectedWord: Word = { ...entry.word };
       expectedWord.senses[senseIndex] = { ...sense, glosses: [expectedGloss] };
 
-      expect(updateEntryGloss(entry, def, mockSemDom.id, "")).toEqual(
-        expectedWord
-      );
+      expect(
+        updateEntryGloss(entry, def, mockSemDom.id, sense.glosses[0].language)
+      ).toEqual(expectedWord);
     });
 
     it("updates gloss of specified language", () => {
@@ -301,9 +301,9 @@ describe("DataEntryTable", () => {
       newSense.semanticDomains = [mockSemDom];
       const expectedWord: Word = { ...word, senses: [oldSense, newSense] };
 
-      expect(updateEntryGloss(entry, def, mockSemDom.id, "")).toEqual(
-        expectedWord
-      );
+      expect(
+        updateEntryGloss(entry, def, mockSemDom.id, sense.glosses[0].language)
+      ).toEqual(expectedWord);
     });
   });
 

--- a/src/components/DataEntry/DataEntryTable/tests/index.test.tsx
+++ b/src/components/DataEntry/DataEntryTable/tests/index.test.tsx
@@ -26,7 +26,13 @@ import {
   newSemanticDomainTreeNode,
   semDomFromTreeNode,
 } from "types/semanticDomain";
-import { multiSenseWord, newSense, newWord, simpleWord } from "types/word";
+import {
+  multiSenseWord,
+  newGloss,
+  newSense,
+  newWord,
+  simpleWord,
+} from "types/word";
 import { Bcp47Code } from "types/writingSystem";
 import { firstGlossText } from "utilities/wordUtilities";
 
@@ -240,7 +246,7 @@ describe("DataEntryTable", () => {
   describe("updateEntryGloss", () => {
     it("throws error when entry doesn't have sense with specified guid", () => {
       const entry: WordAccess = { word: newWord(), senseGuid: "gibberish" };
-      expect(() => updateEntryGloss(entry, "def", "semDomId")).toThrow();
+      expect(() => updateEntryGloss(entry, "def", "semDomId", "")).toThrow();
     });
 
     it("directly updates a sense with no other semantic domains", () => {
@@ -254,7 +260,30 @@ describe("DataEntryTable", () => {
       const expectedWord: Word = { ...entry.word };
       expectedWord.senses[senseIndex] = { ...sense, glosses: [expectedGloss] };
 
-      expect(updateEntryGloss(entry, def, mockSemDom.id)).toEqual(expectedWord);
+      expect(updateEntryGloss(entry, def, mockSemDom.id, "")).toEqual(
+        expectedWord
+      );
+    });
+
+    it("updates gloss of specified language", () => {
+      const senseIndex = 1;
+      const sense: Sense = { ...mockMultiWord.senses[senseIndex] };
+      const targetGloss = newGloss("target language", "tl");
+      sense.glosses = [...sense.glosses, targetGloss];
+      sense.semanticDomains = [mockSemDom];
+      const entry: WordAccess = { word: mockMultiWord, senseGuid: sense.guid };
+      const def = "newGlossDef";
+
+      const expectedGloss: Gloss = { ...targetGloss, def };
+      const expectedWord: Word = { ...entry.word };
+      expectedWord.senses[senseIndex] = {
+        ...sense,
+        glosses: [sense.glosses[0], expectedGloss],
+      };
+
+      expect(
+        updateEntryGloss(entry, def, mockSemDom.id, targetGloss.language)
+      ).toEqual(expectedWord);
     });
 
     it("splits a sense with multiple semantic domains", () => {
@@ -272,7 +301,9 @@ describe("DataEntryTable", () => {
       newSense.semanticDomains = [mockSemDom];
       const expectedWord: Word = { ...word, senses: [oldSense, newSense] };
 
-      expect(updateEntryGloss(entry, def, mockSemDom.id)).toEqual(expectedWord);
+      expect(updateEntryGloss(entry, def, mockSemDom.id, "")).toEqual(
+        expectedWord
+      );
     });
   });
 

--- a/src/utilities/tests/wordUtilities.test.ts
+++ b/src/utilities/tests/wordUtilities.test.ts
@@ -120,6 +120,17 @@ describe("wordUtilities", () => {
       sense.glosses[0] = newGloss(text);
       expect(firstGlossText(sense)).toEqual(text);
     });
+
+    it("matches language, if lang specified and present", () => {
+      const sense = newSense();
+      const lang = "gg";
+      const defFirst = "Not this one.";
+      const defInLang = "This one!";
+      expect(firstGlossText(sense)).toEqual("");
+      sense.glosses.push(newGloss(defFirst, "en"), newGloss(defInLang, lang));
+      expect(firstGlossText(sense, lang)).toEqual(defInLang);
+      expect(firstGlossText(sense, "other")).toEqual(defFirst);
+    });
   });
 
   describe("getAnalysisLangsFromWords", () => {

--- a/src/utilities/wordUtilities.ts
+++ b/src/utilities/wordUtilities.ts
@@ -55,11 +55,15 @@ export function compareFlags(a: Flag, b: Flag): number {
 }
 
 /**
- * Returns the text of the first gloss of a sense.
+ * Returns the text of the first gloss of a sense, matching the lang tag if given.
  * In the case that the array of glosses is empty, returns an empty string.
  */
-export function firstGlossText(sense: Sense): string {
-  return sense.glosses[0]?.def ?? "";
+export function firstGlossText(sense: Sense, lang?: string): string {
+  return (
+    sense.glosses.find((g) => g.language === lang)?.def ??
+    sense.glosses[0]?.def ??
+    ""
+  );
 }
 
 /**


### PR DESCRIPTION
Resolves #3167

Acceptance test:

- Data Entry:
  - In semantic domain 1, create entry with vernacular form "vern" and gloss "glossA"
- Project settings:
  - In "Basic Settings" tab, make sure Autocomplete is on
  - In "Languages" tab, add a new analysis language and move it to the top of the list
- Data Entry:
  - In semantic domain 2, begin adding a new word by typing "vern" in the Vernacular text field
  - Select "vern" from the dropdown options (either by clicking it or pressing enter when it's highlighted)
  - Verify that the "Select and Entry" dialog pops up and that there is a "vern  glossA" option
  - Select it (either by clicking it or pressing enter when it's highlighted)
  - Verify that the "Select a Sense" dialog appears and that there is a "glossA" option
  - Select it (either by clicking it or pressing enter when it's highlighted)
  - Verify that the dialog disappears and the Gloss text field now has the text "glossA"
  - Change the gloss text to "glossB" and press Enter
- Review Entries:
  - Verify that there is a row with "vern" in the Vernacular column and "glossA; glossB" in the Glosses column
  - Edit that row by clicking the pencil icon in the first column
  - Verify that an "Edit : vern" dialog pops up and that in the Senses section there is a single sense with two different glosses ("glossA" in the former analysis language; "glossB" in the latter analysis language)
- Data Entry:
  - In semantic domain 3, begin adding a new word by typing "vern" in the Vernacular text field
  - Select "vern" from the dropdown options (either by clicking it or pressing enter when it's highlighted)
  - Verify that the "Select and Entry" dialog pops up and that there is a "vern  glossB" option
  - Select it (either by clicking it or pressing enter when it's highlighted)
  - Verify that the "Select a Sense" dialog appears and that there is a "glossB" option
  - Select it (either by clicking it or pressing enter when it's highlighted)
  - Verify that the dialog disappears and the Gloss text field now has the text "glossB"
  - Press Enter to submit the word
- Review Entries:
  - Verify that there is a row with: "vern" in the Vernacular column; "1" in the # column; "glossA; glossB" in the Glosses column; semantic domains 1, 2, and 3 in the Domains column.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3239)
<!-- Reviewable:end -->
