### PR TITLE
Expose mongo transactions

### DIFF
--- a/Backend.Tests/Controllers/MergeControllerTests.cs
+++ b/Backend.Tests/Controllers/MergeControllerTests.cs
@@ -14,6 +14,7 @@ namespace Backend.Tests.Controllers
         private IMergeBlacklistRepository _mergeBlacklistRepo = null!;
         private IMergeGraylistRepository _mergeGraylistRepo = null!;
         private IWordRepository _wordRepo = null!;
+        private IMongoDbContext _mongoDbContext = null!;
         private IMergeService _mergeService = null!;
         private IPermissionService _permissionService = null!;
         private IWordService _wordService = null!;
@@ -42,7 +43,8 @@ namespace Backend.Tests.Controllers
             _mergeGraylistRepo = new MergeGraylistRepositoryMock();
             _wordRepo = new WordRepositoryMock();
             _wordService = new WordService(_wordRepo);
-            _mergeService = new MergeService(_mergeBlacklistRepo, _mergeGraylistRepo, _wordRepo, _wordService);
+            _mongoDbContext = new MongoDbContextMock();
+            _mergeService = new MergeService(_mergeBlacklistRepo, _mergeGraylistRepo, _wordRepo, _wordService, _mongoDbContext);
             _permissionService = new PermissionServiceMock();
             _mergeController = new MergeController(_mergeService, _permissionService);
         }

--- a/Backend.Tests/Mocks/MongoDbContextMock.cs
+++ b/Backend.Tests/Mocks/MongoDbContextMock.cs
@@ -5,14 +5,14 @@ using MongoDB.Driver;
 
 namespace Backend.Tests.Mocks;
 
