### PR TITLE
Revert #3290: Clear vern selection when user returns to vern field

### DIFF
--- a/src/components/DataEntry/DataEntryTable/EntryCellComponents/VernWithSuggestions.tsx
+++ b/src/components/DataEntry/DataEntryTable/EntryCellComponents/VernWithSuggestions.tsx
@@ -19,7 +19,6 @@ interface VernWithSuggestionsProps {
   updateVernField: (newValue: string, openDialog?: boolean) => void;
   onBlur: () => void;
   onClose?: (e: SyntheticEvent, reason: AutocompleteCloseReason) => void;
-  onFocus?: () => void;
   suggestedVerns?: string[];
   handleEnter: () => void;
   vernacularLang: WritingSystem;
@@ -52,7 +51,6 @@ export default function VernWithSuggestions(
         // onChange is triggered when an option is selected
         props.updateVernField(value ?? "", true);
       }}
-      onFocus={props.onFocus}
       onInputChange={(_e, value) => {
         // onInputChange is triggered by typing
         props.updateVernField(value);

--- a/src/components/DataEntry/DataEntryTable/NewEntry/index.tsx
+++ b/src/components/DataEntry/DataEntryTable/NewEntry/index.tsx
@@ -221,13 +221,6 @@ export default function NewEntry(props: NewEntryProps): ReactElement {
     }
   };
 
-  /** Clear the duplicate selection if user returns to the vernacular field. */
-  const handleOnVernFocus = (): void => {
-    if (selectedDup) {
-      setSelectedDup();
-    }
-  };
-
   const handleCloseVernDialog = (id?: string): void => {
     if (id !== undefined) {
       setSelectedDup(id);
@@ -267,7 +260,6 @@ export default function NewEntry(props: NewEntryProps): ReactElement {
                 setVernOpen(true);
               }
             }}
-            onFocus={handleOnVernFocus}
             suggestedVerns={suggestedVerns}
             // To prevent unintentional no-gloss submissions:
             // If enter pressed from the vern field, check whether gloss is empty


### PR DESCRIPTION
This reverts commit 474ec40e429bdc14d0b68448b2766ae624eed7dd.

That bugfix created a different bug, where the vern dialog duplicate selection sometimes returns focus to the vern field, which clears what was just selected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3296)
<!-- Reviewable:end -->
