### PR TITLE
Standalone installer improvements

### DIFF
--- a/deploy/scripts/combine_charts.py
+++ b/deploy/scripts/combine_charts.py
@@ -70,6 +70,6 @@ def generate(version: str, aws_login_version: str = default_aws_login_version) -
 
 
 if __name__ == "__main__":
-    """Allow calling from the command line for testing, etc."""
+    """Allow calling from the command line."""
     args = parse_args()
     generate(args.version, args.aws)

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -56,18 +56,12 @@ create-python-venv () {
   #####
   # Setup Python virtual environment
   echo "Setting up venv in ${DEPLOY_DIR}"
-  if [ -f "./venv.tar.gz" ] ; then
-    tar xzf ./venv.tar.gz
-    sed -i "s|%%VENV_DIR%%|${DEPLOY_DIR}/venv|g" ${DEPLOY_DIR}/venv/bin/*
-    source venv/bin/activate
-  else
-    python3 -m venv venv
-    source venv/bin/activate
-    echo "Install pip and pip-tools"
-    python -m pip install --upgrade pip pip-tools
-    echo "Install dependencies"
-    python -m piptools sync requirements.txt
-  fi
+  python3 -m venv venv
+  source venv/bin/activate
+  echo "Install pip and pip-tools"
+  python -m pip install --upgrade pip pip-tools
+  echo "Install dependencies"
+  python -m piptools sync requirements.txt
 }
 
 # Install Kubernetes engine and other supporting
@@ -204,6 +198,7 @@ DEPLOY_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd
 CONFIG_DIR=${HOME}/.config/combine
 mkdir -p ${CONFIG_DIR}
 SINGLE_STEP=0
+IS_SERVER=0
 
 # See if we need to continue from a previous install
 STATE_FILE=${CONFIG_DIR}/install-state
@@ -225,6 +220,9 @@ while (( "$#" )) ; do
       ;;
     restart)
       next-state "Pre-reqs"
+      ;;
+    server)
+      IS_SERVER=1
       ;;
     single-step)
       SINGLE_STEP=1
@@ -313,11 +311,14 @@ while [ "$STATE" != "Done" ] ; do
       next-state "Shutdown-combine"
       ;;
     Shutdown-combine)
-      # Shut down the combine services
-      combinectl stop
-      # Disable combine services from starting at boot time
-      sudo systemctl disable create_ap
-      sudo systemctl disable k3s
+      # If not being installed as a server,
+      if [[ $IS_SERVER != 1 ]] ; then
+        # Shut down the combine services
+        combinectl stop
+        # Disable combine services from starting at boot time
+        sudo systemctl disable create_ap
+        sudo systemctl disable k3s
+      fi
       # Print the current status
       combinectl status
       next-state "Done"

--- a/deploy/scripts/package_images.py
+++ b/deploy/scripts/package_images.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import re
 from typing import Any, Dict, List
 
+import combine_charts
 from utils import init_logging, run_cmd
 import yaml
 
@@ -132,6 +133,8 @@ def package_middleware(
 
 def package_thecombine(tag: str, image_dir: Path) -> None:
     logging.info(f"Packaging The Combine version {tag}.")
+    logging.debug("Create helm charts from templates")
+    combine_charts.generate(tag)
     logging.debug(" - Get template for The Combine.")
     results = run_cmd(
         [

--- a/installer/make-combine-installer.sh
+++ b/installer/make-combine-installer.sh
@@ -57,14 +57,6 @@ if [[ $NET_INSTALL == 0 ]] ; then
   ./package_images.py ${COMBINE_VERSION} ${TEMP_DIR}
   INSTALLER_NAME="combine-installer.run"
   popd
-  # create tarball for venv
-  #
-  # replace the current directory in the venv files with a string
-  # that can be used to relocate the venv
-  VENV_DIR=`pwd`/venv
-  echo "VENV_DIR == ${VENV_DIR}"
-  sed -i "s|${VENV_DIR}|%%VENV_DIR%%|g" venv/bin/*
-  tar czf ${TEMP_DIR}/venv.tar.gz venv
   rm -rf venv
 else
   # Package the Combine for network installation


### PR DESCRIPTION
These changes improve the standalone installer as follows:

- This change adds a `server` option so that installer can be used to setup a NUC (or other device) running as a server.  If the `server` option is specified, then the Combine is configured to start at boot time.
- The Python virtual environment is removed from the installer.  This means that more code must be downloaded during the installation but the installer can run on a system that has a version of Python3 installed that is different from the system that was used to create the installer.
- The script to make the installer will now generate the `Chart.yaml` files from their templates for all of the `helm` charts before building the packages.  Before this change, the installer could only be created from a working directory that had been used to install _The Combine_ previously.