### PR TITLE
Prevent double-click recorder bug

### DIFF
--- a/src/components/Pronunciations/AudioRecorder.tsx
+++ b/src/components/Pronunciations/AudioRecorder.tsx
@@ -26,20 +26,20 @@ export default function AudioRecorder(props: RecorderProps): ReactElement {
   const { t } = useTranslation();
 
   useEffect(() => {
-    // Enable clicking only when the word id has changed
+    // Re-enable clicking when the word id has changed.
     setClicked(false);
   }, [props.id]);
 
-  async function startRecording(): Promise<void> {
+  async function startRecording(): Promise<boolean> {
     if (clicked) {
-      // Prevent clicking again before the word has updated with the first recording.
-      return;
+      // Prevent recording again before this word has updated.
+      return false;
     }
 
     const recordingId = recorder.getRecordingId();
     if (recordingId && recordingId !== props.id) {
       // Prevent interfering with an active recording on a different entry.
-      return;
+      return false;
     }
 
     // Prevent starting a recording before a previous one is finished.
@@ -53,7 +53,9 @@ export default function AudioRecorder(props: RecorderProps): ReactElement {
         errorMessage += ` ${t("pronunciations.recordingPermission")}`;
       }
       toast.error(errorMessage);
+      return false;
     }
+    return true;
   }
 
   async function stopRecording(): Promise<string | undefined> {

--- a/src/components/Pronunciations/AudioRecorder.tsx
+++ b/src/components/Pronunciations/AudioRecorder.tsx
@@ -26,7 +26,7 @@ export default function AudioRecorder(props: RecorderProps): ReactElement {
   const { t } = useTranslation();
 
   useEffect(() => {
-    // Re-enable clicking when the word id has changed.
+    // Re-enable clicking when the word id has changed
     setClicked(false);
   }, [props.id]);
 
@@ -42,10 +42,10 @@ export default function AudioRecorder(props: RecorderProps): ReactElement {
       return false;
     }
 
+    setClicked(true);
+
     // Prevent starting a recording before a previous one is finished.
     await stopRecording();
-
-    setClicked(true);
 
     if (!recorder.startRecording(props.id)) {
       let errorMessage = t("pronunciations.recordingError");
@@ -58,7 +58,7 @@ export default function AudioRecorder(props: RecorderProps): ReactElement {
     return true;
   }
 
-  async function stopRecording(): Promise<string | undefined> {
+  async function stopRecording(): Promise<void> {
     // Prevent triggering this function if no recording is active.
     if (recorder.getRecordingId() === undefined) {
       return;
@@ -68,8 +68,9 @@ export default function AudioRecorder(props: RecorderProps): ReactElement {
       props.onClick();
     }
     const file = await recorder.stopRecording();
-    if (!file) {
+    if (!file || !file.size) {
       toast.error(t("pronunciations.recordingError"));
+      setClicked(false);
       return;
     }
     if (!props.noSpeaker) {

--- a/src/components/Pronunciations/AudioRecorder.tsx
+++ b/src/components/Pronunciations/AudioRecorder.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useContext } from "react";
+import { ReactElement, useContext, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "react-toastify";
 
@@ -22,9 +22,20 @@ export default function AudioRecorder(props: RecorderProps): ReactElement {
     (state: StoreState) => state.currentProjectState.speaker?.id
   );
   const recorder = useContext(RecorderContext);
+  const [clicked, setClicked] = useState(false);
   const { t } = useTranslation();
 
+  useEffect(() => {
+    // Enable clicking only when the word id has changed
+    setClicked(false);
+  }, [props.id]);
+
   async function startRecording(): Promise<void> {
+    if (clicked) {
+      // Prevent clicking again before the word has updated with the first recording.
+      return;
+    }
+
     const recordingId = recorder.getRecordingId();
     if (recordingId && recordingId !== props.id) {
       // Prevent interfering with an active recording on a different entry.
@@ -33,6 +44,8 @@ export default function AudioRecorder(props: RecorderProps): ReactElement {
 
     // Prevent starting a recording before a previous one is finished.
     await stopRecording();
+
+    setClicked(true);
 
     if (!recorder.startRecording(props.id)) {
       let errorMessage = t("pronunciations.recordingError");

--- a/src/components/Pronunciations/RecorderIcon.tsx
+++ b/src/components/Pronunciations/RecorderIcon.tsx
@@ -19,7 +19,7 @@ export const recordIconId = "recordingIcon";
 interface RecorderIconProps {
   disabled?: boolean;
   id: string;
-  startRecording: () => void;
+  startRecording: () => Promise<boolean>;
   stopRecording: () => void;
 }
 
@@ -41,11 +41,12 @@ export default function RecorderIcon(props: RecorderIconProps): ReactElement {
     checkMicPermission().then(setHasMic);
   }, []);
 
-  function toggleIsRecordingToTrue(): void {
+  async function toggleIsRecordingToTrue(): Promise<void> {
     if (!isRecording) {
       // Only start a recording if there's not another on in progress.
-      dispatch(recording(props.id));
-      props.startRecording();
+      if (await props.startRecording()) {
+        dispatch(recording(props.id));
+      }
     } else {
       // This triggers if user clicks-and-holds on one entry's record icon,
       // drags the mouse outside that icon before releasing,

--- a/src/components/Pronunciations/tests/RecorderIcon.test.tsx
+++ b/src/components/Pronunciations/tests/RecorderIcon.test.tsx
@@ -31,7 +31,7 @@ function mockRecordingState(wordId: string): Partial<StoreState> {
 
 const mockWordId = "1234567890";
 
-const mockStartRecording = jest.fn();
+const mockStartRecording = jest.fn(() => Promise.resolve(true));
 const mockStopRecording = jest.fn();
 
 const renderRecorderIcon = async (wordId = ""): Promise<void> => {


### PR DESCRIPTION
Fixes #3411 and prevents trying to upload an empty audio file.

Stress-test with rapid repeated clicks on the same record button. Then pause a do a normal recording on the same button.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3414)
<!-- Reviewable:end -->
