### PR TITLE
Avoid empty lines in aws profiles list

### DIFF
--- a/deploy/scripts/aws_env.py
+++ b/deploy/scripts/aws_env.py
@@ -29,7 +29,7 @@ def list_aws_profiles() -> List[str]:
     aws_ver = aws_version()
     if aws_ver is not None and aws_ver == 2:
         result = run_cmd(["aws", "configure", "list-profiles"], chomp=True)
-        return result.stdout.split("\n")
+        return [profile for profile in result.stdout.split("\n") if profile]
     return []
 
 


### PR DESCRIPTION
Hit an error deploying The Combine because it is possible for the command that lists AWS profiles to have an extra empty line, which results in trying to fetch details for a profile with no name. (Have you every tried to go through the desert on a profile with no name?)

This pr avoids that snag.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3387)
<!-- Reviewable:end -->
