### PR TITLE
fix security issue

### DIFF
--- a/Backend/Controllers/UserController.cs
+++ b/Backend/Controllers/UserController.cs
@@ -108,7 +108,7 @@ namespace BackendFramework.Controllers
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<User>))]
         public async Task<IActionResult> GetAllUsers()
         {
-            if (string.IsNullOrEmpty(_permissionService.GetUserId(HttpContext)))
+            if (!await _permissionService.IsSiteAdmin(HttpContext))
             {
                 return Forbid();
             }


### PR DESCRIPTION
I'm not going to explain the reproduction here since this issue is currently live.

I think merging this in will break the Project users list as it depends on this API. A new API should be created which only returns the users for a specific project.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3864)
<!-- Reviewable:end -->
