### PR TITLE
React router 7

### DIFF
--- a/docs/user_guide/assets/licenses/frontend_licenses.txt
+++ b/docs/user_guide/assets/licenses/frontend_licenses.txt
@@ -1137,33 +1137,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-@remix-run/router 1.17.0
-MIT
-MIT License
-
-Copyright (c) React Training LLC 2015-2019
-Copyright (c) Remix Software Inc. 2020-2021
-Copyright (c) Shopify Inc. 2022-2023
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
 @tanstack/match-sorter-utils 8.19.4
 MIT
 MIT License
@@ -1757,6 +1730,34 @@ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
+
+
+cookie 1.0.2
+MIT
+(The MIT License)
+
+Copyright (c) 2012-2014 Roman Shtylman <shtylman@gmail.com>
+Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 
 
 cosmiconfig 7.1.0
@@ -4328,34 +4329,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-react-router-dom 6.24.0
-MIT
-MIT License
-
-Copyright (c) React Training LLC 2015-2019
-Copyright (c) Remix Software Inc. 2020-2021
-Copyright (c) Shopify Inc. 2022-2023
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
-react-router 6.24.0
+react-router 7.6.0
 MIT
 MIT License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "react-i18next": "^15.0.1",
         "react-modal": "^3.16.1",
         "react-redux": "^9.2.0",
-        "react-router-dom": "6.24.0",
+        "react-router": "^7.6.0",
         "react-toastify": "^9.1.3",
         "recordrtc": "^5.6.1",
         "redux": "^5.0.1",
@@ -4528,15 +4528,6 @@
         "react-redux": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.17.0.tgz",
-      "integrity": "sha512-2D6XaHEVvkCn682XBnipbJjgZUU7xjLtA4dGJRBVUKpEaDYOZMENZoZjAOSb7qirxt5RupjzZxz4fK2FO+EFPw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -19548,35 +19539,34 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.24.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.24.0.tgz",
-      "integrity": "sha512-sQrgJ5bXk7vbcC4BxQxeNa5UmboFm35we1AFK0VvQaz9g0LzxEIuLOhHIoZ8rnu9BO21ishGeL9no1WB76W/eg==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.0.tgz",
+      "integrity": "sha512-GGufuHIVCJDbnIAXP3P9Sxzq3UUsddG3rrI3ut1q6m0FI6vxVBF3JoPQ38+W/blslLH4a5Yutp8drkEpXoddGQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.17.0"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
-    "node_modules/react-router-dom": {
-      "version": "6.24.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.24.0.tgz",
-      "integrity": "sha512-960sKuau6/yEwS8e+NVEidYQb1hNjAYM327gjEyXlc6r3Skf2vtwuJ2l7lssdegD2YjoKG5l8MsVyeTDlVeY8g==",
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
       "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.17.0",
-        "react-router": "6.24.0"
-      },
       "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "node": ">=18"
       }
     },
     "node_modules/react-scripts": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "react-i18next": "^15.0.1",
     "react-modal": "^3.16.1",
     "react-redux": "^9.2.0",
-    "react-router-dom": "6.24.0",
+    "react-router": "^7.6.0",
     "react-toastify": "^9.1.3",
     "recordrtc": "^5.6.1",
     "redux": "^5.0.1",

--- a/src/components/App/AppLoggedIn.tsx
+++ b/src/components/App/AppLoggedIn.tsx
@@ -2,7 +2,7 @@ import loadable from "@loadable/component";
 import { CssBaseline } from "@mui/material";
 import { Theme, ThemeProvider, createTheme } from "@mui/material/styles";
 import { ReactElement, useEffect, useMemo, useState } from "react";
-import { Route, Routes } from "react-router-dom";
+import { Route, Routes } from "react-router";
 
 import { updateUser } from "backend";
 import { getCurrentUser } from "backend/localStorage";

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -14,7 +14,7 @@ export default function App(): ReactElement {
       <Suspense fallback={<div />}>
         <AnnouncementBanner />
         <UpperRightToastContainer />
-        <RouterProvider router={router} />
+        <RouterProvider router={router} future={{ v7_startTransition: true }} />
       </Suspense>
     </div>
   );

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, Suspense } from "react";
-import { RouterProvider } from "react-router-dom";
+import { RouterProvider } from "react-router";
 
 import AnnouncementBanner from "components/AnnouncementBanner";
 import UpperRightToastContainer from "components/Toast/UpperRightToastContainer";