-public class MongoDbContextMock: IMongoDbContext
+public class MongoDbContextMock : IMongoDbContext
 {
     public IMongoDatabase Db => throw new NotSupportedException();
     public Task<IMongoTransaction> BeginTransaction()
     {
         return Task.FromResult<IMongoTransaction>(new MongoTransactionMock());
     }
-    
+
     private sealed class MongoTransactionMock : IMongoTransaction
     {
         public Task CommitTransactionAsync()

--- a/Backend.Tests/Mocks/MongoDbContextMock.cs
+++ b/Backend.Tests/Mocks/MongoDbContextMock.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Threading.Tasks;
+using BackendFramework.Interfaces;
+using MongoDB.Driver;
+
+namespace Backend.Tests.Mocks;
+
+public class MongoDbContextMock: IMongoDbContext
+{
+    public IMongoDatabase Db => throw new NotSupportedException();
+    public Task<IMongoTransaction> BeginTransaction()
+    {
+        return Task.FromResult<IMongoTransaction>(new MongoTransactionMock());
+    }
+    
+    private sealed class MongoTransactionMock : IMongoTransaction
+    {
+        public Task CommitTransactionAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task AbortTransactionAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Backend.Tests/Services/MergeServiceTests.cs
+++ b/Backend.Tests/Services/MergeServiceTests.cs
@@ -14,6 +14,7 @@ namespace Backend.Tests.Services
         private IMergeGraylistRepository _mergeGraylistRepo = null!;
         private IWordRepository _wordRepo = null!;
         private IWordService _wordService = null!;
+        private IMongoDbContext _mongoDbContext = null!;
         private IMergeService _mergeService = null!;
 
         private const string ProjId = "MergeServiceTestProjId";
@@ -26,7 +27,8 @@ namespace Backend.Tests.Services
             _mergeGraylistRepo = new MergeGraylistRepositoryMock();
             _wordRepo = new WordRepositoryMock();
             _wordService = new WordService(_wordRepo);
-            _mergeService = new MergeService(_mergeBlacklistRepo, _mergeGraylistRepo, _wordRepo, _wordService);
+            _mongoDbContext = new MongoDbContextMock();
+            _mergeService = new MergeService(_mergeBlacklistRepo, _mergeGraylistRepo, _wordRepo, _wordService, _mongoDbContext);
         }
 
         [Test]

--- a/Backend/Contexts/BannerContext.cs
+++ b/Backend/Contexts/BannerContext.cs
@@ -1,7 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
-using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 
 namespace BackendFramework.Contexts
@@ -9,14 +8,13 @@ namespace BackendFramework.Contexts
     [ExcludeFromCodeCoverage]
     public class BannerContext : IBannerContext
     {
-        private readonly IMongoDatabase _db;
+        private readonly IMongoDbContext _mongoDbContext;
 
-        public BannerContext(IOptions<Startup.Settings> options)
+        public BannerContext(IMongoDbContext mongoDbContext)
         {
-            var client = new MongoClient(options.Value.ConnectionString);
-            _db = client.GetDatabase(options.Value.CombineDatabase);
+            _mongoDbContext = mongoDbContext;
         }
 
-        public IMongoCollection<Banner> Banners => _db.GetCollection<Banner>("BannerCollection");
+        public IMongoCollection<Banner> Banners => _mongoDbContext.Db.GetCollection<Banner>("BannerCollection");
     }
 }

--- a/Backend/Contexts/MergeBlacklistContext.cs
+++ b/Backend/Contexts/MergeBlacklistContext.cs
@@ -1,7 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
-using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 
 namespace BackendFramework.Contexts
@@ -9,15 +8,13 @@ namespace BackendFramework.Contexts
     [ExcludeFromCodeCoverage]
     public class MergeBlacklistContext : IMergeBlacklistContext
     {
-        private readonly IMongoDatabase _db;
-
-        public MergeBlacklistContext(IOptions<Startup.Settings> options)
+        private readonly IMongoDbContext _mongoDbContext;
+        public MergeBlacklistContext(IMongoDbContext mongoDbContext)
         {
-            var client = new MongoClient(options.Value.ConnectionString);
-            _db = client.GetDatabase(options.Value.CombineDatabase);
+            _mongoDbContext = mongoDbContext;
         }
 
-        public IMongoCollection<MergeWordSet> MergeBlacklist => _db.GetCollection<MergeWordSet>(
+        public IMongoCollection<MergeWordSet> MergeBlacklist => _mongoDbContext.Db.GetCollection<MergeWordSet>(
             "MergeBlacklistCollection");
     }
 }

--- a/Backend/Contexts/MergeGraylistContext.cs
+++ b/Backend/Contexts/MergeGraylistContext.cs
@@ -1,7 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
-using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 
 namespace BackendFramework.Contexts
@@ -9,15 +8,13 @@ namespace BackendFramework.Contexts
     [ExcludeFromCodeCoverage]
     public class MergeGraylistContext : IMergeGraylistContext
     {
-        private readonly IMongoDatabase _db;
-
-        public MergeGraylistContext(IOptions<Startup.Settings> options)
+        private readonly IMongoDbContext _mongoDbContext;
+        public MergeGraylistContext(IMongoDbContext mongoDbContext)
         {
-            var client = new MongoClient(options.Value.ConnectionString);
-            _db = client.GetDatabase(options.Value.CombineDatabase);
+            _mongoDbContext = mongoDbContext;
         }
 
-        public IMongoCollection<MergeWordSet> MergeGraylist => _db.GetCollection<MergeWordSet>(
+        public IMongoCollection<MergeWordSet> MergeGraylist => _mongoDbContext.Db.GetCollection<MergeWordSet>(
             "MergeGraylistCollection");
     }
 }

--- a/Backend/Contexts/MongoDbContext.cs
+++ b/Backend/Contexts/MongoDbContext.cs
@@ -1,0 +1,47 @@
+﻿using System.Threading.Tasks;
+using BackendFramework.Interfaces;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+
+namespace BackendFramework.Contexts;
+
+public class MongoDbContext : IMongoDbContext
+{
+    public IMongoDatabase Db { get; }
+
+    public MongoDbContext(IOptions<Startup.Settings> options)
+    {
+        var client = new MongoClient(options.Value.ConnectionString);
+        Db = client.GetDatabase(options.Value.CombineDatabase);
+    }
+
+    public async Task<IMongoTransaction> BeginTransaction()
+    {
+        return new MongoTransactionWrapper(await Db.Client.StartSessionAsync());
+    }
+
+    private class MongoTransactionWrapper : IMongoTransaction
+    {
+        private readonly IClientSessionHandle _session;
+
+        public MongoTransactionWrapper(IClientSessionHandle session)
+        {
+            _session = session;
+        }
+
+        public Task CommitTransactionAsync()
+        {
+            return _session.CommitTransactionAsync();
+        }
+
+        public Task AbortTransactionAsync()
+        {
+            return _session.AbortTransactionAsync();
+        }
+
+        public void Dispose()
+        {
+            _session.Dispose();
+        }
+    }
+}

--- a/Backend/Contexts/PasswordResetContext.cs
+++ b/Backend/Contexts/PasswordResetContext.cs
@@ -10,17 +10,16 @@ namespace BackendFramework.Contexts
     [ExcludeFromCodeCoverage]
     public class PasswordResetContext : IPasswordResetContext
     {
-        private readonly IMongoDatabase _db;
+        private readonly IMongoDbContext _mongoDbContext;
         public int ExpireTime { get; }
 
-        public PasswordResetContext(IOptions<Startup.Settings> options)
+        public PasswordResetContext(IOptions<Startup.Settings> options, IMongoDbContext mongoDbContext)
         {
-            var client = new MongoClient(options.Value.ConnectionString);
-            _db = client.GetDatabase(options.Value.CombineDatabase);
+            _mongoDbContext = mongoDbContext;
             ExpireTime = options.Value.PassResetExpireTime;
         }
 
-        private IMongoCollection<PasswordReset> PasswordResets => _db.GetCollection<PasswordReset>(
+        private IMongoCollection<PasswordReset> PasswordResets => _mongoDbContext.Db.GetCollection<PasswordReset>(
             "PasswordResetCollection");
 
         public Task ClearAll(string email)

--- a/Backend/Contexts/ProjectContext.cs
+++ b/Backend/Contexts/ProjectContext.cs
@@ -1,7 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
-using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 
 namespace BackendFramework.Contexts
@@ -9,14 +8,12 @@ namespace BackendFramework.Contexts
     [ExcludeFromCodeCoverage]
     public class ProjectContext : IProjectContext
     {
-        private readonly IMongoDatabase _db;
-
-        public ProjectContext(IOptions<Startup.Settings> options)
+        private readonly IMongoDbContext _mongoDbContext;
+        public ProjectContext(IMongoDbContext mongoDbContext)
         {
-            var client = new MongoClient(options.Value.ConnectionString);
-            _db = client.GetDatabase(options.Value.CombineDatabase);
+            _mongoDbContext = mongoDbContext;
         }
 
-        public IMongoCollection<Project> Projects => _db.GetCollection<Project>("ProjectsCollection");
+        public IMongoCollection<Project> Projects => _mongoDbContext.Db.GetCollection<Project>("ProjectsCollection");
     }
 }

--- a/Backend/Contexts/SemanticDomainContext.cs
+++ b/Backend/Contexts/SemanticDomainContext.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
-using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 
 namespace BackendFramework.Contexts
@@ -9,15 +8,13 @@ namespace BackendFramework.Contexts
     [ExcludeFromCodeCoverage]
     public class SemanticDomainContext : ISemanticDomainContext
     {
-        private readonly IMongoDatabase _db;
-
-        public SemanticDomainContext(IOptions<Startup.Settings> options)
+        private readonly IMongoDbContext _mongoDbContext;
+        public SemanticDomainContext(IMongoDbContext mongoDbContext)
         {
-            var client = new MongoClient(options.Value.ConnectionString);
-            _db = client.GetDatabase(options.Value.CombineDatabase);
+            _mongoDbContext = mongoDbContext;
         }
 
-        public IMongoCollection<SemanticDomainTreeNode> SemanticDomains => _db.GetCollection<SemanticDomainTreeNode>("SemanticDomainTree");
-        public IMongoCollection<SemanticDomainFull> FullSemanticDomains => _db.GetCollection<SemanticDomainFull>("SemanticDomains");
+        public IMongoCollection<SemanticDomainTreeNode> SemanticDomains => _mongoDbContext.Db.GetCollection<SemanticDomainTreeNode>("SemanticDomainTree");
+        public IMongoCollection<SemanticDomainFull> FullSemanticDomains => _mongoDbContext.Db.GetCollection<SemanticDomainFull>("SemanticDomains");
     }
 }

--- a/Backend/Contexts/SpeakerContext.cs
+++ b/Backend/Contexts/SpeakerContext.cs
@@ -9,7 +9,7 @@ namespace BackendFramework.Contexts
     public class SpeakerContext : ISpeakerContext
     {
         private readonly IMongoDbContext _mongoDbContext;
-        
+
         public SpeakerContext(IMongoDbContext mongoDbContext)
         {
             _mongoDbContext = mongoDbContext;

--- a/Backend/Contexts/SpeakerContext.cs
+++ b/Backend/Contexts/SpeakerContext.cs
@@ -1,7 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
-using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 
 namespace BackendFramework.Contexts
@@ -9,14 +8,13 @@ namespace BackendFramework.Contexts
     [ExcludeFromCodeCoverage]
     public class SpeakerContext : ISpeakerContext
     {
-        private readonly IMongoDatabase _db;
-
-        public SpeakerContext(IOptions<Startup.Settings> options)
+        private readonly IMongoDbContext _mongoDbContext;
+        
+        public SpeakerContext(IMongoDbContext mongoDbContext)
         {
-            var client = new MongoClient(options.Value.ConnectionString);
-            _db = client.GetDatabase(options.Value.CombineDatabase);
+            _mongoDbContext = mongoDbContext;
         }
 
-        public IMongoCollection<Speaker> Speakers => _db.GetCollection<Speaker>("SpeakersCollection");
+        public IMongoCollection<Speaker> Speakers => _mongoDbContext.Db.GetCollection<Speaker>("SpeakersCollection");
     }
 }

--- a/Backend/Contexts/UserContext.cs
+++ b/Backend/Contexts/UserContext.cs
@@ -1,7 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
-using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 
 namespace BackendFramework.Contexts
@@ -9,14 +8,12 @@ namespace BackendFramework.Contexts
     [ExcludeFromCodeCoverage]
     public class UserContext : IUserContext
     {
-        private readonly IMongoDatabase _db;
-
-        public UserContext(IOptions<Startup.Settings> options)
+        private readonly IMongoDbContext _mongoDbContext;
+        public UserContext(IMongoDbContext mongoDbContext)
         {
-            var client = new MongoClient(options.Value.ConnectionString);
-            _db = client.GetDatabase(options.Value.CombineDatabase);
+            _mongoDbContext = mongoDbContext;
         }
 
-        public IMongoCollection<User> Users => _db.GetCollection<User>("UsersCollection");
+        public IMongoCollection<User> Users => _mongoDbContext.Db.GetCollection<User>("UsersCollection");
     }
 }

--- a/Backend/Contexts/UserEditContext.cs
+++ b/Backend/Contexts/UserEditContext.cs
@@ -1,7 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
-using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 
 namespace BackendFramework.Contexts
@@ -9,14 +8,12 @@ namespace BackendFramework.Contexts
     [ExcludeFromCodeCoverage]
     public class UserEditContext : IUserEditContext
     {
-        private readonly IMongoDatabase _db;
-
-        public UserEditContext(IOptions<Startup.Settings> options)
+        private readonly IMongoDbContext _mongoDbContext;
+        public UserEditContext(IMongoDbContext mongoDbContext)
         {
-            var client = new MongoClient(options.Value.ConnectionString);
-            _db = client.GetDatabase(options.Value.CombineDatabase);
+            _mongoDbContext = mongoDbContext;
         }
 
-        public IMongoCollection<UserEdit> UserEdits => _db.GetCollection<UserEdit>("UserEditsCollection");
+        public IMongoCollection<UserEdit> UserEdits => _mongoDbContext.Db.GetCollection<UserEdit>("UserEditsCollection");
     }
 }

--- a/Backend/Contexts/UserRoleContext.cs
+++ b/Backend/Contexts/UserRoleContext.cs
@@ -1,7 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
-using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 
 namespace BackendFramework.Contexts
@@ -9,14 +8,12 @@ namespace BackendFramework.Contexts
     [ExcludeFromCodeCoverage]
     public class UserRoleContext : IUserRoleContext
     {
-        private readonly IMongoDatabase _db;
-
-        public UserRoleContext(IOptions<Startup.Settings> options)
+        private readonly IMongoDbContext _mongoDbContext;
+        public UserRoleContext(IMongoDbContext mongoDbContext)
         {
-            var client = new MongoClient(options.Value.ConnectionString);
-            _db = client.GetDatabase(options.Value.CombineDatabase);
+            _mongoDbContext = mongoDbContext;
         }
 
-        public IMongoCollection<UserRole> UserRoles => _db.GetCollection<UserRole>("UserRolesCollection");
+        public IMongoCollection<UserRole> UserRoles => _mongoDbContext.Db.GetCollection<UserRole>("UserRolesCollection");
     }
 }

