### PR TITLE
[StatisticsController] Drop unnecessary project checks

### DIFF
--- a/Backend.Tests/Controllers/StatisticsControllerTests.cs
+++ b/Backend.Tests/Controllers/StatisticsControllerTests.cs
@@ -64,13 +64,6 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public async Task TestGetSemanticDomainCountsMissingProject()
-        {
-            var result = await _statsController.GetSemanticDomainCounts(MissingId, "en");
-            Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
-        }
-
-        [Test]
         public async Task TestGetSemanticDomainCounts()
         {
             var result = await _statsController.GetSemanticDomainCounts(_projId, "en");
@@ -84,13 +77,6 @@ namespace Backend.Tests.Controllers
 
             var result = await _statsController.GetWordsPerDayPerUserCounts(_projId);
             Assert.That(result, Is.InstanceOf<ForbidResult>());
-        }
-
-        [Test]
-        public async Task TestGetWordsPerDayPerUserCountsMissingProject()
-        {
-            var result = await _statsController.GetWordsPerDayPerUserCounts(MissingId);
-            Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
         }
 
         [Test]
@@ -113,7 +99,7 @@ namespace Backend.Tests.Controllers
         public async Task TestGetProgressEstimationLineChartRootMissingProject()
         {
             var result = await _statsController.GetProgressEstimationLineChartRoot(MissingId);
-            Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
+            Assert.That(result, Is.InstanceOf<NotFoundResult>());
         }
 
         [Test]
@@ -133,13 +119,6 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public async Task TestGetLineChartRootDataMissingProject()
-        {
-            var result = await _statsController.GetLineChartRootData(MissingId);
-            Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
-        }
-
-        [Test]
         public async Task TestGetLineChartRootData()
         {
             var result = await _statsController.GetLineChartRootData(_projId);
@@ -153,13 +132,6 @@ namespace Backend.Tests.Controllers
 
             var result = await _statsController.GetSemanticDomainUserCounts(_projId, "en");
             Assert.That(result, Is.InstanceOf<ForbidResult>());
-        }
-
-        [Test]
-        public async Task TestGetSemanticDomainUserCountsMissingProject()
-        {
-            var result = await _statsController.GetSemanticDomainUserCounts(MissingId, "en");
-            Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
         }
 
         [Test]

--- a/Backend/Controllers/StatisticsController.cs
+++ b/Backend/Controllers/StatisticsController.cs
@@ -12,7 +12,6 @@ namespace BackendFramework.Controllers
     [Produces("application/json")]
     [Route("v1/projects/{projectId}/statistics")]
 
-
     public class StatisticsController : Controller
     {
         private readonly IStatisticsService _statService;
@@ -31,18 +30,12 @@ namespace BackendFramework.Controllers
         /// <returns> A list of <see cref="SemanticDomainCount"/>s </returns>
         [HttpGet("GetSemanticDomainCounts", Name = "GetSemanticDomainCounts")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<SemanticDomainCount>))]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> GetSemanticDomainCounts(string projectId, string lang)
         {
             if (!await _permissionService.HasProjectPermission(HttpContext, Permission.Statistics, projectId))
             {
                 return Forbid();
-            }
-
-            // Ensure project exists.
-            var proj = await _projRepo.GetProject(projectId);
-            if (proj is null)
-            {
-                return NotFound(projectId);
             }
 
             return Ok(await _statService.GetSemanticDomainCounts(projectId, lang));
@@ -53,18 +46,12 @@ namespace BackendFramework.Controllers
         /// <returns> A list of <see cref="WordsPerDayPerUserCount"/>s </returns>
         [HttpGet("GetWordsPerDayPerUserCounts", Name = "GetWordsPerDayPerUserCounts")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<WordsPerDayPerUserCount>))]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> GetWordsPerDayPerUserCounts(string projectId)
         {
             if (!await _permissionService.HasProjectPermission(HttpContext, Permission.Statistics, projectId))
             {
                 return Forbid();
-            }
-
-            // Ensure project exists.
-            var proj = await _projRepo.GetProject(projectId);
-            if (proj is null)
-            {
-                return NotFound(projectId);
             }
 
             return Ok(await _statService.GetWordsPerDayPerUserCounts(projectId));
@@ -74,6 +61,8 @@ namespace BackendFramework.Controllers
         /// <summary> Get a <see cref="ChartRootData"/> to generate an estimate Line Chart </summary>
         [HttpGet("GetProgressEstimationLineChartRoot", Name = "GetProgressEstimationLineChartRoot")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ChartRootData))]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> GetProgressEstimationLineChartRoot(string projectId)
         {
             if (!await _permissionService.HasProjectPermission(HttpContext, Permission.Statistics, projectId))
@@ -81,11 +70,10 @@ namespace BackendFramework.Controllers
                 return Forbid();
             }
 
-            // Ensure project exists.
             var proj = await _projRepo.GetProject(projectId);
             if (proj is null)
             {
-                return NotFound(projectId);
+                return NotFound();
             }
 
             return Ok(await _statService.GetProgressEstimationLineChartRoot(projectId, proj.WorkshopSchedule));
@@ -95,18 +83,12 @@ namespace BackendFramework.Controllers
         /// <summary> Get a <see cref="ChartRootData"/> to generate a Line Chart </summary>
         [HttpGet("GetLineChartRootData", Name = "GetLineChartRootData")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ChartRootData))]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> GetLineChartRootData(string projectId)
         {
             if (!await _permissionService.HasProjectPermission(HttpContext, Permission.Statistics, projectId))
             {
                 return Forbid();
-            }
-
-            // Ensure project exists.
-            var proj = await _projRepo.GetProject(projectId);
-            if (proj is null)
-            {
-                return NotFound(projectId);
             }
 
             return Ok(await _statService.GetLineChartRootData(projectId));
@@ -118,18 +100,12 @@ namespace BackendFramework.Controllers
         /// <returns> A list of <see cref="SemanticDomainUserCount"/>s </returns>
         [HttpGet("GetSemanticDomainUserCounts", Name = "GetSemanticDomainUserCounts")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<SemanticDomainUserCount>))]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> GetSemanticDomainUserCounts(string projectId, string lang)
         {
             if (!await _permissionService.HasProjectPermission(HttpContext, Permission.Statistics, projectId))
             {
                 return Forbid();
-            }
-
-            //Ensure project exists.
-            var proj = await _projRepo.GetProject(projectId);
-            if (proj is null)
-            {
-                return NotFound(projectId);
             }
 
             return Ok(await _statService.GetSemanticDomainUserCounts(projectId));


### PR DESCRIPTION
A project permission check is sufficient if the project object is not needed.