### PR TITLE
Remove extraneous semicolons

### DIFF
--- a/Backend.Tests/Controllers/LiftControllerTests.cs
+++ b/Backend.Tests/Controllers/LiftControllerTests.cs
@@ -505,7 +505,7 @@ namespace Backend.Tests.Controllers
             foreach (var file in expectedFileNames)
             {
                 Assert.That(consentFileNames.Contains(file));
-            };
+            }
 
             // Delete everything
             mockFiles.ForEach(path => File.Delete(path));

--- a/Backend/Services/MergeService.cs
+++ b/Backend/Services/MergeService.cs
@@ -96,7 +96,7 @@ namespace BackendFramework.Services
             if (!await _wordService.RestoreFrontierWords(projectId, ids.ChildIds))
             {
                 return false;
-            };
+            }
             foreach (var parentId in ids.ParentIds)
             {
                 await _wordService.DeleteFrontierWord(projectId, userId, parentId);


### PR DESCRIPTION
These two unnecessary semicolons are now causing the backend format check to fail: https://github.com/sillsdev/TheCombine/actions/runs/13526485054/job/37798239572?pr=3622

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3623)
<!-- Reviewable:end -->
