### PR TITLE
[User Guide] Fix displaced note

### DIFF
--- a/docs/user_guide/docs/goals.es.md
+++ b/docs/user_guide/docs/goals.es.md
@@ -169,9 +169,7 @@ la siguiente manera:
 
 !!! note "Nota"
 
-A sense can only have one part of speech. If two senses are merged that have different parts of speech in the same
-general category, the parts of speech will be combined, separated by a semicolon (;). However, if they have different
-general categories, only the first one is preserved.
+    A sense can only have one part of speech. If two senses are merged that have different parts of speech in the same general category, the parts of speech will be combined, separated by a semicolon (;). However, if they have different general categories, only the first one is preserved.
 
 #### Entradas y acepciones protegidas
 

--- a/docs/user_guide/docs/goals.md
+++ b/docs/user_guide/docs/goals.md
@@ -164,9 +164,7 @@ information will appear in the Merge Duplicate sense cards as follows:
 
 !!! note "Note"
 
-A sense can only have one part of speech. If two senses are merged that have different parts of speech in the same
-general category, the parts of speech will be combined, separated by a semicolon (;). However, if they have different
-general categories, only the first one is preserved.
+    A sense can only have one part of speech. If two senses are merged that have different parts of speech in the same general category, the parts of speech will be combined, separated by a semicolon (;). However, if they have different general categories, only the first one is preserved.
 
 #### Protected Entries and Senses
 

--- a/docs/user_guide/docs/goals.zh.md
+++ b/docs/user_guide/docs/goals.zh.md
@@ -156,9 +156,7 @@ You can delete an entire entry by clicking the
 
 !!! note "笔记"
 
-A sense can only have one part of speech. If two senses are merged that have different parts of speech in the same
-general category, the parts of speech will be combined, separated by a semicolon (;). However, if they have different
-general categories, only the first one is preserved.
+    A sense can only have one part of speech. If two senses are merged that have different parts of speech in the same general category, the parts of speech will be combined, separated by a semicolon (;). However, if they have different general categories, only the first one is preserved.
 
 #### 受保护的词条与词义
 

--- a/docs/user_guide/docs/project.es.md
+++ b/docs/user_guide/docs/project.es.md
@@ -163,7 +163,8 @@ used for the file names).
 #### Exportar {#export}
 
 Tras pulsar el botón Exportar, puede navegar por otras partes del sitio web mientras se preparan los datos para la
-descargar. When the data is gathered, the download will begin automatically. The filename is the project id.
+descargar. When the data is gathered, the download will begin automatically. El nombre del archivo es el id del
+proyecto.
 
 !!! warning "Importante"
 


### PR DESCRIPTION
The note text wasn't indented, resulting in an empty note followed by a paragraph with the intended note content.

Before:
![Screenshot 2024-08-23 145259](https://github.com/user-attachments/assets/c20f7362-dd3c-4905-8419-c90589518946)

After:
![Screenshot 2024-08-23 145326](https://github.com/user-attachments/assets/29545dbd-053d-4abe-96e0-1532430d06e0)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3325)
<!-- Reviewable:end -->
