### PR TITLE
[SemanticDomainController] Fix GetAllSemanticDomainTreeNodes return type

### DIFF
--- a/Backend.Tests/Controllers/SemanticDomainControllerTests.cs
+++ b/Backend.Tests/Controllers/SemanticDomainControllerTests.cs
@@ -41,7 +41,7 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public void GetAllSemanticDomainNamesFound()
+        public void TestGetAllSemanticDomainNamesFound()
         {
             var treeNodes = new List<SemanticDomainTreeNode> { new(_semDom) };
             ((SemanticDomainRepositoryMock)_semDomRepository).SetNextResponse(treeNodes);
@@ -51,14 +51,14 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public void GetAllSemanticDomainNamesNotFound()
+        public void TestGetAllSemanticDomainNamesNotFound()
         {
             var names = ((OkObjectResult)_semDomController.GetAllSemanticDomainNames(Lang).Result).Value;
             Assert.That(names, Has.Count.EqualTo(0));
         }
 
         [Test]
-        public void GetSemanticDomainFullDomainFound()
+        public void TestGetSemanticDomainFullDomainFound()
         {
             ((SemanticDomainRepositoryMock)_semDomRepository).SetNextResponse(new SemanticDomainFull(_semDom));
             var domain = (SemanticDomainFull?)(
@@ -69,16 +69,15 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public void GetSemanticDomainFullDomainNotFound()
+        public void TestGetSemanticDomainFullDomainNotFound()
         {
             ((SemanticDomainRepositoryMock)_semDomRepository).SetNextResponse(null);
-            var domain = (SemanticDomainFull?)(
-                (ObjectResult)_semDomController.GetSemanticDomainFull(Id, Lang).Result).Value;
+            var domain = ((ObjectResult)_semDomController.GetSemanticDomainFull(Id, Lang).Result).Value;
             Assert.That(domain, Is.Null);
         }
 
         [Test]
-        public void GetSemanticDomainTreeNodeDomainFound()
+        public void TestGetSemanticDomainTreeNodeDomainFound()
         {
             var treeNode = new SemanticDomainTreeNode(_semDom);
             ((SemanticDomainRepositoryMock)_semDomRepository).SetNextResponse(treeNode);
@@ -90,16 +89,15 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public void GetSemanticDomainTreeNodeDomainNotFound()
+        public void TestGetSemanticDomainTreeNodeDomainNotFound()
         {
             ((SemanticDomainRepositoryMock)_semDomRepository).SetNextResponse(null);
-            var domain = (SemanticDomainTreeNode?)(
-                (ObjectResult)_semDomController.GetSemanticDomainTreeNode(Id, Lang).Result).Value;
+            var domain = ((ObjectResult)_semDomController.GetSemanticDomainTreeNode(Id, Lang).Result).Value;
             Assert.That(domain, Is.Null);
         }
 
         [Test]
-        public void GetSemanticDomainTreeNodeByNameDomainFound()
+        public void TestGetSemanticDomainTreeNodeByNameDomainFound()
         {
             var treeNode = new SemanticDomainTreeNode(_semDom);
             ((SemanticDomainRepositoryMock)_semDomRepository).SetNextResponse(treeNode);
@@ -111,12 +109,27 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public void GetSemanticDomainTreeNodeByNameDomainNotFound()
+        public void TestGetSemanticDomainTreeNodeByNameDomainNotFound()
         {
             ((SemanticDomainRepositoryMock)_semDomRepository).SetNextResponse(null);
-            var domain = (SemanticDomainTreeNode?)(
-                (ObjectResult)_semDomController.GetSemanticDomainTreeNodeByName(Name, Lang).Result).Value;
+            var domain = ((ObjectResult)_semDomController.GetSemanticDomainTreeNodeByName(Name, Lang).Result).Value;
             Assert.That(domain, Is.Null);
+        }
+
+        [Test]
+        public void TestGetAllSemanticDomainTreeNodesFound()
+        {
+            ((SemanticDomainRepositoryMock)_semDomRepository).SetNextResponse(new List<SemanticDomainTreeNode>());
+            var list = ((ObjectResult)_semDomController.GetAllSemanticDomainTreeNodes(Lang).Result).Value;
+            Assert.That(list, Has.Count.EqualTo(0));
+        }
+
+        [Test]
+        public void TestGetAllSemanticDomainTreeNodesNotFound()
+        {
+            ((SemanticDomainRepositoryMock)_semDomRepository).SetNextResponse(null);
+            var list = ((ObjectResult)_semDomController.GetAllSemanticDomainTreeNodes(Lang).Result).Value;
+            Assert.That(list, Is.Null);
         }
     }
 }

--- a/Backend/Controllers/SemanticDomainController.cs
+++ b/Backend/Controllers/SemanticDomainController.cs
@@ -58,9 +58,9 @@ namespace BackendFramework.Controllers
             return Ok(await _semDomRepo.GetSemanticDomainTreeNodeByName(name, lang));
         }
 
-        /// <summary> Returns a list of all SemanticDomainTreeNodes <see cref="SemanticDomainTreeNode"/> in specified language </summary>
+        /// <summary> Returns a list of all <see cref="SemanticDomainTreeNode"/>s in specified language </summary>
         [HttpGet("domainGetAll", Name = "GetAllSemanticDomainTreeNodes")]
-        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SemanticDomainTreeNode))]
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<SemanticDomainTreeNode>))]
         public async Task<IActionResult> GetAllSemanticDomainTreeNodes(string lang)
         {
             return Ok(await _semDomRepo.GetAllSemanticDomainTreeNodes(lang));

--- a/src/api/api/semantic-domain-api.ts
+++ b/src/api/api/semantic-domain-api.ts
@@ -337,7 +337,7 @@ export const SemanticDomainApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string
-      ) => AxiosPromise<SemanticDomainTreeNode>
+      ) => AxiosPromise<Array<SemanticDomainTreeNode>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getAllSemanticDomainTreeNodes(
@@ -478,7 +478,7 @@ export const SemanticDomainApiFactory = function (
     getAllSemanticDomainTreeNodes(
       lang?: string,
       options?: any
-    ): AxiosPromise<SemanticDomainTreeNode> {
+    ): AxiosPromise<Array<SemanticDomainTreeNode>> {
       return localVarFp
         .getAllSemanticDomainTreeNodes(lang, options)
         .then((request) => request(axios, basePath));


### PR DESCRIPTION
This function isn't currently used in the frontend.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3837)
<!-- Reviewable:end -->
