### PR TITLE
Cancel GHA workflows when another commit is pushed to a pr

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref_protected && github.run_id || github.event.pull_request.number }}
+
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,10 +4,13 @@ on:
   push:
     branches: [master]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [master]
   schedule:
     - cron: "21 8 * * 3"
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref_protected && github.run_id || github.event.pull_request.number }}
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/.github/workflows/commit_message_check.yml
+++ b/.github/workflows/commit_message_check.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
   pull-requests: write

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -1,8 +1,14 @@
 name: database
 
 on:
+  push:
+    branches: [master]
   pull_request:
     branches: [master]
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref_protected && github.run_id || github.event.pull_request.number }}
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,6 +9,10 @@
 name: "Dependency Review"
 on: [pull_request]
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [master]
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref_protected && github.run_id || github.event.pull_request.number }}
+
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
 

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,8 +1,14 @@
 name: maintenance
 
 on:
+  push:
+    branches: [master]
   pull_request:
     branches: [master]
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref_protected && github.run_id || github.event.pull_request.number }}
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches: [master]
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: write
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref_protected && github.run_id || github.event.pull_request.number }}
+
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
 


### PR DESCRIPTION
Also, cancel in-progress sillsdev.github.io/TheCombine and qa-kube.thecombine.app deployment workflows when a new commit is pushed to `master`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3658)
<!-- Reviewable:end -->