@@ -14,7 +14,7 @@ export default function App(): ReactElement {
       <Suspense fallback={<div />}>
         <AnnouncementBanner />
         <UpperRightToastContainer />
-        <RouterProvider router={router} future={{ v7_startTransition: true }} />
+        <RouterProvider router={router} />
       </Suspense>
     </div>
   );

--- a/src/components/App/tests/index.test.tsx
+++ b/src/components/App/tests/index.test.tsx
@@ -8,7 +8,7 @@ import App from "components/App";
 import { defaultState } from "rootRedux/types";
 import theme from "types/theme";
 
-jest.mock("react-router-dom");
+jest.mock("react-router");
 
 const mockStore = configureMockStore()(defaultState);
 

--- a/src/components/AppBar/Logo.tsx
+++ b/src/components/AppBar/Logo.tsx
@@ -1,6 +1,6 @@
 import { Button, Theme, useMediaQuery } from "@mui/material";
 import { ReactElement } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { buttonMinHeight } from "components/AppBar/AppBarTypes";
 import logo from "resources/CombineLogoV1White.png";

--- a/src/components/AppBar/NavigationButtons.tsx
+++ b/src/components/AppBar/NavigationButtons.tsx
@@ -8,7 +8,7 @@ import {
 } from "@mui/material";
 import { type ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { Permission } from "api/models";
 import { getCurrentPermissions } from "backend";

--- a/src/components/AppBar/ProjectButtons.tsx
+++ b/src/components/AppBar/ProjectButtons.tsx
@@ -9,7 +9,7 @@ import {
 import { ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { Permission } from "api/models";
 import { hasPermission } from "backend";

--- a/src/components/AppBar/UserMenu.tsx
+++ b/src/components/AppBar/UserMenu.tsx
@@ -21,7 +21,7 @@ import {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { isSiteAdmin } from "backend";
 import * as LocalStorage from "backend/localStorage";

--- a/src/components/AppBar/index.tsx
+++ b/src/components/AppBar/index.tsx
@@ -1,6 +1,6 @@
 import { AppBar, Grid, Toolbar } from "@mui/material";
 import { ReactElement, useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 
 import { getProjectId } from "backend/localStorage";
 import { appBarHeight } from "components/AppBar/AppBarTypes";

--- a/src/components/AppBar/tests/Logo.test.tsx
+++ b/src/components/AppBar/tests/Logo.test.tsx
@@ -6,7 +6,7 @@ import Logo, { logoButtonLabel } from "components/AppBar/Logo";
 import { Path } from "types/path";
 import theme from "types/theme";
 
-jest.mock("react-router-dom", () => ({
+jest.mock("react-router", () => ({
   useNavigate:
     () =>
     (...args: any) =>

--- a/src/components/AppBar/tests/NavigationButtons.test.tsx
+++ b/src/components/AppBar/tests/NavigationButtons.test.tsx
@@ -11,7 +11,7 @@ import NavigationButtons, {
 import { Path } from "types/path";
 import theme, { themeColors } from "types/theme";
 
-jest.mock("react-router-dom", () => ({
+jest.mock("react-router", () => ({
   useNavigate: jest.fn(),
 }));
 

--- a/src/components/AppBar/tests/ProjectButtons.test.tsx
+++ b/src/components/AppBar/tests/ProjectButtons.test.tsx
@@ -17,7 +17,7 @@ import { Goal, GoalStatus } from "types/goals";
 import { Path } from "types/path";
 import theme, { themeColors } from "types/theme";
 
-jest.mock("react-router-dom", () => ({
+jest.mock("react-router", () => ({
   useNavigate: jest.fn(),
 }));
 

--- a/src/components/AppBar/tests/UserMenu.test.tsx
+++ b/src/components/AppBar/tests/UserMenu.test.tsx
@@ -15,7 +15,7 @@ jest.mock("backend/localStorage", () => ({
   getCurrentUser: jest.fn(),
 }));
 jest.mock("components/Project/ProjectActions", () => ({}));
-jest.mock("react-router-dom", () => ({
+jest.mock("react-router", () => ({
   useNavigate: jest.fn(),
 }));
 

--- a/src/components/AppBar/tests/index.test.tsx
+++ b/src/components/AppBar/tests/index.test.tsx
@@ -1,7 +1,7 @@
 import { ThemeProvider } from "@mui/material/styles";
 import { act, render } from "@testing-library/react";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import configureMockStore from "redux-mock-store";
 
 import AppBar from "components/AppBar";

--- a/src/components/InvalidLink/index.tsx
+++ b/src/components/InvalidLink/index.tsx
@@ -2,7 +2,7 @@ import { Help } from "@mui/icons-material";
 import { Button, Card, CardContent, Grid, Typography } from "@mui/material";
 import { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { Path } from "types/path";
 import { openUserGuide } from "utilities/pathUtilities";

--- a/src/components/LandingPage/LandingButtons.tsx
+++ b/src/components/LandingPage/LandingButtons.tsx
@@ -2,7 +2,7 @@ import { Info } from "@mui/icons-material";
 import { Button, Card, Stack, Typography } from "@mui/material";
 import { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { Path } from "types/path";
 import theme from "types/theme";

--- a/src/components/LandingPage/index.tsx
+++ b/src/components/LandingPage/index.tsx
@@ -8,7 +8,7 @@ import {
 } from "@mui/material";
 import { ReactElement, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import HarvestThreshWinnow from "components/HarvestThreshWinnow";
 import BottomBar, { bottomBarHeight } from "components/LandingPage/BottomBar";

--- a/src/components/Login/ProjectInvite.tsx
+++ b/src/components/Login/ProjectInvite.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, useCallback, useEffect, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 
 import * as backend from "backend";
 import InvalidLink from "components/InvalidLink";

--- a/src/components/PageNotFound/component.tsx
+++ b/src/components/PageNotFound/component.tsx
@@ -1,7 +1,7 @@
 import { Box, Typography } from "@mui/material";
 import { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import HarvestThreshWinnow from "components/HarvestThreshWinnow";
 import { Path } from "types/path";

--- a/src/components/PageNotFound/tests/component.test.tsx
+++ b/src/components/PageNotFound/tests/component.test.tsx
@@ -2,7 +2,7 @@ import { act, render } from "@testing-library/react";
 
 import PageNotFound from "components/PageNotFound/component";
 
-jest.mock("react-router-dom");
+jest.mock("react-router");
 
 it("renders without crashing", () => {
   act(() => {

--- a/src/components/PasswordReset/Request.tsx
+++ b/src/components/PasswordReset/Request.tsx
@@ -1,7 +1,7 @@
 import { Button, Card, Grid, Typography } from "@mui/material";
 import { FormEvent, ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { resetPasswordRequest } from "backend";
 import { LoadingDoneButton } from "components/Buttons";

--- a/src/components/PasswordReset/ResetPage.tsx
+++ b/src/components/PasswordReset/ResetPage.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 
 import { resetPassword, validateResetToken } from "backend";
 import InvalidLink from "components/InvalidLink";

--- a/src/components/PasswordReset/tests/Request.test.tsx
+++ b/src/components/PasswordReset/tests/Request.test.tsx
@@ -8,7 +8,7 @@ import ResetRequest, {
   PasswordRequestIds,
 } from "components/PasswordReset/Request";
 
-jest.mock("react-router-dom", () => ({
+jest.mock("react-router", () => ({
   useNavigate: jest.fn(),
 }));
 

--- a/src/components/PasswordReset/tests/ResetPage.test.tsx
+++ b/src/components/PasswordReset/tests/ResetPage.test.tsx
@@ -9,7 +9,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import { type ReactElement, type ReactNode } from "react";
 import { Provider } from "react-redux";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router";
 import configureMockStore from "redux-mock-store";
 
 import PasswordReset, {

--- a/src/components/ProjectScreen/ChooseProject.tsx
+++ b/src/components/ProjectScreen/ChooseProject.tsx
@@ -8,7 +8,7 @@ import {
 } from "@mui/material";
 import { type ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { type Project } from "api/models";
 import { getAllActiveProjects } from "backend";

--- a/src/components/ProjectScreen/tests/ChooseProject.test.tsx
+++ b/src/components/ProjectScreen/tests/ChooseProject.test.tsx
@@ -10,7 +10,7 @@ jest.mock("backend", () => ({
   getAllActiveProjects: () => mockGetProjects(),
 }));
 jest.mock("rootRedux/hooks");
-jest.mock("react-router-dom", () => ({
+jest.mock("react-router", () => ({
   useNavigate: jest.fn(),
 }));
 

--- a/src/components/ProjectSettings/index.tsx
+++ b/src/components/ProjectSettings/index.tsx
@@ -34,7 +34,7 @@ import {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { toast } from "react-toastify";
 
 import { Permission, type Project } from "api/models";

--- a/src/components/ProjectSettings/tests/index.test.tsx
+++ b/src/components/ProjectSettings/tests/index.test.tsx
@@ -22,7 +22,7 @@ import { randomProject } from "types/project";
 import theme from "types/theme";
 import { setMatchMedia } from "utilities/testingLibraryUtilities";
 
-jest.mock("react-router-dom", () => ({ useNavigate: jest.fn() }));
+jest.mock("react-router", () => ({ useNavigate: jest.fn() }));
 
 jest.mock("backend", () => ({
   canUploadLift: () => Promise.resolve(false),

--- a/src/components/RequireAuth/index.tsx
+++ b/src/components/RequireAuth/index.tsx
@@ -1,5 +1,5 @@
 import { ReactElement } from "react";
-import { Navigate, useLocation } from "react-router-dom";
+import { Navigate, useLocation } from "react-router";
 
 import { getCurrentUser } from "backend/localStorage";
 

--- a/src/goals/DefaultGoal/BaseGoalScreen.tsx
+++ b/src/goals/DefaultGoal/BaseGoalScreen.tsx
@@ -1,6 +1,6 @@
 import loadable from "@loadable/component";
 import { type ReactElement, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import PageNotFound from "components/PageNotFound/component";
 import DisplayProgress from "goals/DefaultGoal/DisplayProgress";

--- a/src/goals/DefaultGoal/NextGoalScreen.tsx
+++ b/src/goals/DefaultGoal/NextGoalScreen.tsx
@@ -1,5 +1,5 @@
 import { ReactElement } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import PageNotFound from "components/PageNotFound/component";
 import MergeDupsContinueDialog from "goals/MergeDuplicates/MergeDupsContinueDialog";

--- a/src/goals/MergeDuplicates/MergeDupsStep/MergeDragDrop/tests/index.test.tsx
+++ b/src/goals/MergeDuplicates/MergeDupsStep/MergeDragDrop/tests/index.test.tsx
@@ -31,7 +31,7 @@ jest.mock("react-beautiful-dnd", () => ({
     children({ draggableProps: {}, innerRef: jest.fn() }, {}, {}),
   Droppable: ({ children }: any) => children({ innerRef: jest.fn() }, {}),
 }));
-jest.mock("react-router-dom", () => ({
+jest.mock("react-router", () => ({
   useNavigate: jest.fn(),
 }));
 

--- a/src/router/appRoutes.tsx
+++ b/src/router/appRoutes.tsx
@@ -1,5 +1,5 @@
 import loadable from "@loadable/component";
-import { RouteObject } from "react-router-dom";
+import { RouteObject } from "react-router";
 
 import LandingPage from "components/LandingPage";
 import Login from "components/Login/Login";

--- a/src/router/browserRouter.tsx
+++ b/src/router/browserRouter.tsx
@@ -5,7 +5,9 @@ import { appRoutes } from "router/appRoutes";
 import { changePage } from "types/Redux/analytics";
 import { Path } from "types/path";
 
-const router = createBrowserRouter(appRoutes);
+const router = createBrowserRouter(appRoutes, {
+  future: { v7_relativeSplatPath: true },
+});
 
 // set up analytics for page navigation
 // *********** WARNING! ***********

--- a/src/router/browserRouter.tsx
+++ b/src/router/browserRouter.tsx
@@ -10,6 +10,7 @@ const router = createBrowserRouter(appRoutes, {
     v7_relativeSplatPath: true,
     v7_fetcherPersist: true,
     v7_normalizeFormMethod: true,
+    v7_partialHydration: true,
   },
 });
 

--- a/src/router/browserRouter.tsx
+++ b/src/router/browserRouter.tsx
@@ -6,7 +6,11 @@ import { changePage } from "types/Redux/analytics";
 import { Path } from "types/path";
 
 const router = createBrowserRouter(appRoutes, {
-  future: { v7_relativeSplatPath: true, v7_fetcherPersist: true },
+  future: {
+    v7_relativeSplatPath: true,
+    v7_fetcherPersist: true,
+    v7_normalizeFormMethod: true,
+  },
 });
 
 // set up analytics for page navigation

--- a/src/router/browserRouter.tsx
+++ b/src/router/browserRouter.tsx
@@ -1,22 +1,15 @@
-import { createBrowserRouter } from "react-router-dom";
+import { createBrowserRouter } from "react-router";
 
 import { store } from "rootRedux/store";
 import { appRoutes } from "router/appRoutes";
 import { changePage } from "types/Redux/analytics";
 import { Path } from "types/path";
 
-const router = createBrowserRouter(appRoutes, {
-  future: {
-    v7_relativeSplatPath: true,
-    v7_fetcherPersist: true,
-    v7_normalizeFormMethod: true,
-    v7_partialHydration: true,
-  },
-});
+const router = createBrowserRouter(appRoutes);
 
 // set up analytics for page navigation
 // *********** WARNING! ***********
-// react-router v6 no longer uses nor does it support the history package.
+// react-router v6+ no longer uses nor does it support the history package.
 // In addition, its replacement for history.listen is the subscribe method.
 // The subscribe method is currently marked as PRIVATE - DO NOT USE for
 // the time being.  This functionality needs to be verified with future

--- a/src/router/browserRouter.tsx
+++ b/src/router/browserRouter.tsx
@@ -6,7 +6,7 @@ import { changePage } from "types/Redux/analytics";
 import { Path } from "types/path";
 
 const router = createBrowserRouter(appRoutes, {
-  future: { v7_relativeSplatPath: true },
+  future: { v7_relativeSplatPath: true, v7_fetcherPersist: true },
 });
 
 // set up analytics for page navigation

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,3 +1,5 @@
+import { TextEncoder, TextDecoder } from "util";
+
 import "i18n/tests/reactI18nextMock";
 
 // Force tests to fail on console.error and console.warn
@@ -7,6 +9,12 @@ global.console.error = (message) => {
 global.console.warn = (message) => {
   throw message;
 };
+
+// Fix "ReferenceError: TextEncoder is not defined" issue with react-router v7
+// https://stackoverflow.com/a/79332264/10210583
+// https://remarkablemark.org/blog/2025/02/02/fix-jest-errors-in-react-router-7-upgrade/
+global.TextDecoder ||= TextDecoder;
+global.TextEncoder ||= TextEncoder;
 
 // Mock all permissions as granted
 Object.defineProperty(navigator, "permissions", {


### PR DESCRIPTION
Closes #3661 

To test (both with `npm start` and a local docker/kubernetes build):

- Navigate around without logging in: landing page, signup, login, user-guide (not found with `npm dev`)
- Make sure password reset still works
- Login and navigate around The Combine
- Check that our page-not-found loads when changing the url to something that doesn't exist (both logged in and not logged in)