### PR TITLE
Fix shebang for Python scripts

### DIFF
--- a/deploy/scripts/app_release.py
+++ b/deploy/scripts/app_release.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 from __future__ import annotations
 

--- a/deploy/scripts/aws_env.py
+++ b/deploy/scripts/aws_env.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python
 """Set AWS Environment variables from aws cli profiles."""
 
 from __future__ import annotations

--- a/deploy/scripts/build.py
+++ b/deploy/scripts/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 """
 Build the containerd images for The Combine.

--- a/deploy/scripts/check_certs.py
+++ b/deploy/scripts/check_certs.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python
 
 import argparse
 import subprocess

--- a/deploy/scripts/combine_charts.py
+++ b/deploy/scripts/combine_charts.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python
 """
 Update the Helm chart version with the specified version.
 """

--- a/deploy/scripts/kube_env.py
+++ b/deploy/scripts/kube_env.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """Manage the Kubernetes environment for kubectl & helm."""
 
 from __future__ import annotations

--- a/deploy/scripts/package_images.py
+++ b/deploy/scripts/package_images.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python
 
 """
 Package the container images used for The Combine to support air-gapped installation.

--- a/deploy/scripts/sem_dom_import.py
+++ b/deploy/scripts/sem_dom_import.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python
 """
 Create data files for importing the Semantic Domain information into the Mongo database.
 

--- a/deploy/scripts/setup_cluster.py
+++ b/deploy/scripts/setup_cluster.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """Install the pre-requisite helm charts for the Combine on a k8s cluster."""
 
 from __future__ import annotations

--- a/deploy/scripts/setup_combine.py
+++ b/deploy/scripts/setup_combine.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python
 
 """
 Install The Combine Helm charts on a specified Kubernetes cluster.

--- a/deploy/scripts/setup_target.py
+++ b/deploy/scripts/setup_target.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python
 
 import argparse
 import os

--- a/maintenance/scripts/add_user_to_proj.py
+++ b/maintenance/scripts/add_user_to_proj.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """
 Add user to a project.
 

--- a/maintenance/scripts/combine_backup.py
+++ b/maintenance/scripts/combine_backup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """Create a backup of TheCombine and push the file to AWS S3 service."""
 
 import argparse

--- a/maintenance/scripts/combine_restore.py
+++ b/maintenance/scripts/combine_restore.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """
 Restore The Combine from a backup stored in the AWS S3 service.
 

--- a/maintenance/scripts/db_update_audio_type.py
+++ b/maintenance/scripts/db_update_audio_type.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python
 
 import argparse
 import logging

--- a/maintenance/scripts/get_fonts.py
+++ b/maintenance/scripts/get_fonts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """
 Generates font support for all SIL fonts used in Mui-Language-Picker.
 

--- a/maintenance/scripts/monitor.py
+++ b/maintenance/scripts/monitor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """
 Monitor TLS secrets for changes and push changes to AWS S3.
 

--- a/maintenance/scripts/rm_project.py
+++ b/maintenance/scripts/rm_project.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """
 Remove a project and its associated data from TheCombine.
 

--- a/maintenance/scripts/update_cert.py
+++ b/maintenance/scripts/update_cert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """
 Check the expiration time of the TLS secret and update if needed.
 

--- a/scripts/clean_aws_repo.py
+++ b/scripts/clean_aws_repo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 """
 This script cleans out old docker images from the AWS ECR repository.

--- a/scripts/cleanup_local_repo.py
+++ b/scripts/cleanup_local_repo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 """Remove all temporary files and folders within the local Git repository.
 

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 """Regenerate the frontend OpenAPI bindings to the backend.
 

--- a/scripts/get_fonts_dev.py
+++ b/scripts/get_fonts_dev.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 """
 Runs maintenance/scripts/get_fonts.py with dev arguments for -f and -o.

--- a/scripts/split_dictionary.py
+++ b/scripts/split_dictionary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """
 Splits a dictionary file into smaller files.
 """

--- a/scripts/subtitle_tutorial_video.py
+++ b/scripts/subtitle_tutorial_video.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """
 Add subtitles to a tutorial video.
 If video path is not provided, still generates .srt files.


### PR DESCRIPTION
Change the "shebang" for Python scripts from:
```
#!/usr/bin/env python3
```
to
```
#!/usr/bin/env python
```

The original shebang was set so that Linux users can run the Python scripts by just providing the script name, e.g. `./deploy/scripts/app_release.py --get`.

Both of these shebang lines work because the `venv` module sets up `python3` and `python` to point to the version of Python in the virtual environment.  However, when the `venv` is created on Windows, only the `python` alias is created.  This means that the scripts fail when run from a `Git Bash`  session.

The new shebang works for both environments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3370)
<!-- Reviewable:end -->