--- a/Backend/Contexts/WordContext.cs
+++ b/Backend/Contexts/WordContext.cs
@@ -1,7 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
-using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 
 namespace BackendFramework.Contexts
@@ -9,15 +8,13 @@ namespace BackendFramework.Contexts
     [ExcludeFromCodeCoverage]
     public class WordContext : IWordContext
     {
-        private readonly IMongoDatabase _db;
-
-        public WordContext(IOptions<Startup.Settings> options)
+        private readonly IMongoDbContext _mongoDbContext;
+        public WordContext(IMongoDbContext mongoDbContext)
         {
-            var client = new MongoClient(options.Value.ConnectionString);
-            _db = client.GetDatabase(options.Value.CombineDatabase);
+            _mongoDbContext = mongoDbContext;
         }
 
-        public IMongoCollection<Word> Words => _db.GetCollection<Word>("WordsCollection");
-        public IMongoCollection<Word> Frontier => _db.GetCollection<Word>("FrontierCollection");
+        public IMongoCollection<Word> Words => _mongoDbContext.Db.GetCollection<Word>("WordsCollection");
+        public IMongoCollection<Word> Frontier => _mongoDbContext.Db.GetCollection<Word>("FrontierCollection");
     }
 }

--- a/Backend/Interfaces/IMongoDbContext.cs
+++ b/Backend/Interfaces/IMongoDbContext.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+
+namespace BackendFramework.Interfaces;
+
+public interface IMongoDbContext
+{
+    IMongoDatabase Db { get; }
+    Task<IMongoTransaction> BeginTransaction();
+}
+
+public interface IMongoTransaction : IDisposable
+{
+    Task CommitTransactionAsync();
+    Task AbortTransactionAsync();
+}

