### PR TITLE
[ReviewEntries] Add error text when trying to save empty sense

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -335,6 +335,7 @@
     "error": {
       "gloss": "Glosses cannot be left blank",
       "glossAndDefinition": "Glosses and definitions cannot both be left blank",
+      "sense": "Cannot save an empty sense",
       "senses": "Cannot save an entry with no senses",
       "vernacular": "Vernacular cannot be left blank"
     },

--- a/src/goals/ReviewEntries/ReviewEntriesTable/Cells/EditCell/EditSenseDialog.tsx
+++ b/src/goals/ReviewEntries/ReviewEntriesTable/Cells/EditCell/EditSenseDialog.tsx
@@ -145,7 +145,7 @@ export default function EditSenseDialog(
     // Confirm nonempty senses
     const cleanedSense = cleanSense(newSense, { definitionsEnabled });
     if (!cleanedSense || typeof cleanedSense === "string") {
-      toast.error(t(cleanedSense ?? ""));
+      toast.error(t(cleanedSense || "reviewEntries.error.sense"));
       return;
     }
 


### PR DESCRIPTION
We toast an error when user tries to save a completely empty sense (no definition, gloss, semantic domain, or part of speech), but the error message is empty. This pr adds an error message.

To test:
* Open a project with at least one entry
* Go to Review Entries
* Click the edit icon at the start of an entry row
* Click the edit icon next to a sense
* Delete all the content
* Click the green checkmark to save the sense

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3593)
<!-- Reviewable:end -->
