### PR TITLE
[DataEntry] Ensure analysis lang is on recent entry notes

### DIFF
--- a/src/components/DataEntry/DataEntryTable/index.tsx
+++ b/src/components/DataEntry/DataEntryTable/index.tsx
@@ -1003,13 +1003,14 @@ export default function DataEntryTable(
   const updateRecentNote = useCallback(
     async (index: number, text: string): Promise<void> => {
       const oldWord = state.recentWords[index].word;
+      const language = oldWord.note.language || analysisLang.bcp47;
       text = text.trim();
       if (text !== oldWord.note.text) {
-        const note: Note = { ...oldWord.note, text };
+        const note: Note = { ...oldWord.note, language, text };
         await updateWordInBackend({ ...oldWord, note });
       }
     },
-    [state.recentWords, updateWordInBackend]
+    [analysisLang.bcp47, state.recentWords, updateWordInBackend]
   );
 
   const isNewEntryInProgress =

--- a/src/components/DataEntry/DataEntryTable/index.tsx
+++ b/src/components/DataEntry/DataEntryTable/index.tsx
@@ -1003,9 +1003,9 @@ export default function DataEntryTable(
   const updateRecentNote = useCallback(
     async (index: number, text: string): Promise<void> => {
       const oldWord = state.recentWords[index].word;
-      const language = oldWord.note.language || analysisLang.bcp47;
       text = text.trim();
       if (text !== oldWord.note.text) {
+        const language = oldWord.note.language || analysisLang.bcp47;
         const note: Note = { ...oldWord.note, language, text };
         await updateWordInBackend({ ...oldWord, note });
       }


### PR DESCRIPTION
Fixes #3517 

Acceptance test:

- Create a project with `Backend.Tests/Assets/SingleEntryLiftWithSound.zip`
- Go to Data Entry and select any domain
- In the Vernacular field, type "testing" and press Tab
- When the "Select an entry" and "Select a sense" dialogs appear, select the exiting one
- Once the Gloss field is populated with "what is this", press Enter to submit the word
- In the new row that appears, add a note
- Go to project settings and export the project
- Open the .zip and the contained .lift file
- Verify that the entry's note has a language (not just an empty string)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3518)
<!-- Reviewable:end -->
