### PR TITLE
[MergeDups] Allow actions from sidebar of protected sense

### DIFF
--- a/src/goals/MergeDuplicates/MergeDupsStep/MergeDragDrop/index.tsx
+++ b/src/goals/MergeDuplicates/MergeDupsStep/MergeDragDrop/index.tsx
@@ -48,14 +48,14 @@ export default function MergeDragDrop(): ReactElement {
       return;
     } else if (res.destination?.droppableId === trashId) {
       // Case 1: The sense was dropped on the trash icon.
-      if (src.isSenseProtected) {
+      if (src.isSenseProtected && !src.order) {
         // Case 1a: Cannot delete a protected sense.
         return;
       }
       setSenseToDelete(res.draggableId);
     } else if (res.combine) {
       // Case 2: the sense was dropped on another sense.
-      if (src.isSenseProtected) {
+      if (src.isSenseProtected && !src.order) {
         // Case 2a: Cannot merge a protected sense into another sense.
         if (srcWordId !== res.combine.droppableId) {
           // The target sense is in a different word, so move instead of combine.


### PR DESCRIPTION
Fixes #3521 

To test:
- import/open a project with protected senses (e.g. `Natqgu.zip`)
- go to Merge Duplicates
- find a set with at least one protected and one non-protected sense
- drag'n'drop a non-protected sense into a protected sense
- when the sidebar pops open, drag the secondary sense out of the sidebar and into any word
- drag'n'drop the non-protected sense back into a protected senses
- when the sidebar opens, drag the secondary sense into the trash and confirm deletion

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3561)
<!-- Reviewable:end -->
