### PR TITLE
[Login, Signup, PasswordReset] Migrate from deprecated Grid

### DIFF
--- a/src/components/InvalidLink/index.tsx
+++ b/src/components/InvalidLink/index.tsx
@@ -1,5 +1,12 @@
 import { Help } from "@mui/icons-material";
-import { Button, Card, CardContent, Grid, Typography } from "@mui/material";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  Grid2,
+  Typography,
+} from "@mui/material";
 import { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
@@ -17,44 +24,47 @@ export default function InvalidLink(props: InvalidLinkProps): ReactElement {
   const idAffix = "invalid-link";
 
   return (
-    <Grid container justifyContent="center">
-      <Card style={{ width: 450 }}>
+    <Grid2 container justifyContent="center">
+      <Card sx={{ width: 450 }}>
+        <CardHeader
+          title={
+            <Typography align="center" variant="h5">
+              {t(props.textId)}
+            </Typography>
+          }
+        />
+
         <CardContent>
-          <Typography variant="h5" align="center" gutterBottom>
-            {t(props.textId)}
-          </Typography>
           {/* User Guide, Sign Up, and Log In buttons */}
-          <Grid container justifyContent="flex-end" spacing={2}>
-            <Grid item xs={4} sm={6}>
+          <Grid2 container spacing={2}>
+            <Grid2 size="grow">
               <Button id={`${idAffix}-guide`} onClick={() => openUserGuide()}>
                 <Help />
               </Button>
-            </Grid>
+            </Grid2>
 
-            <Grid item xs={4} sm={3}>
-              <Button
-                id={`${idAffix}-signUp`}
-                onClick={() => {
-                  navigate(Path.Signup);
-                }}
-              >
-                {t("login.signUp")}
-              </Button>
-            </Grid>
+            <Button
+              id={`${idAffix}-signUp`}
+              onClick={() => {
+                navigate(Path.Signup);
+              }}
+              variant="contained"
+            >
+              {t("login.signUp")}
+            </Button>
 
-            <Grid item xs={4} sm={3}>
-              <Button
-                id={`${idAffix}-login`}
-                onClick={() => {
-                  navigate(Path.Login);
-                }}
-              >
-                {t("login.login")}
-              </Button>
-            </Grid>
-          </Grid>
+            <Button
+              id={`${idAffix}-login`}
+              onClick={() => {
+                navigate(Path.Login);
+              }}
+              variant="contained"
+            >
+              {t("login.login")}
+            </Button>
+          </Grid2>
         </CardContent>
       </Card>
-    </Grid>
+    </Grid2>
   );
 }

--- a/src/components/Login/Captcha.tsx
+++ b/src/components/Login/Captcha.tsx
@@ -6,7 +6,6 @@ import { toast } from "react-toastify";
 import { verifyCaptchaToken } from "backend";
 import i18n from "i18n";
 import { RuntimeConfig } from "types/runtimeConfig";
-import theme from "types/theme";
 
 export interface CaptchaProps {
   /** Parent function to call when CAPTCHA succeeds or fails. */
@@ -43,7 +42,6 @@ export default function Captcha(props: CaptchaProps): ReactElement {
       onSuccess={verify}
       options={{ language: i18n.resolvedLanguage, theme: "light" }}
       siteKey={RuntimeConfig.getInstance().captchaSiteKey()}
-      style={{ marginBottom: theme.spacing(1) }}
     />
   ) : (
     <Fragment />

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -3,8 +3,10 @@ import {
   Button,
   Card,
   CardContent,
-  Grid,
+  CardHeader,
+  Grid2,
   Link,
+  Stack,
   TextFieldProps,
   Typography,
 } from "@mui/material";
@@ -29,9 +31,9 @@ import { type StoreState } from "rootRedux/types";
 import router from "router/browserRouter";
 import { Path } from "types/path";
 import { RuntimeConfig } from "types/runtimeConfig";
-import theme from "types/theme";
 import { NormalizedTextField } from "utilities/fontComponents";
 import { openUserGuide } from "utilities/pathUtilities";
+import { meetsPasswordRequirements } from "utilities/utilities";
 
 export enum LoginId {
   ButtonLogIn = "login-log-in-button",
@@ -46,6 +48,7 @@ export enum LoginTextId {
   ButtonLogin = "login.login",
   ButtonSignUp = "login.signUp",
   Error401 = "login.failed",
+  ErrorPassword = "login.passwordRequirements",
   ErrorUnknown = "login.failedUnknownReason",
   FieldError = "login.required",
   LabelPassword = "login.password",
@@ -90,10 +93,11 @@ export default function Login(): ReactElement {
   const logIn = (e: FormEvent): void => {
     e.preventDefault();
     const p = password.trim();
+    const pOk = meetsPasswordRequirements(p);
     const u = username.trim();
-    setPasswordError(!p);
+    setPasswordError(!pOk);
     setUsernameError(!u);
-    if (p && u) {
+    if (pOk && u) {
       dispatch(asyncLogIn(u, p));
     }
   };
@@ -108,129 +112,119 @@ export default function Login(): ReactElement {
   });
 
   return (
-    <Grid container justifyContent="center">
-      <Card style={{ width: 450 }}>
-        <form id={LoginId.Form} onSubmit={logIn}>
-          <CardContent>
-            {/* Title */}
-            <Typography variant="h5" align="center" gutterBottom>
+    <Grid2 container justifyContent="center">
+      <Card sx={{ width: 450 }}>
+        {/* Title */}
+        <CardHeader
+          title={
+            <Typography align="center" variant="h5">
               {t(LoginTextId.Title)}
             </Typography>
+          }
+        />
 
-            {/* Username field */}
-            <NormalizedTextField
-              {...defaultTextFieldProps(LoginId.FieldUsername)}
-              autoComplete="username"
-              autoFocus
-              error={usernameError}
-              helperText={usernameError ? t(LoginTextId.FieldError) : undefined}
-              label={t(LoginTextId.LabelUsername)}
-              onChange={handleUpdateUsername}
-              value={username}
-            />
+        <CardContent>
+          <form id={LoginId.Form} onSubmit={logIn}>
+            <Stack spacing={2}>
+              {/* Username field */}
+              <NormalizedTextField
+                {...defaultTextFieldProps(LoginId.FieldUsername)}
+                autoComplete="username"
+                autoFocus
+                error={usernameError}
+                helperText={
+                  usernameError ? t(LoginTextId.FieldError) : undefined
+                }
+                label={t(LoginTextId.LabelUsername)}
+                onChange={handleUpdateUsername}
+                value={username}
+              />
 
-            {/* Password field */}
-            <NormalizedTextField
-              {...defaultTextFieldProps(LoginId.FieldPassword)}
-              autoComplete="current-password"
-              error={passwordError}
-              helperText={passwordError ? t(LoginTextId.FieldError) : undefined}
-              label={t(LoginTextId.LabelPassword)}
-              onChange={handleUpdatePassword}
-              type="password"
-              value={password}
-            />
+              {/* Password field */}
+              <NormalizedTextField
+                {...defaultTextFieldProps(LoginId.FieldPassword)}
+                autoComplete="current-password"
+                error={passwordError}
+                helperText={
+                  passwordError
+                    ? password
+                      ? t(LoginTextId.ErrorPassword)
+                      : t(LoginTextId.FieldError)
+                    : undefined
+                }
+                label={t(LoginTextId.LabelPassword)}
+                onChange={handleUpdatePassword}
+                type="password"
+                value={password}
+              />
 
-            {/* "Forgot password?" link to reset password */}
-            {RuntimeConfig.getInstance().emailServicesEnabled() && (
-              <Typography>
-                <Link
-                  href={"#"}
-                  onClick={() => router.navigate(Path.PwRequest)}
-                  underline="hover"
-                  variant="subtitle2"
-                >
-                  {t(LoginTextId.LinkForgotPassword)}
-                </Link>
-              </Typography>
-            )}
+              {/* "Forgot password?" link to reset password */}
+              {RuntimeConfig.getInstance().emailServicesEnabled() && (
+                <Typography>
+                  <Link
+                    href={"#"}
+                    onClick={() => router.navigate(Path.PwRequest)}
+                    underline="hover"
+                    variant="subtitle2"
+                  >
+                    {t(LoginTextId.LinkForgotPassword)}
+                  </Link>
+                </Typography>
+              )}
 
-            {/* "Failed to log in" */}
-            {status === LoginStatus.Failure && (
-              <Typography
-                style={{ color: "red", marginBottom: 24, marginTop: 24 }}
-                variant="body2"
-              >
-                {t(
-                  loginError.includes("401")
-                    ? LoginTextId.Error401
-                    : LoginTextId.ErrorUnknown
-                )}
-              </Typography>
-            )}
+              {/* "Failed to log in" */}
+              {status === LoginStatus.Failure && (
+                <Typography sx={{ color: "red" }} variant="body2">
+                  {t(
+                    loginError.includes("401")
+                      ? LoginTextId.Error401
+                      : LoginTextId.ErrorUnknown
+                  )}
+                </Typography>
+              )}
 
-            <Captcha setSuccess={setIsVerified} />
+              <Captcha setSuccess={setIsVerified} />
 
-            {/* User Guide, Sign Up, and Log In buttons */}
-            <Grid container justifyContent="space-between">
-              <Grid item xs={1}>
-                <Button
-                  data-testid={LoginId.ButtonUserGuide}
-                  id={LoginId.ButtonUserGuide}
-                  onClick={() => openUserGuide()}
-                >
-                  <Help />
-                </Button>
-              </Grid>
-
-              <Grid
-                container
-                item
-                justifyContent="flex-end"
-                spacing={2}
-                xs="auto"
-              >
-                <Grid item>
+              {/* User Guide, Sign Up, and Log In buttons */}
+              <Grid2 container spacing={2}>
+                <Grid2 size="grow">
                   <Button
-                    data-testid={LoginId.ButtonSignUp}
-                    id={LoginId.ButtonSignUp}
-                    onClick={() => router.navigate(Path.Signup)}
-                    variant="outlined"
+                    data-testid={LoginId.ButtonUserGuide}
+                    id={LoginId.ButtonUserGuide}
+                    onClick={() => openUserGuide()}
                   >
-                    {t(LoginTextId.ButtonSignUp)}
+                    <Help />
                   </Button>
-                </Grid>
+                </Grid2>
 
-                <Grid item>
-                  <LoadingButton
-                    buttonProps={{
-                      "data-testid": LoginId.ButtonLogIn,
-                      id: LoginId.ButtonLogIn,
-                      type: "submit",
-                    }}
-                    disabled={!isVerified}
-                    loading={status === LoginStatus.InProgress}
-                  >
-                    {t(LoginTextId.ButtonLogin)}
-                  </LoadingButton>
-                </Grid>
-              </Grid>
-            </Grid>
+                <Button
+                  data-testid={LoginId.ButtonSignUp}
+                  id={LoginId.ButtonSignUp}
+                  onClick={() => router.navigate(Path.Signup)}
+                  variant="outlined"
+                >
+                  {t(LoginTextId.ButtonSignUp)}
+                </Button>
 
-            {/* Login announcement banner */}
-            {!!banner && (
-              <Typography
-                style={{
-                  marginTop: theme.spacing(2),
-                  padding: theme.spacing(1),
-                }}
-              >
-                {banner}
-              </Typography>
-            )}
-          </CardContent>
-        </form>
+                <LoadingButton
+                  buttonProps={{
+                    "data-testid": LoginId.ButtonLogIn,
+                    id: LoginId.ButtonLogIn,
+                    type: "submit",
+                  }}
+                  disabled={!isVerified}
+                  loading={status === LoginStatus.InProgress}
+                >
+                  {t(LoginTextId.ButtonLogin)}
+                </LoadingButton>
+              </Grid2>
+
+              {/* Login announcement banner */}
+              {!!banner && <Typography>{banner}</Typography>}
+            </Stack>
+          </form>
+        </CardContent>
       </Card>
-    </Grid>
+    </Grid2>
   );
 }

--- a/src/components/Login/Signup.tsx
+++ b/src/components/Login/Signup.tsx
@@ -2,7 +2,9 @@ import {
   Button,
   Card,
   CardContent,
-  Grid,
+  CardHeader,
+  Grid2,
+  Stack,
   TextField,
   TextFieldProps,
   Typography,
@@ -187,90 +189,89 @@ export default function Signup(props: SignupProps): ReactElement {
   });
 
   return (
-    <Grid container justifyContent="center">
+    <Grid2 container justifyContent="center">
       <Card style={{ width: 450 }}>
-        <form id={SignupId.Form} onSubmit={signUp}>
-          <CardContent>
-            {/* Title */}
-            <Typography align="center" gutterBottom variant="h5">
+        {/* Title */}
+        <CardHeader
+          title={
+            <Typography align="center" variant="h5">
               {t("login.signUpNew")}
             </Typography>
+          }
+        />
 
-            {/* Name field */}
-            <NormalizedTextField
-              {...defaultTextFieldProps(SignupField.Name)}
-              autoComplete="name"
-              autoFocus
-              helperText={
-                fieldError[SignupField.Name] ? t("login.required") : undefined
-              }
-            />
+        <CardContent>
+          <form id={SignupId.Form} onSubmit={signUp}>
+            <Stack spacing={2}>
+              {/* Name field */}
+              <NormalizedTextField
+                {...defaultTextFieldProps(SignupField.Name)}
+                autoComplete="name"
+                autoFocus
+                helperText={
+                  fieldError[SignupField.Name] ? t("login.required") : undefined
+                }
+              />
 
-            {/* Username field */}
-            <NormalizedTextField
-              {...defaultTextFieldProps(SignupField.Username)}
-              autoComplete="username"
-              helperText={t("login.usernameRequirements")}
-              onBlur={() => checkUsername()}
-            />
+              {/* Username field */}
+              <NormalizedTextField
+                {...defaultTextFieldProps(SignupField.Username)}
+                autoComplete="username"
+                helperText={t("login.usernameRequirements")}
+                onBlur={() => checkUsername()}
+              />
 
-            {/* Email field */}
-            {/* Don't use NormalizedTextField for type="email".
-            At best, it doesn't normalize, because of the punycode. */}
-            <TextField
-              {...defaultTextFieldProps(SignupField.Email)}
-              autoComplete="email"
-              type="email"
-            />
+              {/* Email field */}
+              {/* Don't use NormalizedTextField for type="email".
+              At best, it doesn't normalize, because of the punycode. */}
+              <TextField
+                {...defaultTextFieldProps(SignupField.Email)}
+                autoComplete="email"
+                type="email"
+              />
 
-            {/* Password field */}
-            <NormalizedTextField
-              {...defaultTextFieldProps(SignupField.Password1)}
-              autoComplete="new-password"
-              helperText={t("login.passwordRequirements")}
-              onBlur={() => checkPassword1()}
-              type="password"
-            />
+              {/* Password field */}
+              <NormalizedTextField
+                {...defaultTextFieldProps(SignupField.Password1)}
+                autoComplete="new-password"
+                helperText={t("login.passwordRequirements")}
+                onBlur={() => checkPassword1()}
+                type="password"
+              />
 
-            {/* Confirm Password field */}
-            <NormalizedTextField
-              {...defaultTextFieldProps(SignupField.Password2)}
-              autoComplete="new-password"
-              helperText={
-                fieldError[SignupField.Password2]
-                  ? t("login.confirmPasswordError")
-                  : undefined
-              }
-              onBlur={() => checkPassword2()}
-              type="password"
-            />
+              {/* Confirm Password field */}
+              <NormalizedTextField
+                {...defaultTextFieldProps(SignupField.Password2)}
+                autoComplete="new-password"
+                helperText={
+                  fieldError[SignupField.Password2]
+                    ? t("login.confirmPasswordError")
+                    : undefined
+                }
+                onBlur={() => checkPassword2()}
+                type="password"
+              />
 
-            {/* "Failed to sign up" */}
-            {!!error && (
-              <Typography
-                style={{ color: "red", marginBottom: 24, marginTop: 24 }}
-                variant="body2"
-              >
-                {t(error)}
-              </Typography>
-            )}
+              {/* "Failed to sign up" */}
+              {!!error && (
+                <Typography sx={{ color: "red" }} variant="body2">
+                  {t(error)}
+                </Typography>
+              )}
 
-            <Captcha setSuccess={setIsVerified} />
+              <Captcha setSuccess={setIsVerified} />
 
-            {/* Sign Up and Log In buttons */}
-            <Grid container justifyContent="flex-end" spacing={2}>
-              <Grid item>
+              {/* Sign Up and Log In buttons */}
+              <Stack direction="row" justifyContent="flex-end" spacing={2}>
                 <Button
                   data-testid={SignupId.ButtonLogIn}
                   id={SignupId.ButtonLogIn}
                   onClick={() => router.navigate(Path.Login)}
-                  type="button"
                   variant="outlined"
                 >
                   {t("login.backToLogin")}
                 </Button>
-              </Grid>
-              <Grid item>
+
                 <LoadingDoneButton
                   buttonProps={{
                     color: "primary",
@@ -284,11 +285,11 @@ export default function Signup(props: SignupProps): ReactElement {
                 >
                   {t("login.signUp")}
                 </LoadingDoneButton>
-              </Grid>
-            </Grid>
-          </CardContent>
-        </form>
+              </Stack>
+            </Stack>
+          </form>
+        </CardContent>
       </Card>
-    </Grid>
+    </Grid2>
   );
 }

--- a/src/components/PasswordReset/Request.tsx
+++ b/src/components/PasswordReset/Request.tsx
@@ -1,4 +1,12 @@
-import { Button, Card, Grid, Typography } from "@mui/material";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  Grid2,
+  Stack,
+  Typography,
+} from "@mui/material";
 import { FormEvent, ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
@@ -40,59 +48,57 @@ export default function ResetRequest(): ReactElement {
   };
 
   return (
-    <Grid container justifyContent="center">
-      <Card style={{ padding: 10, width: 450 }}>
-        <Typography align="center" variant="h5">
-          {t("passwordReset.resetRequestTitle")}
-        </Typography>
-        {isDone ? (
-          <>
-            <Typography>{t("passwordReset.resetDone")}</Typography>
-            <Grid item>
+    <Grid2 container justifyContent="center">
+      <Card sx={{ width: 450 }}>
+        <CardHeader
+          title={
+            <Typography align="center" variant="h5">
+              {t("passwordReset.resetRequestTitle")}
+            </Typography>
+          }
+        />
+
+        <CardContent>
+          {isDone ? (
+            <Stack alignItems="flex-start" spacing={2}>
+              <Typography>{t("passwordReset.resetDone")}</Typography>
+
               <Button
                 data-testid={PasswordRequestIds.ButtonLogin}
                 id={PasswordRequestIds.ButtonLogin}
                 onClick={() => navigate(Path.Login)}
-                type="button"
-                variant="outlined"
+                variant="contained"
               >
                 {t("login.backToLogin")}
               </Button>
-            </Grid>
-          </>
-        ) : (
-          <>
-            <Typography align="center" variant="subtitle1">
-              {t("passwordReset.resetRequestInstructions")}
-            </Typography>
+            </Stack>
+          ) : (
             <form onSubmit={onSubmit}>
-              <Grid item>
+              <Stack alignItems="flex-start" spacing={1}>
+                <Typography>
+                  {t("passwordReset.resetRequestInstructions")}
+                </Typography>
+
                 <NormalizedTextField
+                  fullWidth
                   helperText={isError && t("passwordReset.resetFail")}
                   id={PasswordRequestIds.FieldEmailOrUsername}
                   inputProps={{
                     "data-testid": PasswordRequestIds.FieldEmailOrUsername,
                   }}
                   label={t("passwordReset.emailOrUsername")}
-                  margin="normal"
                   onChange={(e) => setEmailOrUsername(e.target.value)}
                   required
-                  type="text"
-                  style={{ width: "100%" }}
                   value={emailOrUsername}
-                  variant="outlined"
                 />
-              </Grid>
-              <Grid item>
+
                 <Captcha setSuccess={setIsVerified} />
-              </Grid>
-              <Grid item>
+
                 <LoadingDoneButton
                   buttonProps={{
-                    color: "primary",
                     "data-testid": PasswordRequestIds.ButtonSubmit,
                     id: PasswordRequestIds.ButtonSubmit,
-                    onClick: () => onSubmit,
+                    onClick: onSubmit,
                     variant: "contained",
                   }}
                   disabled={!emailOrUsername || !isVerified}
@@ -100,11 +106,11 @@ export default function ResetRequest(): ReactElement {
                 >
                   {t("passwordReset.submit")}
                 </LoadingDoneButton>
-              </Grid>
+              </Stack>
             </form>
-          </>
-        )}
+          )}
+        </CardContent>
       </Card>
-    </Grid>
+    </Grid2>
   );
 }

--- a/src/components/PasswordReset/ResetPage.tsx
+++ b/src/components/PasswordReset/ResetPage.tsx
@@ -1,5 +1,12 @@
-import ExitToAppIcon from "@mui/icons-material/ExitToApp";
-import { Button, Card, Grid, Typography } from "@mui/material";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  Grid2,
+  Stack,
+  Typography,
+} from "@mui/material";
 import {
   type FormEvent,
   type ReactElement,
@@ -9,6 +16,7 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router";
+import { toast } from "react-toastify";
 
 import { resetPassword, validateResetToken } from "backend";
 import InvalidLink from "components/InvalidLink";
@@ -16,21 +24,10 @@ import { Path } from "types/path";
 import { NormalizedTextField } from "utilities/fontComponents";
 import { meetsPasswordRequirements } from "utilities/utilities";
 
-export enum PasswordResetTestIds {
+export enum PasswordResetIds {
   Password = "PasswordReset.password",
-  PasswordReqError = "PasswordReset.requirements-error",
   ConfirmPassword = "PasswordReset.confirm-password",
-  PasswordMatchError = "PasswordReset.match-error",
-  PasswordResetFail = "PasswordReset.reset-fail",
-  BackToLoginButton = "PasswordReset.button.back-to-login",
   SubmitButton = "PasswordReset.button.submit",
-}
-
-enum RequestState {
-  None,
-  Attempt,
-  Fail,
-  Success,
 }
 
 export default function PasswordReset(): ReactElement {
@@ -44,7 +41,6 @@ export default function PasswordReset(): ReactElement {
   const [passwordConfirm, setPasswordConfirm] = useState("");
   const [passwordFitsRequirements, setPasswordFitsRequirements] =
     useState(false);
-  const [requestState, setRequestState] = useState(RequestState.None);
 
   const validateLink = useCallback(async (): Promise<void> => {
     if (token) {
@@ -56,14 +52,8 @@ export default function PasswordReset(): ReactElement {
     validateLink();
   });
 
-  const backToLogin = (e: FormEvent<HTMLElement>): void => {
-    e.preventDefault();
-    navigate(Path.Login);
-  };
-
   const onSubmit = async (e: FormEvent<HTMLElement>): Promise<void> => {
     if (token) {
-      setRequestState(RequestState.Attempt);
       await asyncReset(token, password);
       e.preventDefault();
     }
@@ -81,114 +71,75 @@ export default function PasswordReset(): ReactElement {
 
   const asyncReset = async (token: string, password: string): Promise<void> => {
     if (await resetPassword(token, password)) {
-      setRequestState(RequestState.Success);
-      navigate(Path.Login);
+      toast.success(t("passwordReset.resetSuccess"));
     } else {
-      setRequestState(RequestState.Fail);
+      toast.error(t("passwordReset.resetFail"));
     }
+    navigate(Path.Login);
   };
 
   return isValidLink ? (
-    <Grid container justifyContent="center">
-      <Card style={{ padding: 10, width: 450 }}>
-        <form onSubmit={onSubmit}>
-          <Typography variant="h5" align="center" gutterBottom>
-            {t("passwordReset.resetTitle")}
-          </Typography>
-          <Grid item>
-            <NormalizedTextField
-              id="password-reset-password1"
-              variant="outlined"
-              label={t("login.password")}
-              type="password"
-              value={password}
-              style={{ width: "100%" }}
-              margin="normal"
-              error={!passwordFitsRequirements}
-              inputProps={{ "data-testid": PasswordResetTestIds.Password }}
-              onChange={(e) =>
-                onChangePassword(e.target.value, passwordConfirm)
-              }
-            />
-            {!passwordFitsRequirements && (
-              <Typography
-                id="login.passwordRequirements"
-                data-testid={PasswordResetTestIds.PasswordReqError}
-                variant="body2"
-                style={{ display: "inline", margin: 24, color: "red" }}
-              >
-                {t("login.passwordRequirements")}
-              </Typography>
-            )}
-          </Grid>
-          <Grid item>
-            <NormalizedTextField
-              id="password-reset-password2"
-              inputProps={{
-                "data-testid": PasswordResetTestIds.ConfirmPassword,
-              }}
-              variant="outlined"
-              label={t("login.confirmPassword")}
-              type="password"
-              value={passwordConfirm}
-              style={{ width: "100%" }}
-              margin="normal"
-              error={!isPasswordConfirmed && passwordConfirm.length > 0}
-              onChange={(e) => onChangePassword(password, e.target.value)}
-            />
-            {!isPasswordConfirmed && passwordConfirm.length > 0 && (
-              <Typography
-                id="login.confirmPasswordError"
-                data-testid={PasswordResetTestIds.PasswordMatchError}
-                variant="body2"
-                style={{ display: "inline", margin: 24, color: "red" }}
-              >
-                {t("login.confirmPasswordError")}
-              </Typography>
-            )}
-          </Grid>
+    <Grid2 container justifyContent="center">
+      <Card sx={{ width: 450 }}>
+        <CardHeader
+          title={
+            <Typography align="center" variant="h5">
+              {t("passwordReset.resetTitle")}
+            </Typography>
+          }
+        />
 
-          <Grid container justifyContent="flex-end" spacing={2}>
-            <Grid item>
-              {requestState === RequestState.Fail ? (
-                <>
-                  <Typography
-                    id="passwordReset.resetFail"
-                    data-testid={PasswordResetTestIds.PasswordResetFail}
-                    variant="body2"
-                    style={{ display: "inline", margin: 24, color: "red" }}
-                  >
-                    {t("passwordReset.resetFail")}
-                  </Typography>
-                  <Button
-                    id="password-reset-submit"
-                    variant="contained"
-                    color="primary"
-                    data-testid={PasswordResetTestIds.BackToLoginButton}
-                    onClick={backToLogin}
-                  >
-                    {t("passwordReset.backToLogin")}
-                    &nbsp;
-                    <ExitToAppIcon />
-                  </Button>
-                </>
-              ) : (
-                <Button
-                  id="password-reset-submit"
-                  data-testid={PasswordResetTestIds.SubmitButton}
-                  variant="contained"
-                  color="primary"
-                  disabled={!(passwordFitsRequirements && isPasswordConfirmed)}
-                  onClick={onSubmit}
-                >
-                  {t("passwordReset.submit")}
-                </Button>
-              )}
-            </Grid>
-          </Grid>
-        </form>
+        <CardContent>
+          <form onSubmit={onSubmit}>
+            <Stack alignItems="flex-end" spacing={2}>
+              <NormalizedTextField
+                error={!passwordFitsRequirements}
+                fullWidth
+                helperText={
+                  !passwordFitsRequirements && t("login.passwordRequirements")
+                }
+                id="password-reset-password1"
+                inputProps={{ "data-testid": PasswordResetIds.Password }}
+                label={t("login.password")}
+                onChange={(e) =>
+                  onChangePassword(e.target.value, passwordConfirm)
+                }
+                type="password"
+                value={password}
+              />
+
+              <NormalizedTextField
+                error={!isPasswordConfirmed && passwordConfirm.length > 0}
+                fullWidth
+                helperText={
+                  !isPasswordConfirmed &&
+                  passwordConfirm.length > 0 &&
+                  t("login.confirmPasswordError")
+                }
+                id={PasswordResetIds.ConfirmPassword}
+                inputProps={{
+                  "data-testid": PasswordResetIds.ConfirmPassword,
+                }}
+                label={t("login.confirmPassword")}
+                onChange={(e) => onChangePassword(password, e.target.value)}
+                type="password"
+                value={passwordConfirm}
+              />
+
+              <Button
+                data-testid={PasswordResetIds.SubmitButton}
+                disabled={!(passwordFitsRequirements && isPasswordConfirmed)}
+                id={PasswordResetIds.SubmitButton}
+                onClick={onSubmit}
+                variant="contained"
+              >
+                {t("passwordReset.submit")}
+              </Button>
+            </Stack>
+          </form>
+        </CardContent>
       </Card>
-    </Grid>
+    </Grid2>
   ) : (
     <InvalidLink textId="passwordReset.invalidURL" />
   );

--- a/src/components/PasswordReset/tests/ResetPage.test.tsx
+++ b/src/components/PasswordReset/tests/ResetPage.test.tsx
@@ -13,7 +13,7 @@ import { MemoryRouter, Route, Routes } from "react-router";
 import configureMockStore from "redux-mock-store";
 
 import PasswordReset, {
-  PasswordResetTestIds,
+  PasswordResetIds,
 } from "components/PasswordReset/ResetPage";
 import { Path } from "types/path";
 
@@ -65,115 +65,56 @@ const customRender = async (
 };
 
 describe("PasswordReset", () => {
-  it("renders with password length error", async () => {
+  it("disables button when password too short", async () => {
     const user = userEvent.setup();
     await customRender(<PasswordReset />);
 
     const shortPassword = "foo";
-    const passwdField = screen.getByTestId(PasswordResetTestIds.Password);
-    const passwdConfirm = screen.getByTestId(
-      PasswordResetTestIds.ConfirmPassword
-    );
+    const passwdField = screen.getByTestId(PasswordResetIds.Password);
+    const passwdConfirm = screen.getByTestId(PasswordResetIds.ConfirmPassword);
 
     await user.type(passwdField, shortPassword);
     await user.type(passwdConfirm, shortPassword);
 
-    const reqErrors = screen.queryAllByTestId(
-      PasswordResetTestIds.PasswordReqError
-    );
-    const confirmErrors = screen.queryAllByTestId(
-      PasswordResetTestIds.PasswordMatchError
-    );
-    const submitButton = screen.getByTestId(PasswordResetTestIds.SubmitButton);
-
-    expect(reqErrors.length).toBeGreaterThan(0);
-    expect(confirmErrors.length).toBe(0);
+    const submitButton = screen.getByTestId(PasswordResetIds.SubmitButton);
     expect(submitButton.closest("button")).toBeDisabled();
   });
 
-  it("renders with password match error", async () => {
+  it("disables button when passwords don't match", async () => {
     const user = userEvent.setup();
     await customRender(<PasswordReset />);
 
     const passwordEntry = "password";
     const confirmEntry = "passward";
-    const passwdField = screen.getByTestId(PasswordResetTestIds.Password);
-    const passwdConfirm = screen.getByTestId(
-      PasswordResetTestIds.ConfirmPassword
-    );
+    const passwdField = screen.getByTestId(PasswordResetIds.Password);
+    const passwdConfirm = screen.getByTestId(PasswordResetIds.ConfirmPassword);
 
     await user.type(passwdField, passwordEntry);
     await user.type(passwdConfirm, confirmEntry);
 
-    const reqErrors = screen.queryAllByTestId(
-      PasswordResetTestIds.PasswordReqError
-    );
-    const confirmErrors = screen.queryAllByTestId(
-      PasswordResetTestIds.PasswordMatchError
-    );
-    const submitButton = screen.getByTestId(PasswordResetTestIds.SubmitButton);
-
-    expect(reqErrors.length).toBe(0);
-    expect(confirmErrors.length).toBeGreaterThan(0);
+    const submitButton = screen.getByTestId(PasswordResetIds.SubmitButton);
     expect(submitButton.closest("button")).toBeDisabled();
   });
 
-  it("renders with no password errors", async () => {
+  it("enables button when passwords are long enough and match", async () => {
     const user = userEvent.setup();
     await customRender(<PasswordReset />);
 
     const passwordEntry = "password";
-    const confirmEntry = "password";
-    const passwdField = screen.getByTestId(PasswordResetTestIds.Password);
-    const passwdConfirm = screen.getByTestId(
-      PasswordResetTestIds.ConfirmPassword
-    );
+    const passwdField = screen.getByTestId(PasswordResetIds.Password);
+    const passwdConfirm = screen.getByTestId(PasswordResetIds.ConfirmPassword);
 
     await user.type(passwdField, passwordEntry);
-    await user.type(passwdConfirm, confirmEntry);
+    await user.type(passwdConfirm, passwordEntry);
 
-    const reqErrors = screen.queryAllByTestId(
-      PasswordResetTestIds.PasswordReqError
-    );
-    const confirmErrors = screen.queryAllByTestId(
-      PasswordResetTestIds.PasswordMatchError
-    );
-    const submitButton = screen.getByTestId(PasswordResetTestIds.SubmitButton);
-
-    expect(reqErrors.length).toBe(0);
-    expect(confirmErrors.length).toBe(0);
+    const submitButton = screen.getByTestId(PasswordResetIds.SubmitButton);
     expect(submitButton.closest("button")).toBeEnabled();
-  });
-
-  it("renders with expire error", async () => {
-    // rerender the component with the resetFailure prop set.
-    const user = userEvent.setup();
-    await customRender(<PasswordReset />);
-
-    const passwordEntry = "password";
-    const confirmEntry = "password";
-    const passwdField = screen.getByTestId(PasswordResetTestIds.Password);
-    const passwdConfirm = screen.getByTestId(
-      PasswordResetTestIds.ConfirmPassword
-    );
-
-    await user.type(passwdField, passwordEntry);
-    await user.type(passwdConfirm, confirmEntry);
-
-    const submitButton = screen.getByTestId(PasswordResetTestIds.SubmitButton);
-    mockPasswordReset.mockResolvedValueOnce(false);
-    await user.click(submitButton);
-
-    const resetErrors = screen.queryAllByTestId(
-      PasswordResetTestIds.PasswordResetFail
-    );
-    expect(resetErrors.length).toBeGreaterThan(0);
   });
 
   it("renders the InvalidLink component if token not valid", async () => {
     mockValidateResetToken.mockResolvedValueOnce(false);
     await customRender(<PasswordReset />);
-    for (const id of Object.values(PasswordResetTestIds)) {
+    for (const id of Object.values(PasswordResetIds)) {
       expect(screen.queryAllByTestId(id)).toHaveLength(0);
     }
     // The textId will show up as text because t() is mocked to return its input.


### PR DESCRIPTION
Part of #3787

Notes for review:

- In most places, replaced `<Grid>` with `<Grid2>`, `<Stack>`, `<div>`, or nothing, as fit the design need.
- `<Stack direction="row">` can be used in place of `<Grid2>` when we don't want the items in the row to wrap to a second row in a narrow window
- `<Card>` layout was made more consistent across `InvalidLink`, `Login`, `Signup`, `ResetRequest`, & `PasswordReset`
- Do a side-by-side visual comparison between this and `master` (on QA) to make sure appearance is (roughly) the same or (subjectively) improved on all edited components
- Try each edited component with various window widths > 350px (we don't care about narrower than that)
- Click "Forgot password?" on the Login page to test `ResetRequest`; initiate a password reset and click the link sent to your email to test `PasswordReset`; change a character in the token within that url to test `InvalidLink`
- Test with a few different UI languages