### PR TITLE
[Backend.Tests] Change sealed internal to internal sealed

### DIFF
--- a/Backend.Tests/Mocks/BannerRepositoryMock.cs
+++ b/Backend.Tests/Mocks/BannerRepositoryMock.cs
@@ -6,7 +6,7 @@ using BackendFramework.Models;
 
 namespace Backend.Tests.Mocks
 {
-    sealed internal class BannerRepositoryMock : IBannerRepository
+    internal sealed class BannerRepositoryMock : IBannerRepository
     {
         private Dictionary<BannerType, Banner> _banners;
 

--- a/Backend.Tests/Mocks/CaptchaServiceMock.cs
+++ b/Backend.Tests/Mocks/CaptchaServiceMock.cs
@@ -3,7 +3,7 @@ using BackendFramework.Interfaces;
 
 namespace Backend.Tests.Mocks
 {
-    sealed internal class CaptchaServiceMock : ICaptchaService
+    internal sealed class CaptchaServiceMock : ICaptchaService
     {
         public Task<bool> VerifyToken(string token)
         {

--- a/Backend.Tests/Mocks/EmailServiceMock.cs
+++ b/Backend.Tests/Mocks/EmailServiceMock.cs
@@ -4,7 +4,7 @@ using MimeKit;
 
 namespace Backend.Tests.Mocks
 {
-    sealed internal class EmailServiceMock : IEmailService
+    internal sealed class EmailServiceMock : IEmailService
     {
         public Task<bool> SendEmail(MimeMessage msg)
         {

--- a/Backend.Tests/Mocks/HubContextMock.cs
+++ b/Backend.Tests/Mocks/HubContextMock.cs
@@ -9,14 +9,14 @@ namespace Backend.Tests.Mocks
     /// <summary>
     /// A *very* sparse, mostly unimplemented Mock of SignalR HubContext.
     /// </summary>
-    sealed internal class HubContextMock<T> : IHubContext<T> where T : CombineHub
+    internal sealed class HubContextMock<T> : IHubContext<T> where T : CombineHub
     {
         public IHubClients Clients => new HubClientsMock();
 
         public IGroupManager Groups => throw new System.NotImplementedException();
     }
 
-    sealed internal class HubClientsMock : IHubClients
+    internal sealed class HubClientsMock : IHubClients
     {
         public IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds)
         {
@@ -61,7 +61,7 @@ namespace Backend.Tests.Mocks
         public IClientProxy All => new ClientProxyMock();
     }
 
-    sealed internal class ClientProxyMock : IClientProxy
+    internal sealed class ClientProxyMock : IClientProxy
     {
         // Disable this warning as this mock simply needs to return an empty Task, not await anything.
 #pragma warning disable 1998

--- a/Backend.Tests/Mocks/LocationProviderMock.cs
+++ b/Backend.Tests/Mocks/LocationProviderMock.cs
@@ -4,7 +4,7 @@ using BackendFramework.Otel;
 
 namespace Backend.Tests.Mocks
 {
-    sealed internal class LocationProviderMock : ILocationProvider
+    internal sealed class LocationProviderMock : ILocationProvider
     {
         public Task<LocationApi?> GetLocation()
         {

--- a/Backend.Tests/Mocks/MergeBlacklistRepositoryMock.cs
+++ b/Backend.Tests/Mocks/MergeBlacklistRepositoryMock.cs
@@ -8,7 +8,7 @@ using BackendFramework.Models;
 
 namespace Backend.Tests.Mocks
 {
-    sealed internal class MergeBlacklistRepositoryMock : IMergeBlacklistRepository
+    internal sealed class MergeBlacklistRepositoryMock : IMergeBlacklistRepository
     {
         private readonly List<MergeWordSet> _mergeBlacklist;
 

--- a/Backend.Tests/Mocks/MergeGraylistRepositoryMock.cs
+++ b/Backend.Tests/Mocks/MergeGraylistRepositoryMock.cs
@@ -8,7 +8,7 @@ using BackendFramework.Models;
 
 namespace Backend.Tests.Mocks
 {
-    sealed internal class MergeGraylistRepositoryMock : IMergeGraylistRepository
+    internal sealed class MergeGraylistRepositoryMock : IMergeGraylistRepository
     {
         private readonly List<MergeWordSet> _mergeGraylist;
 

--- a/Backend.Tests/Mocks/PasswordResetContextMock.cs
+++ b/Backend.Tests/Mocks/PasswordResetContextMock.cs
@@ -6,7 +6,7 @@ using BackendFramework.Models;
 
 namespace Backend.Tests.Mocks
 {
-    sealed internal class PasswordResetContextMock : IPasswordResetContext
+    internal sealed class PasswordResetContextMock : IPasswordResetContext
     {
         private List<PasswordReset> _resets;
 

--- a/Backend.Tests/Mocks/PasswordResetServiceMock.cs
+++ b/Backend.Tests/Mocks/PasswordResetServiceMock.cs
@@ -4,7 +4,7 @@ using BackendFramework.Models;
 
 namespace Backend.Tests.Mocks
 {
-    sealed internal class PasswordResetServiceMock : IPasswordResetService
+    internal sealed class PasswordResetServiceMock : IPasswordResetService
     {
         public Task<PasswordReset> CreatePasswordReset(string email)
         {

--- a/Backend.Tests/Mocks/PermissionServiceMock.cs
+++ b/Backend.Tests/Mocks/PermissionServiceMock.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Http;
 
 namespace Backend.Tests.Mocks
 {
-    sealed internal class PermissionServiceMock : IPermissionService
+    internal sealed class PermissionServiceMock : IPermissionService
     {
         private readonly IUserRepository _userRepo;
         private const string NoHttpContextAvailable = "NO_HTTP_CONTEXT_AVAILABLE";
@@ -168,8 +168,5 @@ namespace Backend.Tests.Mocks
         }
     }
 
-    internal sealed class UserAuthenticationException : Exception
-    {
-        public UserAuthenticationException() { }
-    }
+    internal sealed class UserAuthenticationException : Exception;
 }

--- a/Backend.Tests/Mocks/ProjectRepositoryMock.cs
+++ b/Backend.Tests/Mocks/ProjectRepositoryMock.cs
@@ -9,7 +9,7 @@ using BackendFramework.Models;
 
 namespace Backend.Tests.Mocks
 {
-    sealed internal class ProjectRepositoryMock : IProjectRepository
+    internal sealed class ProjectRepositoryMock : IProjectRepository
     {
         private readonly List<Project> _projects;
 

--- a/Backend.Tests/Mocks/SemanticDomainRepositoryMock.cs
+++ b/Backend.Tests/Mocks/SemanticDomainRepositoryMock.cs
@@ -5,7 +5,7 @@ using BackendFramework.Models;
 
 namespace Backend.Tests.Mocks
 {
-    sealed internal class SemanticDomainRepositoryMock : ISemanticDomainRepository
+    internal sealed class SemanticDomainRepositoryMock : ISemanticDomainRepository
     {
         private object? _responseObj;
 

--- a/Backend.Tests/Mocks/SpeakerRepositoryMock.cs
+++ b/Backend.Tests/Mocks/SpeakerRepositoryMock.cs
@@ -8,7 +8,7 @@ using BackendFramework.Models;
 
 namespace Backend.Tests.Mocks
 {
-    sealed internal class SpeakerRepositoryMock : ISpeakerRepository
+    internal sealed class SpeakerRepositoryMock : ISpeakerRepository
     {
         private readonly List<Speaker> _speakers;
 

--- a/Backend.Tests/Mocks/StatisticsServiceMock.cs
+++ b/Backend.Tests/Mocks/StatisticsServiceMock.cs
@@ -6,7 +6,7 @@ using BackendFramework.Models;
 
 namespace Backend.Tests.Mocks
 {
-    sealed internal class StatisticsServiceMock : IStatisticsService
+    internal sealed class StatisticsServiceMock : IStatisticsService
     {
         public Task<List<SemanticDomainCount>> GetSemanticDomainCounts(string projectId, string lang)
         {

--- a/Backend.Tests/Mocks/UserEditRepositoryMock.cs
+++ b/Backend.Tests/Mocks/UserEditRepositoryMock.cs
@@ -7,7 +7,7 @@ using BackendFramework.Models;
 
 namespace Backend.Tests.Mocks
 {
-    sealed internal class UserEditRepositoryMock : IUserEditRepository
+    internal sealed class UserEditRepositoryMock : IUserEditRepository
     {
         private readonly List<UserEdit> _userEdits;
 

--- a/Backend.Tests/Mocks/UserRepositoryMock.cs
+++ b/Backend.Tests/Mocks/UserRepositoryMock.cs
@@ -8,7 +8,7 @@ using BackendFramework.Models;
 
 namespace Backend.Tests.Mocks
 {
-    sealed internal class UserRepositoryMock : IUserRepository
+    internal sealed class UserRepositoryMock : IUserRepository
     {
         private readonly List<User> _users;
 
@@ -100,8 +100,5 @@ namespace Backend.Tests.Mocks
         }
     }
 
-    internal sealed class UserCreationException : Exception
-    {
-        public UserCreationException() { }
-    }
+    internal sealed class UserCreationException : Exception;
 }

--- a/Backend.Tests/Mocks/UserRoleRepositoryMock.cs
+++ b/Backend.Tests/Mocks/UserRoleRepositoryMock.cs
@@ -8,7 +8,7 @@ using BackendFramework.Models;
 
 namespace Backend.Tests.Mocks
 {
-    sealed internal class UserRoleRepositoryMock : IUserRoleRepository
+    internal sealed class UserRoleRepositoryMock : IUserRoleRepository
     {
         private readonly List<UserRole> _userRoles;
 

--- a/Backend.Tests/Mocks/WordRepositoryMock.cs
+++ b/Backend.Tests/Mocks/WordRepositoryMock.cs
@@ -7,7 +7,7 @@ using BackendFramework.Models;
 
 namespace Backend.Tests.Mocks
 {
-    sealed internal class WordRepositoryMock : IWordRepository
+    internal sealed class WordRepositoryMock : IWordRepository
     {
         private readonly List<Word> _words;
         private readonly List<Word> _frontier;

--- a/Backend/Helper/FileStorage.cs
+++ b/Backend/Helper/FileStorage.cs
@@ -25,10 +25,7 @@ namespace BackendFramework.Helper
         }
 
         /// <summary> Indicates that an error occurred locating the current user's home directory. </summary>
-        public sealed class HomeFolderNotFoundException : Exception
-        {
-            public HomeFolderNotFoundException() { }
-        }
+        public sealed class HomeFolderNotFoundException : Exception;
 
         /// <summary>
         /// Generate a path to the file name of an audio file for the Project based on the Word ID.

--- a/Backend/Helper/Sanitization.cs
+++ b/Backend/Helper/Sanitization.cs
@@ -8,16 +8,10 @@ using System.Text;
 namespace BackendFramework.Helper
 {
     /// <summary> Indicates an invalid input file name. </summary>
-    public sealed class InvalidFileNameException : Exception
-    {
-        public InvalidFileNameException() : base() { }
-    }
+    public sealed class InvalidFileNameException : Exception;
 
     /// <summary> Indicates an invalid input id. </summary>
-    public sealed class InvalidIdException : Exception
-    {
-        public InvalidIdException() { }
-    }
+    public sealed class InvalidIdException : Exception;
 
     public static class Sanitization
     {


### PR DESCRIPTION
Match our usage of `public sealed` and `private sealed`.
Also remove unnecessary empty exception constructors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3833)
<!-- Reviewable:end -->
