### PR TITLE
[maintenance] Support arm64

### DIFF
--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -26,6 +26,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             *.actions.githubusercontent.com:443
+            *.cloudfront.net:443
             *.data.mcr.microsoft.com:443
             ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
             api.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com:443
@@ -42,6 +43,7 @@ jobs:
             github.com:443
             mcr.microsoft.com:443
             production.cloudflare.docker.com:443
+            public.ecr.aws:443
             pypi.org:443
             registry-1.docker.io:443
             registry.npmjs.org:443

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -25,6 +25,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             *.actions.githubusercontent.com:443
+            *.cloudfront.net:443
             *.data.mcr.microsoft.com:443
             api.ecr-public.us-east-1.amazonaws.com:443
             api.github.com:443

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -20,6 +20,7 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            *.cloudfront.net:443
             archive.ubuntu.com:80
             auth.docker.io:443
             files.pythonhosted.org:443

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -25,6 +25,7 @@ jobs:
             files.pythonhosted.org:443
             github.com:443
             production.cloudflare.docker.com:443
+            public.ecr.aws:443
             pypi.org:443
             registry-1.docker.io:443
             security.ubuntu.com:80

--- a/README.md
+++ b/README.md
@@ -731,16 +731,20 @@ Install the Kubernetes resources to run _The Combine_ by running:
 python deploy/scripts/setup_combine.py [--target <target_name>] [--tag <image_tag>]
 ```
 
-The default target is `localhost`; the default tag is `latest`. For development testing the script will usually be run
-with no arguments.
+Notes:
 
-If an invalid target is entered, the script will list available targets and prompt the user his/her selection.
-`deploy/scripts/setup_combine.py` assumes that the `kubectl` configuration file is setup to manage the desired
-Kubernetes cluster. For most development users, there will only be the _Rancher Desktop/Docker Desktop_ cluster to
-manage and the installation process will set that up correctly. If there are multiple clusters to manage, the
-`--kubeconfig` and `--context` options will let you specify a different cluster.
+- The default target is `localhost`; the default tag is `latest`. For development testing the script will usually be run
+  with no arguments.
 
-Run the script with the `--help` option to see possible options for the script.
+- If an invalid target is entered, the script will list available targets and prompt the user his/her selection.
+  `deploy/scripts/setup_combine.py` assumes that the `kubectl` configuration file is setup to manage the desired
+  Kubernetes cluster. For most development users, there will only be the _Rancher Desktop/Docker Desktop_ cluster to
+  manage and the installation process will set that up correctly. If there are multiple clusters to manage, the
+  `--kubeconfig` and `--context` options will let you specify a different cluster.
+
+- Run the script with the `--help` option to see possible options for the script.
+
+- The setup assumes `amd64` architecture. If the target architecture is `arm64`, add `--set global.cpuArch=arm64`.
 
 When the script completes, the resources will be installed on the specified cluster. It may take a few moments before
 all the containers are up and running. If you are using _Rancher Desktop_, you can use the
@@ -749,22 +753,25 @@ all the containers are up and running. If you are using _Rancher Desktop_, you c
 
 ```console
 $ kubectl -n thecombine get deployments
-NAME          READY   UP-TO-DATE   AVAILABLE   AGE
-backend       1/1     1            1           10m
-database      1/1     1            1           10m
-frontend      1/1     1            1           10m
-maintenance   1/1     1            1           10m
+NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
+backend                        1/1     1            1           10m
+database                       1/1     1            1           10m
+frontend                       1/1     1            1           10m
+maintenance                    1/1     1            1           10m
+otel-opentelemetry-collector   1/1     1            1           19m
 ```
 
 or
 
 ```console
 $ kubectl -n thecombine get pods
