### PR TITLE
[GHA] Update CodeQL workflows

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -91,51 +91,6 @@ jobs:
           flags: backend
           name: Backend
 
-  CodeQL_build:
-    permissions:
-      actions: read # for github/codeql-action/init to get workflow details
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/autobuild to send a status report
-    runs-on: ubuntu-22.04
-    steps:
-      # See https://docs.stepsecurity.io/harden-runner/getting-started/ for instructions on
-      # configuring harden-runner and identifying allowed endpoints.
-      - name: Harden Runner
-        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            aka.ms:443
-            api.github.com:443
-            api.nuget.org:443
-            builds.dotnet.microsoft.com:443
-            dc.services.visualstudio.com:443
-            github.com:443
-            objects.githubusercontent.com:443
-      - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      # Manually install .NET to work around:
-      # https://github.com/github/codeql-action/issues/757
-      - name: Setup .NET
-        uses: actions/setup-dotnet@87b7050bc53ea08284295505d98d2aa94301e852 # v4.2.0
-        with:
-          dotnet-version: "8.0.x"
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@d39d31e687223d841ef683f52467bd88e9b21c14 # v3.25.3
-        with:
-          languages: csharp
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@d39d31e687223d841ef683f52467bd88e9b21c14 # v3.25.3
-      - name: Upload artifacts if build failed
-        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
-        if: ${{ failure() }}
-        with:
-          name: tracer-logs
-          path: ${{ runner.temp }}/*.log
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@d39d31e687223d841ef683f52467bd88e9b21c14 # v3.25.3
-
   docker_build:
     if: ${{ github.event.type }} == "PullRequest"
     runs-on: ubuntu-22.04

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,7 +52,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@d39d31e687223d841ef683f52467bd88e9b21c14 # v3.25.3
+        uses: github/codeql-action/init@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -65,7 +65,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@d39d31e687223d841ef683f52467bd88e9b21c14 # v3.25.3
+        uses: github/codeql-action/autobuild@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8
 
       # Command-line programs to run using the OS shell.
       # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -78,6 +78,6 @@ jobs:
       #   ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@d39d31e687223d841ef683f52467bd88e9b21c14 # v3.25.3
+        uses: github/codeql-action/analyze@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,14 +1,3 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:
@@ -28,18 +17,16 @@ jobs:
     name: Analyze
     runs-on: ubuntu-22.04
     permissions:
-      actions: read
-      contents: read
-      security-events: write
+      actions: read # for github/codeql-action/init to get workflow details
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/autobuild to send a status report
 
     strategy:
       fail-fast: false
       matrix:
-        language: ["csharp", "javascript", "python"]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Use only 'java' to analyze code written in Java, Kotlin or both
-        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+        language: ["actions", "csharp", "javascript-typescript", "python"]
+        # CodeQL supports ['actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
+        # See https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
       # See https://docs.stepsecurity.io/harden-runner/getting-started/ for instructions on


### PR DESCRIPTION
* Remove CodeQL from the `backend` workflow, because:
  * it was redundant with what's in the `codeql` workflow,
  * it had a no-longer-necessary "Setup .NET" step that was a relic of CodeQL previously not supporting the newest .NET,
  * it wasn't even uploading results (e.g., https://github.com/sillsdev/TheCombine/actions/runs/13061541171/job/36446160360#step:9:527);
* Add `actions` to the languages to analyze, since CodeQL now supports GHA analysis;
* Bump to the latest version, which includes said support.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3563)
<!-- Reviewable:end -->
