### PR TITLE
[GHA] Update backend and CodeQL endpoints

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -34,6 +34,7 @@ jobs:
             dotnetbuilds.azureedge.net:443
             dotnetcli.azureedge.net:443
             github.com:443
+            johnvansickle.com:443
             objects.githubusercontent.com:443
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -153,7 +153,6 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             *.data.mcr.microsoft.com:443
-            *.symcb.com:80
             api.nuget.org:443
             archive.ubuntu.com:80
             dc.services.visualstudio.com:443

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -28,12 +28,12 @@ jobs:
             aka.ms:443
             api.github.com:443
             api.nuget.org:443
+            builds.dotnet.microsoft.com:443
             dc.services.visualstudio.com:443
             deb.debian.org:80
             dotnetbuilds.azureedge.net:443
             dotnetcli.azureedge.net:443
             github.com:443
-            md-hdd-t032zjxllntc.z26.blob.storage.azure.net:443
             objects.githubusercontent.com:443
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -110,12 +110,11 @@ jobs:
             aka.ms:443
             api.github.com:443
             api.nuget.org:443
+            builds.dotnet.microsoft.com:443
             dc.services.visualstudio.com:443
             dotnetcli.azureedge.net:443
             github.com:443
             objects.githubusercontent.com:443
-            ts-crl.ws.symantec.com:80
-
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       # Manually install .NET to work around:
@@ -161,7 +160,6 @@ jobs:
             github.com:443
             mcr.microsoft.com:443
             security.ubuntu.com:80
-            ts-crl.ws.symantec.com:80
       # For subfolders, currently a full checkout is required.
       # See: https://github.com/marketplace/actions/build-and-push-docker-images#path-context
       - name: Checkout repository

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -34,7 +34,7 @@ jobs:
             dotnetbuilds.azureedge.net:443
             dotnetcli.azureedge.net:443
             github.com:443
-            johnvansickle.com:443
+            md-hdd-t032zjxllntc.z26.blob.storage.azure.net:443
             objects.githubusercontent.com:443
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,6 +53,7 @@ jobs:
             *.actions.githubusercontent.com:443
             api.github.com:443
             api.nuget.org:443
+            builds.dotnet.microsoft.com:443
             dc.services.visualstudio.com:443
             files.pythonhosted.org:443
             github.com:443

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,12 +53,13 @@ jobs:
             *.actions.githubusercontent.com:443
             api.github.com:443
             api.nuget.org:443
-            builds.dotnet.microsoft.com:443
             dc.services.visualstudio.com:443
             files.pythonhosted.org:443
             github.com:443
             objects.githubusercontent.com:443
             pypi.org:443
+            uploads.github.com:443
+
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 


### PR DESCRIPTION
Our CodeQL results were failing to upload (e.g., https://github.com/sillsdev/TheCombine/actions/runs/12777064526/job/35617067435#step:7:486 and https://app.stepsecurity.io/github/sillsdev/TheCombine/actions/runs/12777064526?jobid=35617067435&tab=network-events). Added `uploads.github.com:443` to `.github/workflows/codeql.yml` to fix that (e.g., https://github.com/sillsdev/TheCombine/actions/runs/12790261713/job/35655616598?pr=3522#step:7:481).

Harden Runner is only now handling all the backend/CodeQL_build network events (and still doesn't report the network events of backend/test_build -- see https://app.stepsecurity.io/github/sillsdev/TheCombine/actions/runs/12777064538?jobid=35617067433&tab=network-events). Added the missing endpoint `builds.dotnet.microsoft.com:443` to `.github/workflows/backend.yml`. Also removed superfluous endpoint `ts-crl.ws.symantec.com:80`.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3522)
<!-- Reviewable:end -->
