### PR TITLE
[frontend] Migrate 5 components from deprecated Grid

### DIFF
--- a/src/components/AnalyticsConsent/index.tsx
+++ b/src/components/AnalyticsConsent/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Grid, Theme, Typography, useMediaQuery } from "@mui/material";
+import { Button, Grid2, Stack, Typography } from "@mui/material";
 import Drawer from "@mui/material/Drawer";
 import { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
@@ -16,8 +16,6 @@ export default function AnalyticsConsent(props: ConsentProps): ReactElement {
   const acceptAnalytics = (): void => props.onChangeConsent(true);
   const rejectAnalytics = (): void => props.onChangeConsent(false);
   const clickedAway = (): void => props.onChangeConsent(undefined);
-
-  const isXs = useMediaQuery<Theme>((th) => th.breakpoints.only("xs"));
 
   function ConsentButton(props: {
     onClick: () => void;
@@ -41,13 +39,12 @@ export default function AnalyticsConsent(props: ConsentProps): ReactElement {
       onClose={!props.required ? clickedAway : undefined}
       PaperProps={{ style: { padding: 20 } }}
     >
-      <Grid
-        container
-        direction={isXs ? "column" : "row"}
+      <Stack
+        direction={{ xs: "column", sm: "row" }}
         alignItems="center"
         spacing={3}
       >
-        <Grid item xs>
+        <div>
           <Typography
             variant="h6"
             style={{ color: themeColors.primary, fontWeight: 600 }}
@@ -58,22 +55,19 @@ export default function AnalyticsConsent(props: ConsentProps): ReactElement {
           <Typography variant="body1">
             {t("analyticsConsent.consentModal.description")}
           </Typography>
-        </Grid>
-        <Grid item container xs="auto" spacing={1}>
-          <Grid item>
-            <ConsentButton
-              onClick={acceptAnalytics}
-              text={t("analyticsConsent.consentModal.acceptAllBtn")}
-            />
-          </Grid>
-          <Grid item>
-            <ConsentButton
-              onClick={rejectAnalytics}
-              text={t("analyticsConsent.consentModal.acceptNecessaryBtn")}
-            />
-          </Grid>
-        </Grid>
-      </Grid>
+        </div>
+
+        <Grid2 container size="auto" spacing={1}>
+          <ConsentButton
+            onClick={acceptAnalytics}
+            text={t("analyticsConsent.consentModal.acceptAllBtn")}
+          />
+          <ConsentButton
+            onClick={rejectAnalytics}
+            text={t("analyticsConsent.consentModal.acceptNecessaryBtn")}
+          />
+        </Grid2>
+      </Stack>
     </Drawer>
   );
 }

--- a/src/components/AppBar/index.tsx
+++ b/src/components/AppBar/index.tsx
@@ -1,4 +1,4 @@
-import { AppBar, Grid, Toolbar } from "@mui/material";
+import { AppBar, Stack, Toolbar } from "@mui/material";
 import { ReactElement, useEffect, useState } from "react";
 import { useLocation } from "react-router";
 
@@ -29,22 +29,29 @@ export default function AppBarComponent(): ReactElement {
         style={{ maxHeight: appBarHeight, zIndex: theme.zIndex.drawer + 1 }}
       >
         <Toolbar>
-          <Grid container justifyContent="space-between" alignItems="center">
-            <Grid item>
+          <Stack
+            alignItems="center"
+            direction="row"
+            justifyContent="space-between"
+            width="100%"
+          >
+            <div>
               <Logo />
               {!!getProjectId() && (
                 <NavigationButtons currentTab={currentTab} />
               )}
-            </Grid>
-            <Grid item>
+            </div>
+
+            <div>
               {!!getProjectId() && <ProjectButtons currentTab={currentTab} />}
               <DownloadButton colorSecondary />
-            </Grid>
-            <Grid item>
+            </div>
+
+            <div>
               <UserMenu currentTab={currentTab} />
               <UserGuideButton />
-            </Grid>
-          </Grid>
+            </div>
+          </Stack>
         </Toolbar>
       </AppBar>
     </div>

--- a/src/components/LandingPage/index.tsx
+++ b/src/components/LandingPage/index.tsx
@@ -1,6 +1,6 @@
 import {
   Box,
-  Grid,
+  Grid2,
   Stack,
   Theme,
   Typography,
@@ -44,16 +44,16 @@ export default function LandingPage(): ReactElement {
   return (
     <>
       <TopBar />
-      <Grid container direction={isXs ? "column" : "row-reverse"}>
-        <Grid item xs="auto">
+      <Grid2 container direction={isXs ? "column" : "row-reverse"}>
+        <Grid2 size="auto">
           <LandingButtons top={isXs} />
-        </Grid>
-        <Grid item xs>
+        </Grid2>
+        <Grid2 size="grow">
           <Box style={{ maxHeight: maxBodyHeight, overflow: "auto" }}>
             <Body />
           </Box>
-        </Grid>
-      </Grid>
+        </Grid2>
+      </Grid2>
       <BottomBar />
     </>
   );

--- a/src/components/ProjectScreen/CreateProject.tsx
+++ b/src/components/ProjectScreen/CreateProject.tsx
@@ -2,7 +2,7 @@ import { Cancel } from "@mui/icons-material";
 import {
   Card,
   CardContent,
-  Grid,
+  Grid2,
   IconButton,
   MenuItem,
   Select,
@@ -299,7 +299,7 @@ export default function CreateProject(): ReactElement {
             />
           )}
           {/* Form submission button */}
-          <Grid
+          <Grid2
             container
             justifyContent="flex-end"
             style={{ marginTop: theme.spacing(1) }}
@@ -315,7 +315,7 @@ export default function CreateProject(): ReactElement {
             >
               {t("createProject.create")}
             </LoadingDoneButton>
-          </Grid>
+          </Grid2>
         </CardContent>
       </form>
     </Card>

--- a/src/components/UserSettings/UserSettings.tsx
+++ b/src/components/UserSettings/UserSettings.tsx
@@ -3,9 +3,10 @@ import {
   Button,
   Card,
   CardContent,
-  Grid,
+  Grid2,
   MenuItem,
   Select,
+  Stack,
   TextField,
   Tooltip,
   Typography,
@@ -133,16 +134,16 @@ export function UserSettings(props: {
   }
 
   return (
-    <Grid container justifyContent="center">
+    <Grid2 container justifyContent="center">
       <Card style={{ width: 450 }}>
-        <form onSubmit={(e) => onSubmit(e)}>
-          <CardContent>
-            <Grid item container spacing={6}>
-              <Grid item container spacing={2} alignItems="center">
-                <Grid item>
-                  <ClickableAvatar avatar={avatar} setAvatar={setAvatar} />
-                </Grid>
-                <Grid item xs>
+        <CardContent>
+          <form onSubmit={(e) => onSubmit(e)}>
+            <Stack spacing={6}>
+              {/* id: avatar, name, username */}
+              <Stack alignItems="center" direction="row" spacing={2}>
+                <ClickableAvatar avatar={avatar} setAvatar={setAvatar} />
+
+                <Grid2 size="grow">
                   <NormalizedTextField
                     id={UserSettingsIds.FieldName}
                     fullWidth
@@ -156,6 +157,7 @@ export function UserSettings(props: {
                     }}
                     style={{ margin: theme.spacing(1), marginInlineStart: 0 }}
                   />
+
                   <Typography
                     data-testid={UserSettingsIds.FieldUsername}
                     id={UserSettingsIds.FieldUsername}
@@ -166,21 +168,19 @@ export function UserSettings(props: {
                     {": "}
                     {props.user.username}
                   </Typography>
-                </Grid>
-              </Grid>
+                </Grid2>
+              </Stack>
 
-              <Grid item container spacing={2}>
-                <Grid item>
-                  <Typography variant="h6">
-                    {t("userSettings.contact")}
-                  </Typography>
-                </Grid>
+              {/* contact: phone, email */}
+              <Stack spacing={2}>
+                <Typography variant="h6">
+                  {t("userSettings.contact")}
+                </Typography>
 
-                <Grid item container spacing={1} alignItems="center">
-                  <Grid item>
-                    <Phone />
-                  </Grid>
-                  <Grid item xs>
+                <Stack alignItems="center" direction="row" spacing={1}>
+                  <Phone />
+
+                  <Grid2 size="grow">
                     <NormalizedTextField
                       id={UserSettingsIds.FieldPhone}
                       inputProps={{ "data-testid": UserSettingsIds.FieldPhone }}
@@ -191,14 +191,13 @@ export function UserSettings(props: {
                       onChange={(e) => setPhone(e.target.value)}
                       type="tel"
                     />
-                  </Grid>
-                </Grid>
+                  </Grid2>
+                </Stack>
 
-                <Grid item container spacing={1} alignItems="center">
-                  <Grid item>
-                    <Email />
-                  </Grid>
-                  <Grid item xs>
+                <Stack alignItems="center" direction="row" spacing={1}>
+                  <Email />
+
+                  <Grid2 size="grow">
                     <TextField
                       id={UserSettingsIds.FieldEmail}
                       inputProps={{ "data-testid": UserSettingsIds.FieldEmail }}
@@ -217,53 +216,49 @@ export function UserSettings(props: {
                       }
                       type="email"
                     />
-                  </Grid>
-                </Grid>
-              </Grid>
+                  </Grid2>
+                </Stack>
+              </Stack>
 
-              <Grid item container spacing={2}>
-                <Grid item xs={12}>
-                  <Typography variant="h6">
-                    {t("userSettings.uiLanguage")}
-                  </Typography>
-                </Grid>
+              {/* ui language */}
+              <Stack alignItems="flex-start" spacing={2}>
+                <Typography variant="h6">
+                  {t("userSettings.uiLanguage")}
+                </Typography>
 
-                <Grid item>
-                  <Select
-                    variant="standard"
-                    data-testid={UserSettingsIds.SelectUiLang}
-                    id={UserSettingsIds.SelectUiLang}
-                    value={uiLang}
-                    onChange={(e) => setUiLang(e.target.value ?? "")}
-                    /* Use `displayEmpty` and a conditional `renderValue` function to force
-                     * something to appear when the menu is closed and its value is "" */
-                    displayEmpty
-                    renderValue={
-                      uiLang
-                        ? undefined
-                        : () => t("userSettings.uiLanguageDefault")
-                    }
-                  >
-                    <MenuItem value={""}>
-                      {t("userSettings.uiLanguageDefault")}
+                <Select
+                  variant="standard"
+                  data-testid={UserSettingsIds.SelectUiLang}
+                  id={UserSettingsIds.SelectUiLang}
+                  value={uiLang}
+                  onChange={(e) => setUiLang(e.target.value ?? "")}
+                  /* Use `displayEmpty` and a conditional `renderValue` function to force
+                   * something to appear when the menu is closed and its value is "" */
+                  displayEmpty
+                  renderValue={
+                    uiLang
+                      ? undefined
+                      : () => t("userSettings.uiLanguageDefault")
+                  }
+                >
+                  <MenuItem value={""}>
+                    {t("userSettings.uiLanguageDefault")}
+                  </MenuItem>
+                  {uiWritingSystems.map((ws) => (
+                    <MenuItem key={ws.bcp47} value={ws.bcp47}>
+                      {`${ws.bcp47} (${ws.name})`}
                     </MenuItem>
-                    {uiWritingSystems.map((ws) => (
-                      <MenuItem key={ws.bcp47} value={ws.bcp47}>
-                        {`${ws.bcp47} (${ws.name})`}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </Grid>
-              </Grid>
+                  ))}
+                </Select>
+              </Stack>
 
-              <Grid item container spacing={2}>
-                <Grid item xs={12}>
-                  <Typography variant="h6">
-                    {t("userSettings.glossSuggestion")}
-                  </Typography>
-                </Grid>
+              {/* gloss spelling suggestions */}
+              <Stack alignItems="flex-start" spacing={2}>
+                <Typography variant="h6">
+                  {t("userSettings.glossSuggestion")}
+                </Typography>
 
-                <Grid item>
+                <Stack direction="row">
                   <Select
                     data-testid={UserSettingsIds.SelectGlossSuggestion}
                     id={UserSettingsIds.SelectGlossSuggestion}
@@ -280,56 +275,51 @@ export function UserSettings(props: {
                       {t("projectSettings.autocomplete.on")}
                     </MenuItem>
                   </Select>
-                </Grid>
 
-                <Grid item>
                   <Tooltip
                     title={t("userSettings.glossSuggestionHint")}
                     placement={document.body.dir === "rtl" ? "left" : "right"}
                   >
                     <HelpOutline fontSize="small" />
                   </Tooltip>
-                </Grid>
-              </Grid>
+                </Stack>
+              </Stack>
 
+              {/* analytics consent */}
               {!RuntimeConfig.getInstance().isOffline() && (
-                <Grid item container spacing={2}>
-                  <Grid item xs={12}>
-                    <Typography variant="h6">
-                      {t("userSettings.analyticsConsent.title")}
-                    </Typography>
-                  </Grid>
+                <Stack alignItems="flex-start" spacing={2}>
+                  <Typography variant="h6">
+                    {t("userSettings.analyticsConsent.title")}
+                  </Typography>
 
-                  <Grid item>
-                    <Typography>
-                      {t(
-                        analyticsOn
-                          ? "userSettings.analyticsConsent.consentYes"
-                          : "userSettings.analyticsConsent.consentNo"
-                      )}
-                    </Typography>
-                  </Grid>
+                  <Typography>
+                    {t(
+                      analyticsOn
+                        ? "userSettings.analyticsConsent.consentYes"
+                        : "userSettings.analyticsConsent.consentNo"
+                    )}
+                  </Typography>
 
-                  <Grid item>
-                    <Button
-                      data-testid={UserSettingsIds.ButtonChangeConsent}
-                      id={UserSettingsIds.ButtonChangeConsent}
-                      onClick={() => setDisplayConsent(true)}
-                      variant="outlined"
-                    >
-                      {t("userSettings.analyticsConsent.button")}
-                    </Button>
-                  </Grid>
+                  <Button
+                    data-testid={UserSettingsIds.ButtonChangeConsent}
+                    id={UserSettingsIds.ButtonChangeConsent}
+                    onClick={() => setDisplayConsent(true)}
+                    variant="outlined"
+                  >
+                    {t("userSettings.analyticsConsent.button")}
+                  </Button>
+
                   {displayConsent && (
                     <AnalyticsConsent
                       onChangeConsent={handleConsentChange}
                       required={false}
                     />
                   )}
-                </Grid>
+                </Stack>
               )}
 
-              <Grid item container justifyContent="flex-end">
+              {/* save button */}
+              <Grid2 container justifyContent="flex-end">
                 <Button
                   data-testid={UserSettingsIds.ButtonSubmit}
                   disabled={disabled}
@@ -339,11 +329,11 @@ export function UserSettings(props: {
                 >
                   {t("buttons.save")}
                 </Button>
-              </Grid>
-            </Grid>
-          </CardContent>
-        </form>
+              </Grid2>
+            </Stack>
+          </form>
+        </CardContent>
       </Card>
-    </Grid>
+    </Grid2>
   );
 }


### PR DESCRIPTION
Part of #3787

Notes for review:

- Replaced `<Grid>` with `<Grid2>`, `<Stack>`, `<Box>`, `<div>`, or nothing, as fit the design need.
- `<Stack direction="row">` can be used in place of `<Grid2>` when we don't want the items in the row to wrap to a second row in a narrow window
- Do a side-by-side visual comparison between this and `master` (on QA) to make sure appearance is (roughly) the same or (subjectively) improved on all edited components
- Try each edited component with various window widths > 300px (we don't care about narrower than that)