-NAME                           READY   STATUS    RESTARTS   AGE
-backend-5657559949-z2flp       1/1     Running   0          10m
-database-794b4d956f-zjszm      1/1     Running   0          10m
-frontend-7d6d79f8c5-lkhhz      1/1     Running   0          10m
-maintenance-7f4b5b89b8-rhgk9   1/1     Running   0          10m
+NAME                                            READY   STATUS      RESTARTS   AGE
+backend-5657559949-z2flp                        1/1     Running     0          10m
+database-794b4d956f-zjszm                       1/1     Running     0          10m
+frontend-7d6d79f8c5-lkhhz                       1/1     Running     0          10m
+install-fonts-4jcsl                             0/1     Completed   0          8m
+maintenance-7f4b5b89b8-rhgk9                    1/1     Running     0          10m
+otel-opentelemetry-collector-5b5b69557b-zqk5d   1/1     Running     0          19m
 ```
 
 ### Connecting to Your Cluster

--- a/deploy/helm/aws-login/templates/aws-ecr-login-cronjob.yaml
+++ b/deploy/helm/aws-login/templates/aws-ecr-login-cronjob.yaml
@@ -18,7 +18,7 @@ spec:
         spec:
           serviceAccountName: {{ .Values.awsEcr.serviceAccount }}
           containers:
-          - image: {{ .Values.awsEcr.image }}:{{ .Values.awsEcr.imageTag }}
+          - image: {{ .Values.awsEcr.image }}:{{ .Values.awsEcr.imageVersion }}-{{ .Values.global.cpuArch }}
             imagePullPolicy: IfNotPresent
             name: {{ .Values.awsEcr.cronJobName }}
             command:

--- a/deploy/helm/aws-login/templates/aws-ecr-login-oneshot.yaml
+++ b/deploy/helm/aws-login/templates/aws-ecr-login-oneshot.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       serviceAccountName: {{ .Values.awsEcr.serviceAccount }}
       containers:
-      - image: {{ .Values.awsEcr.image }}:{{ .Values.awsEcr.imageTag }}
+      - image: {{ .Values.awsEcr.image }}:{{ .Values.awsEcr.imageVersion }}-{{ .Values.global.cpuArch }}
         imagePullPolicy: IfNotPresent
         name: "{{ .Values.awsEcr.jobName }}"
         command:

--- a/deploy/helm/aws-login/values.yaml
+++ b/deploy/helm/aws-login/values.yaml
@@ -15,14 +15,15 @@ global:
   awsAccessKeyId: "Override"
   awsSecretAccessKey: "Override"
   pullSecretName: aws-login-credentials
+  cpuArch: "arm64"
 
 awsEcr:
   configName: aws-ecr-config
   cron: yes
   cronJobName: ecr-cred-helper-cron
   dockerEmail: noreply@thecombine.app
-  image: sillsdev/aws-kubectl
-  imageTag: "0.3.0"
+  image: "public.ecr.aws/thecombine/aws-kubectl"
+  imageVersion: "0.4.0"
   jobName: ecr-cred-helper
   schedule: "0 */8 * * *"
   secretsName: aws-ecr-credentials

--- a/deploy/helm/aws-login/values.yaml
+++ b/deploy/helm/aws-login/values.yaml
@@ -15,7 +15,7 @@ global:
   awsAccessKeyId: "Override"
   awsSecretAccessKey: "Override"
   pullSecretName: aws-login-credentials
-  cpuArch: "arm64"
+  cpuArch: "amd64"
 
 awsEcr:
   configName: aws-ecr-config

--- a/deploy/helm/thecombine/charts/maintenance/templates/cronjob-daily-backup.yaml
+++ b/deploy/helm/thecombine/charts/maintenance/templates/cronjob-daily-backup.yaml
@@ -18,7 +18,7 @@ spec:
         spec:
           serviceAccountName: {{ .Values.serviceAccount.name }}
           containers:
-          - image: sillsdev/aws-kubectl:0.3.0
+          - image: {{ .Values.awsEcr.image }}:{{ .Values.awsEcr.imageVersion }}-{{ .Values.global.cpuArch }}
             imagePullPolicy: Always
             name: daily-backup
             command:

--- a/deploy/helm/thecombine/charts/maintenance/templates/cronjob-update-fonts.yaml
+++ b/deploy/helm/thecombine/charts/maintenance/templates/cronjob-update-fonts.yaml
@@ -18,7 +18,7 @@ spec:
         spec:
           serviceAccountName: {{ .Values.serviceAccount.name }}
           containers:
-          - image: sillsdev/aws-kubectl:0.3.0
+          - image: {{ .Values.awsEcr.image }}:{{ .Values.awsEcr.imageVersion }}-{{ .Values.global.cpuArch }}
             imagePullPolicy: Always
             name: update-fonts
             command:

--- a/deploy/helm/thecombine/charts/maintenance/templates/get-fonts-hook.yaml
+++ b/deploy/helm/thecombine/charts/maintenance/templates/get-fonts-hook.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       containers:
-      - image: sillsdev/aws-kubectl:0.3.0
+      - image: {{ .Values.awsEcr.image }}:{{ .Values.awsEcr.imageVersion }}-{{ .Values.global.cpuArch }}
         imagePullPolicy: Always
         name: "install-fonts"
         command:

--- a/deploy/helm/thecombine/charts/maintenance/values.yaml
+++ b/deploy/helm/thecombine/charts/maintenance/values.yaml
@@ -26,6 +26,7 @@ global:
   imageRegistry: ""
   # Default AWS S3 location
   awsS3Location: "thecombine.app"
+  cpuArch: "arm64"
 
 imageName: combine_maint
 
@@ -34,7 +35,10 @@ serviceAccount:
   role: role-maintenance
   roleBinding: role-maintenance-binding
 
-serviceAccount.name: account-maintenance
+awsEcr:
+  image: "public.ecr.aws/thecombine/aws-kubectl"
+  imageVersion: "0.4.0"
+
 #######################################
 # Variables controlling backups
 #######################################

--- a/deploy/helm/thecombine/charts/maintenance/values.yaml
+++ b/deploy/helm/thecombine/charts/maintenance/values.yaml
@@ -26,7 +26,7 @@ global:
   imageRegistry: ""
   # Default AWS S3 location
   awsS3Location: "thecombine.app"
-  cpuArch: "arm64"
+  cpuArch: "amd64"
 
 imageName: combine_maint
 

--- a/maintenance/Dockerfile
+++ b/maintenance/Dockerfile
@@ -16,7 +16,7 @@
 #   - ARM 64-bit
 ############################################################
 
-FROM sillsdev/aws-kubectl:0.3.0
+FROM public.ecr.aws/thecombine/aws-kubectl:0.4.0-$TARGETARCH
 
 USER root
 


### PR DESCRIPTION
For maintenance use of `aws/kubectl`, switch from [Docker Hub (amd64 only)](https://hub.docker.com/r/sillsdev/aws-kubectl/tags) to [AWS ECR (both amd64 and arm64)](https://gallery.ecr.aws/thecombine/aws-kubectl).

Parallel pr: https://github.com/sillsdev/aws-kubectl/pull/5

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3449)
<!-- Reviewable:end -->
