### PR TITLE
[AudioController] Clean up methods and add tests

### DIFF
--- a/Backend.Tests/Controllers/AudioControllerTests.cs
+++ b/Backend.Tests/Controllers/AudioControllerTests.cs
@@ -58,6 +58,7 @@ namespace Backend.Tests.Controllers
         public void TestUploadAudioFileUnauthorized()
         {
             _audioController.ControllerContext.HttpContext = PermissionServiceMock.UnauthorizedHttpContext();
+
             var result = _audioController.UploadAudioFile(_projId, _wordId, _file).Result;
             Assert.That(result, Is.InstanceOf<ForbidResult>());
 
@@ -82,7 +83,7 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public void TestUploadConsentNullFile()
+        public void TestUploadAudioFileNullFile()
         {
             var result = _audioController.UploadAudioFile(_projId, _wordId, null).Result;
             Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
@@ -92,15 +93,26 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public void TestUploadConsentEmptyFile()
+        public void TestUploadAudioFileEmptyFile()
         {
             // Use 0 for the third argument
             _file = new FormFile(_stream, 0, 0, "Name", FileName);
 
             var result = _audioController.UploadAudioFile(_projId, _wordId, _file).Result;
             Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+
             result = _audioController.UploadAudioFile(_projId, _wordId, "speakerId", _file).Result;
             Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+        }
+
+        [Test]
+        public void TestUploadAudioFileNoWord()
+        {
+            var result = _audioController.UploadAudioFile(_projId, "not-a-user", _file).Result;
+            Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
+
+            result = _audioController.UploadAudioFile(_projId, "not-a-user", "speakerId", _file).Result;
+            Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
         }
 
         [Test]
@@ -115,30 +127,59 @@ namespace Backend.Tests.Controllers
         [Test]
         public void TestDownloadAudioFileInvalidArguments()
         {
-            var result = _audioController.DownloadAudioFile("invalid/projId", "wordId", "fileName");
+            var result = _audioController.DownloadAudioFile("invalid/projId", "fileName");
             Assert.That(result, Is.TypeOf<UnsupportedMediaTypeResult>());
 
-            result = _audioController.DownloadAudioFile("projId", "invalid/wordId", "fileName");
-            Assert.That(result, Is.TypeOf<UnsupportedMediaTypeResult>());
-
-            result = _audioController.DownloadAudioFile("projId", "wordId", "invalid/fileName");
+            result = _audioController.DownloadAudioFile("projId", "invalid/fileName");
             Assert.That(result, Is.TypeOf<UnsupportedMediaTypeResult>());
         }
 
         [Test]
         public void TestDownloadAudioFileNoFile()
         {
-            var result = _audioController.DownloadAudioFile("projId", "wordId", "fileName");
+            var result = _audioController.DownloadAudioFile("projId", "fileName");
             Assert.That(result, Is.TypeOf<BadRequestObjectResult>());
         }
 
         [Test]
-        public void DeleteAudio()
+        public void TestDeleteAudioFileUnauthorized()
+        {
+            _audioController.ControllerContext.HttpContext = PermissionServiceMock.UnauthorizedHttpContext();
+            var result = _audioController.DeleteAudioFile(_projId, _wordId, _file.FileName).Result;
+            Assert.That(result, Is.TypeOf<ForbidResult>());
+        }
+
+        [Test]
+        public void TestDeleteAudioFileInvalidArguments()
+        {
+            var result = _audioController.DeleteAudioFile("in/va/lid", _wordId, _file.FileName).Result;
+            Assert.That(result, Is.TypeOf<UnsupportedMediaTypeResult>());
+
+            result = _audioController.DeleteAudioFile(_projId, "in/va/lid", _file.FileName).Result;
+            Assert.That(result, Is.TypeOf<UnsupportedMediaTypeResult>());
+
+            result = _audioController.DeleteAudioFile(_projId, _wordId, "in/va/lid").Result;
+            Assert.That(result, Is.TypeOf<UnsupportedMediaTypeResult>());
+        }
+
+        [Test]
+        public void TestDeleteAudioFileNoWordWithAudio()
+        {
+            var result = _audioController.DeleteAudioFile(_projId, "not-a-word", _file.FileName).Result;
+            Assert.That(result, Is.TypeOf<NotFoundObjectResult>());
+
+            var wordId = _wordRepo.Create(Util.RandomWord(_projId)).Result.Id;
+            result = _audioController.DeleteAudioFile(_projId, wordId, _file.FileName).Result;
+            Assert.That(result, Is.TypeOf<NotFoundObjectResult>());
+        }
+
+        [Test]
+        public void TestDeleteAudioFile()
         {
             // Refill test database
             _wordRepo.DeleteAllWords(_projId);
             var origWord = Util.RandomWord(_projId);
-            var fileName = "a.wav";
+            const string fileName = "a.wav";
             origWord.Audio.Add(new Pronunciation(fileName));
             var wordId = _wordRepo.Create(origWord).Result.Id;
 

--- a/Backend/Controllers/AudioController.cs
+++ b/Backend/Controllers/AudioController.cs
@@ -30,7 +30,9 @@ namespace BackendFramework.Controllers
         [AllowAnonymous]
         [HttpGet("download/{fileName}", Name = "DownloadAudioFile")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(FileContentResult))]
-        public IActionResult DownloadAudioFile(string projectId, string wordId, string fileName)
+        [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
+        [ProducesResponseType(StatusCodes.Status415UnsupportedMediaType)]
+        public IActionResult DownloadAudioFile(string projectId, string fileName)
         {
             // SECURITY: Omitting authentication so the frontend can use the API endpoint directly as a URL.
             // if (!await _permissionService.HasProjectPermission(HttpContext, Permission.WordEntry))
@@ -43,7 +45,6 @@ namespace BackendFramework.Controllers
             {
                 fileName = Sanitization.SanitizeFileName(fileName);
                 projectId = Sanitization.SanitizeId(projectId);
-                wordId = Sanitization.SanitizeId(wordId);
             }
             catch
             {
@@ -67,6 +68,10 @@ namespace BackendFramework.Controllers
         /// <returns> Id of updated word </returns>
         [HttpPost("upload", Name = "UploadAudioFile")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
+        [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(string))]
+        [ProducesResponseType(StatusCodes.Status415UnsupportedMediaType)]
         public async Task<IActionResult> UploadAudioFile(string projectId, string wordId, IFormFile? file)
         {
             return await UploadAudioFile(projectId, wordId, "", file);
@@ -80,6 +85,10 @@ namespace BackendFramework.Controllers
         /// <returns> Id of updated word </returns>
         [HttpPost("upload/{speakerId}", Name = "UploadAudioFileWithSpeaker")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
+        [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(string))]
+        [ProducesResponseType(StatusCodes.Status415UnsupportedMediaType)]
         public async Task<IActionResult> UploadAudioFile(
             string projectId, string wordId, string speakerId, IFormFile? file)
         {
@@ -111,6 +120,12 @@ namespace BackendFramework.Controllers
                 return BadRequest("Empty File");
             }
 
+            var word = await _wordRepo.GetWord(projectId, wordId);
+            if (word is null)
+            {
+                return NotFound($"wordId: {wordId}");
+            }
+
             // This path should be unique even though it is only based on the Word ID because currently, a new
             // Word is created each time an audio file is uploaded.
             var filePath = FileStorage.GenerateAudioFilePathForWord(projectId, wordId);
@@ -122,11 +137,6 @@ namespace BackendFramework.Controllers
             }
 
             // Add the relative path to the audio field
-            var word = await _wordRepo.GetWord(projectId, wordId);
-            if (word is null)
-            {
-                return NotFound(wordId);
-            }
             var audio = new Pronunciation(Path.GetFileName(filePath), speakerId);
             word.Audio.Add(audio);
 
@@ -139,6 +149,9 @@ namespace BackendFramework.Controllers
         /// <summary> Deletes audio in <see cref="Word"/> with specified ID </summary>
         [HttpDelete("delete/{fileName}", Name = "DeleteAudioFile")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(string))]
+        [ProducesResponseType(StatusCodes.Status415UnsupportedMediaType)]
         public async Task<IActionResult> DeleteAudioFile(string projectId, string wordId, string fileName)
         {
             if (!await _permissionService.HasProjectPermission(HttpContext, Permission.WordEntry, projectId))
@@ -164,7 +177,7 @@ namespace BackendFramework.Controllers
             {
                 return Ok(newWord.Id);
             }
-            return NotFound("The project was found, but the word audio was not deleted");
+            return NotFound($"wordId: {wordId}; fileName: {fileName}");
         }
     }
 }

--- a/src/api/api/audio-api.ts
+++ b/src/api/api/audio-api.ts
@@ -101,28 +101,28 @@ export const AudioApiAxiosParamCreator = function (
     /**
      *
      * @param {string} projectId
-     * @param {string} wordId
      * @param {string} fileName
+     * @param {string} wordId
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     downloadAudioFile: async (
       projectId: string,
-      wordId: string,
       fileName: string,
+      wordId: string,
       options: any = {}
     ): Promise<RequestArgs> => {
       // verify required parameter 'projectId' is not null or undefined
       assertParamExists("downloadAudioFile", "projectId", projectId);
-      // verify required parameter 'wordId' is not null or undefined
-      assertParamExists("downloadAudioFile", "wordId", wordId);
       // verify required parameter 'fileName' is not null or undefined
       assertParamExists("downloadAudioFile", "fileName", fileName);
+      // verify required parameter 'wordId' is not null or undefined
+      assertParamExists("downloadAudioFile", "wordId", wordId);
       const localVarPath =
         `/v1/projects/{projectId}/words/{wordId}/audio/download/{fileName}`
           .replace(`{${"projectId"}}`, encodeURIComponent(String(projectId)))
-          .replace(`{${"wordId"}}`, encodeURIComponent(String(wordId)))
-          .replace(`{${"fileName"}}`, encodeURIComponent(String(fileName)));
+          .replace(`{${"fileName"}}`, encodeURIComponent(String(fileName)))
+          .replace(`{${"wordId"}}`, encodeURIComponent(String(wordId)));
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
       let baseOptions;
@@ -321,15 +321,15 @@ export const AudioApiFp = function (configuration?: Configuration) {
     /**
      *
      * @param {string} projectId
-     * @param {string} wordId
      * @param {string} fileName
+     * @param {string} wordId
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async downloadAudioFile(
       projectId: string,
-      wordId: string,
       fileName: string,
+      wordId: string,
       options?: any
     ): Promise<
       (axios?: AxiosInstance, basePath?: string) => AxiosPromise<any>
@@ -337,8 +337,8 @@ export const AudioApiFp = function (configuration?: Configuration) {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.downloadAudioFile(
           projectId,
-          wordId,
           fileName,
+          wordId,
           options
         );
       return createRequestFunction(
@@ -445,19 +445,19 @@ export const AudioApiFactory = function (
     /**
      *
      * @param {string} projectId
-     * @param {string} wordId
      * @param {string} fileName
+     * @param {string} wordId
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     downloadAudioFile(
       projectId: string,
-      wordId: string,
       fileName: string,
+      wordId: string,
       options?: any
     ): AxiosPromise<any> {
       return localVarFp
-        .downloadAudioFile(projectId, wordId, fileName, options)
+        .downloadAudioFile(projectId, fileName, wordId, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -547,14 +547,14 @@ export interface AudioApiDownloadAudioFileRequest {
    * @type {string}
    * @memberof AudioApiDownloadAudioFile
    */
-  readonly wordId: string;
+  readonly fileName: string;
 
   /**
    *
    * @type {string}
    * @memberof AudioApiDownloadAudioFile
    */
-  readonly fileName: string;
+  readonly wordId: string;
 }
 
 /**
@@ -662,8 +662,8 @@ export class AudioApi extends BaseAPI {
     return AudioApiFp(this.configuration)
       .downloadAudioFile(
         requestParameters.projectId,
-        requestParameters.wordId,
         requestParameters.fileName,
+        requestParameters.wordId,
         options
       )
       .then((request) => request(this.axios, this.basePath));

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -162,7 +162,9 @@ export async function deleteAudio(
   return (await audioApi.deleteAudioFile(params, defaultOptions())).data;
 }
 
-// Use of the returned url acts as an HttpGet.
+/** Returns a url that, when used, acts as an HttpGet.
+ * Note: Backend doesn't need wordId to find the file,
+ * but it's still required in the url and helpful for analytics. */
 export function getAudioUrl(wordId: string, fileName: string): string {
   return `${apiBaseURL}/projects/${LocalStorage.getProjectId()}/words/${wordId}/audio/download/${fileName}`;
 }


### PR DESCRIPTION
- `DownloadAudioFile`: removes unused wordId param
- `UploadAudioFile`: verifies word exists before copying the file
- Adds all missing `ProducesResponseType` attributes
- Expands testing