--- a/Backend/Startup.cs
+++ b/Backend/Startup.cs
@@ -287,6 +287,9 @@ namespace BackendFramework
             services.AddTransient<IWordContext, WordContext>();
             services.AddTransient<IWordRepository, WordRepository>();
             services.AddTransient<IWordService, WordService>();
+            
+            // mongo context, scoped so it is shared across a single request
+            services.AddScoped<IMongoDbContext, MongoDbContext>();
         }
 
         /// <summary> This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Backend/Startup.cs
+++ b/Backend/Startup.cs
@@ -287,7 +287,7 @@ namespace BackendFramework
             services.AddTransient<IWordContext, WordContext>();
             services.AddTransient<IWordRepository, WordRepository>();
             services.AddTransient<IWordService, WordService>();
-            
+
             // mongo context, scoped so it is shared across a single request
             services.AddScoped<IMongoDbContext, MongoDbContext>();
         }

--- a/Backend/Startup.cs
+++ b/Backend/Startup.cs
@@ -339,7 +339,8 @@ namespace BackendFramework
 
             // If an admin user has been created via the command line, treat that as a single action and shut the
             // server down so the calling script knows it's been completed successfully or unsuccessfully.
-            var userRepo = app.ApplicationServices.GetService<IUserRepository>();
+            using var startupScope = app.ApplicationServices.CreateAsyncScope();
+            var userRepo = startupScope.ServiceProvider.GetService<IUserRepository>();
             if (userRepo is not null && CreateAdminUser(userRepo))
             {
                 _logger.LogInformation("Stopping application");


### PR DESCRIPTION
From [this](https://github.com/sillsdev/TheCombine/pull/3194#discussion_r1774773492) discussion and a follow up with Jason he mentioned that transactions haven't been exposed to utilize them in mongo.

In order for transactions to work across repos there needs to only be one Mongo client in a given request, I've refactored all the type specific contexts to get the IMongoDb from the new IMongoDbContext which is a [scoped service](https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection#scoped)  so there's only one instance per request.

Then I changed a couple methods in the Merge service to make changes inside transactions. You'll notice that the transaction is not aborted in our user code, this is because the transaction is disposable and if it's disposed before it's committed then it will be aborted, so if an exception is thrown between Begin and Commit then the changes made will be rolled back.

Feel free to suggest changes, I don't really love how I had to mock out and expose the transactions via the IMongoDbContext which also contains the IMongoDatabase, but I didn't really feel like making a separate service just for transactions, @jasonleenaylor let me know what you think there if we want to split those out.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3369)
<!-- Reviewable:end -->
