### PR TITLE
Don't check mic permission on Firefox

### DIFF
--- a/src/components/Pronunciations/Recorder.ts
+++ b/src/components/Pronunciations/Recorder.ts
@@ -1,6 +1,9 @@
 import RecordRTC from "recordrtc";
 
-import { getFileNameForWord } from "components/Pronunciations/utilities";
+import {
+  checkMicPermission,
+  getFileNameForWord,
+} from "components/Pronunciations/utilities";
 
 export default class Recorder {
   private toast: (textId: string) => void;
@@ -63,14 +66,12 @@ export default class Recorder {
 
   private onError(err: Error): void {
     console.error(err);
-    navigator.permissions
-      .query({ name: "microphone" as PermissionName })
-      .then((result) => {
-        this.toast(
-          result.state === "granted"
-            ? "pronunciations.audioStreamError"
-            : "pronunciations.noMicAccess"
-        );
-      });
+    checkMicPermission().then((hasPermission: boolean) =>
+      this.toast(
+        hasPermission
+          ? "pronunciations.audioStreamError"
+          : "pronunciations.noMicAccess"
+      )
+    );
   }
 }

--- a/src/components/Pronunciations/RecorderIcon.tsx
+++ b/src/components/Pronunciations/RecorderIcon.tsx
@@ -8,6 +8,7 @@ import {
   resetPronunciations,
 } from "components/Pronunciations/Redux/PronunciationsActions";
 import { PronunciationsStatus } from "components/Pronunciations/Redux/PronunciationsReduxTypes";
+import { checkMicPermission } from "components/Pronunciations/utilities";
 import { useAppDispatch, useAppSelector } from "rootRedux/hooks";
 import { type StoreState } from "rootRedux/types";
 import { themeColors } from "types/theme";
@@ -37,9 +38,7 @@ export default function RecorderIcon(props: RecorderIconProps): ReactElement {
   const { t } = useTranslation();
 
   useEffect(() => {
-    navigator.permissions
-      .query({ name: "microphone" as PermissionName })
-      .then((result) => setHasMic(result.state === "granted"));
+    checkMicPermission().then(setHasMic);
   }, []);
 
   function toggleIsRecordingToTrue(): void {

--- a/src/components/Pronunciations/utilities.ts
+++ b/src/components/Pronunciations/utilities.ts
@@ -30,10 +30,21 @@ export async function uploadFileFromPronunciation(
   return newId;
 }
 
-/** On Chrome/Chromium, checks if the user has granted mic permission to The Combine.
- * On other browsers, assumes permission is granted. */
+/** Names of Firefox browsers in user-agent strings, all lowercase.
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent/Firefox */
+const firefoxBrowsers = ["firefox", "focus", "fxios"];
+
+/** Check if a user-agent string is of a Firefox browser. */
+function isUserAgentFirefox(userAgent: string): boolean {
+  const uaLower = userAgent.toLocaleLowerCase();
+  return firefoxBrowsers.some((browser) => uaLower.includes(browser));
+}
+
+/** Checks if the user has granted mic permission to The Combine,
+ * except on Firefox assumes permission is granted. */
 export async function checkMicPermission(): Promise<boolean> {
-  if (navigator.userAgent.includes("Chrom")) {
+  if (!isUserAgentFirefox(navigator.userAgent)) {
     const result = await navigator.permissions.query({
       name: "microphone" as PermissionName, // This causes a TypeError on Firefox.
     });

--- a/src/components/Pronunciations/utilities.ts
+++ b/src/components/Pronunciations/utilities.ts
@@ -29,3 +29,16 @@ export async function uploadFileFromPronunciation(
   URL.revokeObjectURL(fileName);
   return newId;
 }
+
+/** On Chrome/Chromium, checks if the user has granted mic permission to The Combine.
+ * On other browsers, assumes permission is granted. */
+export async function checkMicPermission(): Promise<boolean> {
+  if (navigator.userAgent.includes("Chrom")) {
+    const result = await navigator.permissions.query({
+      name: "microphone" as PermissionName, // This causes a TypeError on Firefox.
+    });
+    return result.state === "granted";
+  } else {
+    return Promise.resolve(true);
+  }
+}

--- a/src/components/Pronunciations/utilities.ts
+++ b/src/components/Pronunciations/utilities.ts
@@ -38,7 +38,6 @@ export async function checkMicPermission(): Promise<boolean> {
       name: "microphone" as PermissionName, // This causes a TypeError on Firefox.
     });
     return result.state === "granted";
-  } else {
-    return true;
   }
+  return true;
 }

--- a/src/components/Pronunciations/utilities.ts
+++ b/src/components/Pronunciations/utilities.ts
@@ -39,6 +39,6 @@ export async function checkMicPermission(): Promise<boolean> {
     });
     return result.state === "granted";
   } else {
-    return Promise.resolve(true);
+    return true;
   }
 }


### PR DESCRIPTION
https://github.com/sillsdev/TheCombine/pull/3247 broke recording on Firefox:
```
Uncaught (in promise) TypeError: 'microphone' (value of 'name' member of PermissionDescriptor) is not a valid value for enumeration PermissionName.
```

(See https://stackoverflow.com/questions/53147944/firefox-permission-name-member-of-permissiondescriptor-camera-is-not-a-vali)

This fix checks for permission on all non-Firefox browsers and assumes permission for Firefox.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3298)
<!-- Reviewable:end -->
