### PR TITLE
[WordCard, goals] Migrate from deprecated Grid

### DIFF
--- a/src/components/Buttons/UndoButton.tsx
+++ b/src/components/Buttons/UndoButton.tsx
@@ -1,4 +1,4 @@
-import { Button, Grid } from "@mui/material";
+import { Button } from "@mui/material";
 import { ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -30,35 +30,27 @@ export default function UndoButton(props: UndoButtonProps): ReactElement {
     }
   }, [isUndoAllowed, undoDialogOpen]);
 
-  return (
-    <Grid container direction="column" justifyContent="center">
-      {isUndoEnabled ? (
-        <div>
-          <Button
-            aria-label={props.buttonLabelEnabled ?? "Undo"}
-            data-testid={props.buttonIdEnabled}
-            id={props.buttonIdEnabled}
-            onClick={() => setUndoDialogOpen(true)}
-            variant="outlined"
-          >
-            {t(props.textIdEnabled)}
-          </Button>
-          <CancelConfirmDialog
-            open={undoDialogOpen}
-            text={props.textIdDialog}
-            handleCancel={() => setUndoDialogOpen(false)}
-            handleConfirm={() =>
-              props.undo().then(() => setUndoDialogOpen(false))
-            }
-            buttonIdCancel={props.buttonIdCancel}
-            buttonIdConfirm={props.buttonIdConfirm}
-          />
-        </div>
-      ) : (
-        <div>
-          <Button disabled>{t(props.textIdDisabled)}</Button>
-        </div>
-      )}
-    </Grid>
+  return isUndoEnabled ? (
+    <>
+      <Button
+        aria-label={props.buttonLabelEnabled ?? "Undo"}
+        data-testid={props.buttonIdEnabled}
+        id={props.buttonIdEnabled}
+        onClick={() => setUndoDialogOpen(true)}
+        variant="outlined"
+      >
+        {t(props.textIdEnabled)}
+      </Button>
+      <CancelConfirmDialog
+        open={undoDialogOpen}
+        text={props.textIdDialog}
+        handleCancel={() => setUndoDialogOpen(false)}
+        handleConfirm={() => props.undo().then(() => setUndoDialogOpen(false))}
+        buttonIdCancel={props.buttonIdCancel}
+        buttonIdConfirm={props.buttonIdConfirm}
+      />
+    </>
+  ) : (
+    <Button disabled>{t(props.textIdDisabled)}</Button>
   );
 }

--- a/src/components/WordCard/DomainChipsGrid.tsx
+++ b/src/components/WordCard/DomainChipsGrid.tsx
@@ -1,4 +1,4 @@
-import { Grid } from "@mui/material";
+import { Grid2 } from "@mui/material";
 import { type ReactElement } from "react";
 
 import { type SemanticDomain } from "api/models";
@@ -26,12 +26,14 @@ export default function DomainChipsGrid(
   };
 
   return (
-    <Grid container spacing={2}>
+    <Grid2 container spacing={2}>
       {props.semDoms.map((d) => (
-        <Grid item key={`${d.id}${d.name}`}>
-          <DomainChip domain={updateName(d)} provenance={props.provenance} />
-        </Grid>
+        <DomainChip
+          domain={updateName(d)}
+          key={`${d.id}${d.name}`}
+          provenance={props.provenance}
+        />
       ))}
-    </Grid>
+    </Grid2>
   );
 }

--- a/src/components/WordCard/SenseCard.tsx
+++ b/src/components/WordCard/SenseCard.tsx
@@ -28,12 +28,7 @@ export default function SenseCard(props: SenseCardProps): ReactElement {
   const semDoms = props.sense.semanticDomains;
 
   return (
-    <Card
-      style={{
-        backgroundColor: props.bgColor || "white",
-        marginBottom: 10,
-      }}
-    >
+    <Card style={{ backgroundColor: props.bgColor || "white" }}>
       <CardContent style={{ position: "relative" }}>
         {/* Part of speech (if any) */}
         <div style={{ insetInlineStart: 0, position: "absolute", top: 0 }}>

--- a/src/components/WordCard/SummarySenseCard.tsx
+++ b/src/components/WordCard/SummarySenseCard.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, Chip, Grid, Typography } from "@mui/material";
+import { Card, CardContent, Chip, Grid2, Typography } from "@mui/material";
 import { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -57,13 +57,11 @@ export default function SummarySenseCard(
         />
 
         {/* Semantic domain numbers */}
-        <Grid container spacing={1}>
+        <Grid2 container spacing={1}>
           {domIds.map((id) => (
-            <Grid item key={id}>
-              <Chip label={id} />
-            </Grid>
+            <Chip key={id} label={id} />
           ))}
-        </Grid>
+        </Grid2>
       </CardContent>
     </Card>
   );

--- a/src/components/WordCard/index.tsx
+++ b/src/components/WordCard/index.tsx
@@ -5,6 +5,7 @@ import {
   CardContent,
   CardHeader,
   IconButton,
+  Stack,
   Typography,
 } from "@mui/material";
 import { Fragment, ReactElement, useEffect, useState } from "react";
@@ -130,14 +131,16 @@ export default function WordCard(props: WordCardProps): ReactElement {
 
         {/* Senses */}
         {full ? (
-          senses.map((s) => (
-            <SenseCard
-              key={s.guid}
-              languages={languages}
-              provenance={provenance}
-              sense={s}
-            />
-          ))
+          <Stack spacing={1}>
+            {senses.map((s) => (
+              <SenseCard
+                key={s.guid}
+                languages={languages}
+                provenance={provenance}
+                sense={s}
+              />
+            ))}
+          </Stack>
         ) : (
           <SummarySenseCard senses={senses} />
         )}

--- a/src/goals/CharacterInventory/CharInv/CharacterDetail/index.tsx
+++ b/src/goals/CharacterInventory/CharInv/CharacterDetail/index.tsx
@@ -1,5 +1,5 @@
 import { Close } from "@mui/icons-material";
-import { Grid, IconButton, Typography } from "@mui/material";
+import { Grid2, IconButton, Typography } from "@mui/material";
 import { ReactElement } from "react";
 
 import CharacterInfo from "goals/CharacterInventory/CharInv/CharacterDetail/CharacterInfo";
@@ -18,7 +18,7 @@ export default function CharacterDetail(
   props: CharacterDetailProps
 ): ReactElement {
   return (
-    <Grid
+    <Grid2
       container
       spacing={2}
       direction="row"
@@ -26,31 +26,31 @@ export default function CharacterDetail(
       alignItems="center"
       style={{ padding: theme.spacing(1) }}
     >
-      <Grid item xs={3}>
+      <Grid2 size={3}>
         <Typography variant="h1" align="center">
           {props.character}
           {""}
           {/* There is a zero-width joiner here in case of non-printing characters. */}
         </Typography>
-      </Grid>
-      <Grid item xs={8}>
+      </Grid2>
+      <Grid2 size={8}>
         <CharacterStatusControl character={props.character} />
-      </Grid>
-      <Grid item xs={1}>
+      </Grid2>
+      <Grid2 size={1}>
         <IconButton onClick={() => props.close()} size="large">
           {" "}
           <Close />
         </IconButton>
-      </Grid>
-      <Grid item xs={12}>
+      </Grid2>
+      <Grid2 size={12}>
         <CharacterInfo character={props.character} />
-      </Grid>
-      <Grid item xs={12}>
+      </Grid2>
+      <Grid2 size={12}>
         <CharacterWords character={props.character} />
-      </Grid>
-      <Grid item xs={12}>
+      </Grid2>
+      <Grid2 size={12}>
         <FindAndReplace initialFindValue={props.character} />
-      </Grid>
-    </Grid>
+      </Grid2>
+    </Grid2>
   );
 }

--- a/src/goals/CharacterInventory/CharInv/CharacterEntry.tsx
+++ b/src/goals/CharacterInventory/CharInv/CharacterEntry.tsx
@@ -1,16 +1,38 @@
 import { KeyboardArrowDown } from "@mui/icons-material";
-import { Button, Collapse, Grid } from "@mui/material";
+import {
+  Button,
+  Collapse,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Grid2,
+} from "@mui/material";
 import { ReactElement, ReactNode, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { LoadingButton } from "components/Buttons";
 import {
+  exit,
   setRejectedCharacters,
   setValidCharacters,
+  uploadInventory,
 } from "goals/CharacterInventory/Redux/CharacterInventoryActions";
 import { useAppDispatch, useAppSelector } from "rootRedux/hooks";
 import { type StoreState } from "rootRedux/types";
 import theme from "types/theme";
 import { TextFieldWithFont } from "utilities/fontComponents";
+
+export enum CharInvCancelSaveIds {
+  ButtonCancel = "char-inv-cancel-button",
+  ButtonSave = "char-inv-save-button",
+  DialogCancel = "char-inv-cancel-dialog",
+  DialogCancelButtonNo = "char-inv-cancel-dialog-no-button",
+  DialogCancelButtonYes = "char-inv-cancel-dialog-yes-button",
+  DialogCancelText = "char-inv-cancel-dialog-text",
+  DialogCancelTitle = "char-inv-cancel-dialog-title",
+}
 
 /**
  * Allows for viewing and entering accepted and rejected characters in a
@@ -23,56 +45,89 @@ export default function CharacterEntry(): ReactElement {
     (state: StoreState) => state.characterInventoryState
   );
 
-  const [checked, setChecked] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
+  const [saveInProgress, setSaveInProgress] = useState(false);
 
   const { t } = useTranslation();
 
-  return (
-    <Grid item xs={12}>
-      <Grid
-        container
-        style={{
-          background: "whitesmoke",
-          borderTop: "1px solid #ccc",
-          padding: theme.spacing(1),
-        }}
-        spacing={2}
-      >
-        <Button
-          id="character-entry-submit"
-          onClick={() => setChecked(!checked)}
-        >
-          {t("charInventory.characterSet.advanced")}{" "}
-          <KeyboardArrowDown
-            style={{
-              transform: checked ? "rotate(180deg)" : "rotate(0deg)",
-              transition: "all 200ms",
-            }}
-          />
-        </Button>
-        <Collapse in={checked} style={{ width: "100%" }}>
-          {/* Input for accepted characters */}
-          <Grid item xs={12}>
-            <CharactersInput
-              characters={validCharacters}
-              id="valid-characters-input"
-              label={t("charInventory.characterSet.acceptedCharacters")}
-              setCharacters={(chars) => dispatch(setValidCharacters(chars))}
-            />
-          </Grid>
+  const save = async (): Promise<void> => {
+    setSaveInProgress(true);
+    await dispatch(uploadInventory());
+  };
 
-          {/* Input for rejected characters */}
-          <Grid item xs={12}>
-            <CharactersInput
-              characters={rejectedCharacters}
-              id="rejected-characters-input"
-              label={t("charInventory.characterSet.rejectedCharacters")}
-              setCharacters={(chars) => dispatch(setRejectedCharacters(chars))}
+  return (
+    <div
+      style={{
+        background: "whitesmoke",
+        border: "1px solid #ccc",
+        padding: theme.spacing(1),
+      }}
+    >
+      <Grid2 container alignContent="center" justifyContent="space-between">
+        <Grid2 container spacing={2}>
+          {/* Save button */}
+          <LoadingButton
+            buttonProps={{
+              id: CharInvCancelSaveIds.ButtonSave,
+              onClick: () => save(),
+            }}
+            loading={saveInProgress}
+          >
+            {t("buttons.save")}
+          </LoadingButton>
+
+          {/* Cancel button */}
+          <Button
+            color="secondary"
+            id={CharInvCancelSaveIds.ButtonCancel}
+            onClick={() => setCancelDialogOpen(true)}
+            variant="contained"
+          >
+            {t("buttons.cancel")}
+          </Button>
+
+          {/* Cancel yes/no dialog */}
+          <CancelDialog
+            onClose={() => setCancelDialogOpen(false)}
+            open={cancelDialogOpen}
+          />
+        </Grid2>
+
+        {/* Advanced toggle-button */}
+        <Button
+          endIcon={
+            <KeyboardArrowDown
+              style={{
+                transform: advancedOpen ? "rotate(180deg)" : "rotate(0deg)",
+                transition: "all 200ms",
+              }}
             />
-          </Grid>
-        </Collapse>
-      </Grid>
-    </Grid>
+          }
+          onClick={() => setAdvancedOpen((prev) => !prev)}
+        >
+          {t("charInventory.characterSet.advanced")}
+        </Button>
+      </Grid2>
+
+      <Collapse in={advancedOpen}>
+        {/* Input for accepted characters */}
+        <CharactersInput
+          characters={validCharacters}
+          id="valid-characters-input"
+          label={t("charInventory.characterSet.acceptedCharacters")}
+          setCharacters={(chars) => dispatch(setValidCharacters(chars))}
+        />
+
+        {/* Input for rejected characters */}
+        <CharactersInput
+          characters={rejectedCharacters}
+          id="rejected-characters-input"
+          label={t("charInventory.characterSet.rejectedCharacters")}
+          setCharacters={(chars) => dispatch(setRejectedCharacters(chars))}
+        />
+      </Collapse>
+    </div>
   );
 }
 
@@ -95,10 +150,59 @@ function CharactersInput(props: CharactersInputProps): ReactElement {
       onChange={(e) =>
         props.setCharacters(e.target.value.replace(/\s/g, "").split(""))
       }
-      style={{ maxWidth: 512, marginTop: theme.spacing(1) }}
+      style={{ marginTop: theme.spacing(2) }}
       value={props.characters.join("")}
       variant="outlined"
       vernacular
     />
+  );
+}
+
+interface CancelDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/** "Are you sure?" dialog for the cancel button */
+function CancelDialog(props: CancelDialogProps): ReactElement {
+  const { t } = useTranslation();
+
+  return (
+    <Dialog
+      aria-describedby="alert-dialog-description"
+      aria-labelledby="alert-dialog-title"
+      id={CharInvCancelSaveIds.DialogCancel}
+      onClose={() => props.onClose()}
+      open={props.open}
+    >
+      <DialogTitle id={CharInvCancelSaveIds.DialogCancelTitle}>
+        {t("charInventory.dialog.title")}
+      </DialogTitle>
+
+      <DialogContent>
+        <DialogContentText id={CharInvCancelSaveIds.DialogCancelText}>
+          {t("charInventory.dialog.content")}
+        </DialogContentText>
+      </DialogContent>
+
+      <DialogActions>
+        <Button
+          autoFocus
+          color="secondary"
+          id={CharInvCancelSaveIds.DialogCancelButtonYes}
+          onClick={() => exit()}
+          variant="contained"
+        >
+          {t("charInventory.dialog.yes")}
+        </Button>
+
+        <Button
+          id={CharInvCancelSaveIds.DialogCancelButtonNo}
+          onClick={() => props.onClose()}
+        >
+          {t("charInventory.dialog.no")}
+        </Button>
+      </DialogActions>
+    </Dialog>
   );
 }

--- a/src/goals/CharacterInventory/CharInv/CharacterList/index.tsx
+++ b/src/goals/CharacterInventory/CharInv/CharacterList/index.tsx
@@ -1,5 +1,11 @@
 import { ArrowDownward, ArrowUpward } from "@mui/icons-material";
-import { FormControl, Grid, InputLabel, MenuItem, Select } from "@mui/material";
+import {
+  FormControl,
+  Grid2,
+  InputLabel,
+  MenuItem,
+  Select,
+} from "@mui/material";
 import { ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -42,53 +48,54 @@ export default function CharacterList(): ReactElement {
 
   return (
     <>
-      <Grid item xs={12}>
-        <FormControl variant="standard">
-          <InputLabel htmlFor="sort-order">
-            {t("charInventory.sortBy")}
-          </InputLabel>
-          <Select
-            variant="standard"
-            value={sortOrder}
-            onChange={(e) => setSortOrder(e.target.value as SortOrder)}
-            inputProps={{ id: "sort-order" }}
-          >
-            <MenuItem value={SortOrder.CharacterAscending}>
-              {t("charInventory.characters")}
-              <ArrowUpward fontSize="small" />
-            </MenuItem>
-            <MenuItem value={SortOrder.CharacterDescending}>
-              {t("charInventory.characters")}
-              <ArrowDownward fontSize="small" />
-            </MenuItem>
-            <MenuItem value={SortOrder.OccurrencesAscending}>
-              {t("charInventory.occurrences")}
-              <ArrowUpward fontSize="small" />
-            </MenuItem>
-            <MenuItem value={SortOrder.OccurrencesDescending}>
-              {t("charInventory.occurrences")}
-              <ArrowDownward fontSize="small" />
-            </MenuItem>
-            <MenuItem value={SortOrder.Status}>
-              {t("charInventory.status")}
-            </MenuItem>
-          </Select>
-        </FormControl>
-      </Grid>
-      {
-        /* The grid of character tiles */
-        orderedChars.map((character) => (
-          <CharacterCard
-            key={character.character}
-            char={character.character}
-            count={character.occurrences}
-            status={character.status}
-            onClick={() => selectCharacter(character.character)}
-            fontHeight={fontHeight}
-            cardWidth={cardWidth}
-          />
-        ))
-      }
+      <FormControl variant="standard">
+        <InputLabel htmlFor="sort-order">
+          {t("charInventory.sortBy")}
+        </InputLabel>
+        <Select
+          variant="standard"
+          value={sortOrder}
+          onChange={(e) => setSortOrder(e.target.value as SortOrder)}
+          inputProps={{ id: "sort-order" }}
+        >
+          <MenuItem value={SortOrder.CharacterAscending}>
+            {t("charInventory.characters")}
+            <ArrowUpward fontSize="small" />
+          </MenuItem>
+          <MenuItem value={SortOrder.CharacterDescending}>
+            {t("charInventory.characters")}
+            <ArrowDownward fontSize="small" />
+          </MenuItem>
+          <MenuItem value={SortOrder.OccurrencesAscending}>
+            {t("charInventory.occurrences")}
+            <ArrowUpward fontSize="small" />
+          </MenuItem>
+          <MenuItem value={SortOrder.OccurrencesDescending}>
+            {t("charInventory.occurrences")}
+            <ArrowDownward fontSize="small" />
+          </MenuItem>
+          <MenuItem value={SortOrder.Status}>
+            {t("charInventory.status")}
+          </MenuItem>
+        </Select>
+      </FormControl>
+
+      <Grid2 container>
+        {
+          /* The grid of character tiles */
+          orderedChars.map((character) => (
+            <CharacterCard
+              key={character.character}
+              char={character.character}
+              count={character.occurrences}
+              status={character.status}
+              onClick={() => selectCharacter(character.character)}
+              fontHeight={fontHeight}
+              cardWidth={cardWidth}
+            />
+          ))
+        }
+      </Grid2>
     </>
   );
 }

--- a/src/goals/CharacterInventory/CharInv/CharacterSetHeader.tsx
+++ b/src/goals/CharacterInventory/CharInv/CharacterSetHeader.tsx
@@ -1,5 +1,5 @@
 import { Help } from "@mui/icons-material";
-import { Grid, Tooltip, Typography } from "@mui/material";
+import { Tooltip, Typography } from "@mui/material";
 import { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -9,20 +9,18 @@ export default function CharacterSetHeader(): ReactElement {
   const { t } = useTranslation();
 
   return (
-    <Grid item xs={12}>
-      <Typography
-        component="h1"
-        variant="h4"
-        style={{ marginTop: theme.spacing(1) }}
+    <Typography
+      component="h1"
+      variant="h4"
+      style={{ marginTop: theme.spacing(1) }}
+    >
+      {t("charInventory.characterSet.title")}{" "}
+      <Tooltip
+        title={t("charInventory.characterSet.help")}
+        placement={document.body.dir === "rtl" ? "left" : "right"}
       >
-        {t("charInventory.characterSet.title")}{" "}
-        <Tooltip
-          title={t("charInventory.characterSet.help")}
-          placement={document.body.dir === "rtl" ? "left" : "right"}
-        >
-          <Help />
-        </Tooltip>
-      </Typography>
-    </Grid>
+        <Help />
+      </Tooltip>
+    </Typography>
   );
 }

--- a/src/goals/CharacterInventory/CharInv/index.tsx
+++ b/src/goals/CharacterInventory/CharInv/index.tsx
@@ -1,39 +1,17 @@
-import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-  Grid,
-} from "@mui/material";
-import { ReactElement, useEffect, useState } from "react";
-import { useTranslation } from "react-i18next";
+import { Grid2, Stack } from "@mui/material";
+import { ReactElement, useEffect } from "react";
 
-import { LoadingButton } from "components/Buttons";
 import CharacterDetail from "goals/CharacterInventory/CharInv/CharacterDetail";
 import CharacterEntry from "goals/CharacterInventory/CharInv/CharacterEntry";
 import CharacterList from "goals/CharacterInventory/CharInv/CharacterList";
 import CharacterSetHeader from "goals/CharacterInventory/CharInv/CharacterSetHeader";
 import {
-  exit,
   loadCharInvData,
   resetCharInv,
   setSelectedCharacter,
-  uploadInventory,
 } from "goals/CharacterInventory/Redux/CharacterInventoryActions";
 import { useAppDispatch, useAppSelector } from "rootRedux/hooks";
 import { type StoreState } from "rootRedux/types";
-import theme from "types/theme";
-
-const idPrefix = "character-inventory";
-export const buttonIdCancel = `${idPrefix}-cancel-button`;
-export const buttonIdSave = `${idPrefix}-save-button`;
-export const dialogButtonIdNo = `${idPrefix}-cancel-dialog-no-button`;
-export const dialogButtonIdYes = `${idPrefix}-cancel-dialog-yes-button`;
-export const dialogIdCancel = `${idPrefix}-cancel-dialog`;
-const dialogTextIdCancel = `${idPrefix}-cancel-dialog-text`;
-const dialogTitleIdCancel = `${idPrefix}-cancel-dialog-title`;
 
 /**
  * Allows users to define a character inventory for a project
@@ -45,11 +23,6 @@ export default function CharacterInventory(): ReactElement {
     (state: StoreState) => state.characterInventoryState.selectedCharacter
   );
 
-  const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
-  const [saveInProgress, setSaveInProgress] = useState(false);
-
-  const { t } = useTranslation();
-
   useEffect(() => {
     dispatch(loadCharInvData());
 
@@ -57,99 +30,24 @@ export default function CharacterInventory(): ReactElement {
     () => dispatch(resetCharInv());
   }, [dispatch]);
 
-  const save = async (): Promise<void> => {
-    setSaveInProgress(true);
-    await dispatch(uploadInventory());
-  };
-
   return (
-    <>
-      <Grid container justifyContent="center" spacing={2}>
-        <Grid item xl={9} lg={8} md={7} xs={12}>
-          <Grid
-            container
-            spacing={2}
-            direction="row"
-            justifyContent="flex-start"
-            alignItems="center"
-          >
-            <CharacterSetHeader />
-            <CharacterEntry />
-            <CharacterList />
-          </Grid>
-        </Grid>
+    <Grid2 container spacing={2} sx={{ margin: 2 }}>
+      <Grid2 size={selectedCharacter ? { xl: 9, lg: 8, md: 7, xs: 12 } : 12}>
+        <Stack alignItems="flex-start" spacing={2}>
+          <CharacterSetHeader />
+          <CharacterEntry />
+          <CharacterList />
+        </Stack>
+      </Grid2>
 
-        <Grid item xl={3} lg={4} md={5} xs={12}>
-          {!!selectedCharacter && (
-            <CharacterDetail
-              character={selectedCharacter}
-              close={() => dispatch(setSelectedCharacter(""))}
-            />
-          )}
-        </Grid>
-
-        <Grid item xs={12} style={{ borderTop: "1px solid #ccc" }}>
-          {/* Submission buttons */}
-          <Grid container justifyContent="center">
-            <LoadingButton
-              loading={saveInProgress}
-              buttonProps={{
-                id: buttonIdSave,
-                onClick: () => save(),
-                style: { margin: theme.spacing(1) },
-              }}
-            >
-              {t("buttons.save")}
-            </LoadingButton>
-            <Button
-              color="secondary"
-              id={buttonIdCancel}
-              variant="contained"
-              onClick={() => setCancelDialogOpen(true)}
-              style={{ margin: theme.spacing(1) }}
-            >
-              {" "}
-              {t("buttons.cancel")}
-            </Button>
-          </Grid>
-        </Grid>
-      </Grid>
-
-      {/* "Are you sure?" dialog for the cancel button */}
-      <Dialog
-        id={dialogIdCancel}
-        open={cancelDialogOpen}
-        onClose={() => setCancelDialogOpen(false)}
-        aria-labelledby="alert-dialog-title"
-        aria-describedby="alert-dialog-description"
-      >
-        <DialogTitle id={dialogTitleIdCancel}>
-          {t("charInventory.dialog.title")}
-        </DialogTitle>
-        <DialogContent>
-          <DialogContentText id={dialogTextIdCancel}>
-            {t("charInventory.dialog.content")}
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button
-            id={dialogButtonIdYes}
-            onClick={() => exit()}
-            variant="contained"
-            color="secondary"
-            autoFocus
-          >
-            {t("charInventory.dialog.yes")}
-          </Button>
-          <Button
-            id={dialogButtonIdNo}
-            onClick={() => setCancelDialogOpen(false)}
-            color="primary"
-          >
-            {t("charInventory.dialog.no")}
-          </Button>
-        </DialogActions>
-      </Dialog>
-    </>
+      {!!selectedCharacter && (
+        <Grid2 size="grow">
+          <CharacterDetail
+            character={selectedCharacter}
+            close={() => dispatch(setSelectedCharacter(""))}
+          />
+        </Grid2>
+      )}
+    </Grid2>
   );
 }

--- a/src/goals/CharacterInventory/CharInv/tests/index.test.tsx
+++ b/src/goals/CharacterInventory/CharInv/tests/index.test.tsx
@@ -2,13 +2,8 @@ import { Provider } from "react-redux";
 import { ReactTestRenderer, act, create } from "react-test-renderer";
 import configureMockStore from "redux-mock-store";
 
-import CharInv, {
-  buttonIdCancel,
-  buttonIdSave,
-  dialogButtonIdNo,
-  dialogButtonIdYes,
-  dialogIdCancel,
-} from "goals/CharacterInventory/CharInv";
+import CharInv from "goals/CharacterInventory/CharInv";
+import { CharInvCancelSaveIds } from "goals/CharacterInventory/CharInv/CharacterEntry";
 import { defaultState as characterInventoryState } from "goals/CharacterInventory/Redux/CharacterInventoryReduxTypes";
 
 // Replace Dialog with something that doesn't create portals,
@@ -63,30 +58,42 @@ describe("CharInv", () => {
 
   it("saves inventory on save", async () => {
     expect(mockUploadInventory).toHaveBeenCalledTimes(0);
-    const saveButton = charMaster.root.findByProps({ id: buttonIdSave });
+    const saveButton = charMaster.root.findByProps({
+      id: CharInvCancelSaveIds.ButtonSave,
+    });
     await act(async () => saveButton.props.onClick());
     expect(mockUploadInventory).toHaveBeenCalledTimes(1);
   });
 
   it("opens a dialogue on cancel, closes on no", async () => {
-    const cancelDialog = charMaster.root.findByProps({ id: dialogIdCancel });
+    const cancelDialog = charMaster.root.findByProps({
+      id: CharInvCancelSaveIds.DialogCancel,
+    });
     expect(cancelDialog.props.open).toBeFalsy();
 
-    const cancelButton = charMaster.root.findByProps({ id: buttonIdCancel });
+    const cancelButton = charMaster.root.findByProps({
+      id: CharInvCancelSaveIds.ButtonCancel,
+    });
     await act(async () => cancelButton.props.onClick());
     expect(cancelDialog.props.open).toBeTruthy();
 
-    const noButton = charMaster.root.findByProps({ id: dialogButtonIdNo });
+    const noButton = charMaster.root.findByProps({
+      id: CharInvCancelSaveIds.DialogCancelButtonNo,
+    });
     await act(async () => noButton.props.onClick());
     expect(cancelDialog.props.open).toBeFalsy();
   });
 
   it("exits on cancel-yes", async () => {
-    const cancelButton = charMaster.root.findByProps({ id: buttonIdCancel });
+    const cancelButton = charMaster.root.findByProps({
+      id: CharInvCancelSaveIds.ButtonCancel,
+    });
     await act(async () => cancelButton.props.onClick());
     expect(mockExit).toHaveBeenCalledTimes(0);
 
-    const yesButton = charMaster.root.findByProps({ id: dialogButtonIdYes });
+    const yesButton = charMaster.root.findByProps({
+      id: CharInvCancelSaveIds.DialogCancelButtonYes,
+    });
     await act(async () => yesButton.props.onClick());
     expect(mockExit).toHaveBeenCalledTimes(1);
   });

--- a/src/goals/DefaultGoal/DisplayProgress.tsx
+++ b/src/goals/DefaultGoal/DisplayProgress.tsx
@@ -1,4 +1,4 @@
-import { Grid, LinearProgress, Paper, Typography } from "@mui/material";
+import { LinearProgress, Paper, Stack, Typography } from "@mui/material";
 import { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
@@ -31,16 +31,12 @@ export default function DisplayProgress(): ReactElement | null {
 
   return numSteps > 1 ? (
     <Paper key={currentStep}>
-      <Grid container direction="column">
-        <Grid item xs>
-          <Typography variant={"h4"}>
-            {t(stepTranslateId, { val1: currentStep + 1, val2: numSteps })}
-          </Typography>
-        </Grid>
-        <Grid item xs>
-          <LinearProgress variant="determinate" value={percentComplete} />
-        </Grid>
-      </Grid>
+      <Stack>
+        <Typography variant={"h4"}>
+          {t(stepTranslateId, { val1: currentStep + 1, val2: numSteps })}
+        </Typography>
+        <LinearProgress variant="determinate" value={percentComplete} />
+      </Stack>
     </Paper>
   ) : null;
 }

--- a/src/goals/MergeDuplicates/MergeDupsCompleted.tsx
+++ b/src/goals/MergeDuplicates/MergeDupsCompleted.tsx
@@ -1,5 +1,5 @@
 import { ArrowRightAlt } from "@mui/icons-material";
-import { Card, Grid, Paper, Typography } from "@mui/material";
+import { Box, Card, Grid2, Paper, Stack, Typography } from "@mui/material";
 import { ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
@@ -53,48 +53,42 @@ export function MergeChange(props: { change: MergeUndoIds }): ReactElement {
   const isDeletion = !change.parentIds.length;
 
   return (
-    <Grid container style={{ flexWrap: "nowrap", overflow: "auto" }}>
+    <Grid2 container style={{ flexWrap: "nowrap", overflow: "auto" }}>
       {isDeletion && <Typography>{t("mergeDups.undo.deleted")}</Typography>}
       {change.childIds.map((id) => (
-        <WordPaper key={id} wordId={id} />
+        <WordBox key={id} wordId={id} />
       ))}
       {!isDeletion && (
         <>
-          <Grid style={{ margin: theme.spacing(1) }}>
-            <ArrowRightAlt
-              fontSize="large"
-              style={{
-                position: "relative",
-                left: "50%",
-                top: "50%",
-                transform: "translate(-50%, -50%)",
-              }}
-            />
-          </Grid>
+          <Box alignContent="center" style={{ margin: theme.spacing(1) }}>
+            <ArrowRightAlt fontSize="large" />
+          </Box>
           {change.parentIds.map((id) => (
-            <WordPaper key={id} wordId={id} />
+            <WordBox key={id} wordId={id} />
           ))}
         </>
       )}
-      <UndoButton
-        buttonIdEnabled={`merge-undo-${change.parentIds.join("-")}`}
-        buttonIdCancel="merge-undo-cancel"
-        buttonIdConfirm="merge-undo-confirm"
-        textIdDialog={
-          isDeletion
-            ? "mergeDups.undo.undoDeleteDialog"
-            : "mergeDups.undo.undoDialog"
-        }
-        textIdDisabled="mergeDups.undo.undoDisabled"
-        textIdEnabled={
-          isDeletion ? "mergeDups.undo.undoDelete" : "mergeDups.undo.undo"
-        }
-        isUndoAllowed={handleIsUndoAllowed}
-        undo={async () => {
-          await undoMerge(change);
-        }}
-      />
-    </Grid>
+      <Box alignContent="center">
+        <UndoButton
+          buttonIdEnabled={`merge-undo-${change.parentIds.join("-")}`}
+          buttonIdCancel="merge-undo-cancel"
+          buttonIdConfirm="merge-undo-confirm"
+          textIdDialog={
+            isDeletion
+              ? "mergeDups.undo.undoDeleteDialog"
+              : "mergeDups.undo.undoDialog"
+          }
+          textIdDisabled="mergeDups.undo.undoDisabled"
+          textIdEnabled={
+            isDeletion ? "mergeDups.undo.undoDelete" : "mergeDups.undo.undo"
+          }
+          isUndoAllowed={handleIsUndoAllowed}
+          undo={async () => {
+            await undoMerge(change);
+          }}
+        />
+      </Box>
+    </Grid2>
   );
 }
 
@@ -110,11 +104,7 @@ export function doWordsIncludeMerges(
   );
 }
 
-interface WordPaperProps {
-  wordId: string;
-}
-
-function WordPaper(props: WordPaperProps): ReactElement {
+function WordBox(props: { wordId: string }): ReactElement {
   const [word, setWord] = useState<Word | undefined>();
   const [flag, setFlag] = useState<Flag>(newFlag());
 
@@ -126,7 +116,7 @@ function WordPaper(props: WordPaperProps): ReactElement {
   }, [word]);
 
   return (
-    <Grid key={props.wordId} style={{ margin: theme.spacing(1) }}>
+    <Box style={{ margin: theme.spacing(1) }}>
       <Paper
         style={{
           backgroundColor: "lightgrey",
@@ -137,22 +127,18 @@ function WordPaper(props: WordPaperProps): ReactElement {
           square
           style={{ padding: theme.spacing(1), height: 44, minWidth: 100 }}
         >
-          <Grid container justifyContent="space-between">
-            <Grid>
-              <TypographyWithFont variant="h5" vernacular>
-                {word?.vernacular}
-              </TypographyWithFont>
-            </Grid>
-            <Grid>
-              <FlagButton flag={flag} buttonId={`word-${props.wordId}-flag`} />
-            </Grid>
-          </Grid>
+          <Stack direction="row" justifyContent="space-between">
+            <TypographyWithFont variant="h5" vernacular>
+              {word?.vernacular}
+            </TypographyWithFont>
+            <FlagButton flag={flag} buttonId={`word-${props.wordId}-flag`} />
+          </Stack>
         </Paper>
         <div style={{ maxHeight: "55vh", overflowY: "auto" }}>
           {word?.senses?.map(SenseCard)}
         </div>
       </Paper>
-    </Grid>
+    </Box>
   );
 }
 

--- a/src/goals/MergeDuplicates/MergeDupsStep/MergeDragDrop/SidebarDrop.tsx
+++ b/src/goals/MergeDuplicates/MergeDupsStep/MergeDragDrop/SidebarDrop.tsx
@@ -1,5 +1,5 @@
 import { ArrowForwardIos, HelpOutline } from "@mui/icons-material";
-import { Grid, IconButton, Typography } from "@mui/material";
+import { Grid2, IconButton, Typography } from "@mui/material";
 import { type ReactElement } from "react";
 import { Droppable } from "react-beautiful-dnd";
 
@@ -29,21 +29,24 @@ export default function SidebarDrop(): ReactElement {
           {...providedDroppable.droppableProps}
           style={{ backgroundColor: "lightblue", height: "100%", padding: 20 }}
         >
-          <Grid container justifyContent="space-between">
+          <Grid2 container justifyContent="space-between">
             <IconButton
               id="sidebar-close"
               onClick={() => dispatch(setSidebar())}
             >
               <ArrowForwardIos />
             </IconButton>
+
             <IconButton
               id="sidebar-help"
               onClick={() => openUserGuide("goals.html#merge-a-sense")}
             >
               <HelpOutline />
             </IconButton>
-          </Grid>
+          </Grid2>
+
           <Typography variant="h5">{vernacular}</Typography>
+
           {sidebar.mergeSenses.map((mergeSense, index) => (
             <SidebarDragSense
               index={index}

--- a/src/goals/MergeDuplicates/MergeDupsStep/MergeDragDrop/index.tsx
+++ b/src/goals/MergeDuplicates/MergeDupsStep/MergeDragDrop/index.tsx
@@ -1,5 +1,11 @@
 import { Delete } from "@mui/icons-material";
-import { Drawer, Grid, ImageList, ImageListItem, Tooltip } from "@mui/material";
+import {
+  Drawer,
+  Grid2,
+  ImageList,
+  ImageListItem,
+  Tooltip,
+} from "@mui/material";
 import { CSSProperties, ReactElement, useState } from "react";
 import { DragDropContext, Droppable, DropResult } from "react-beautiful-dnd";
 import { useTranslation } from "react-i18next";
@@ -240,8 +246,8 @@ export default function MergeDragDrop(): ReactElement {
 
   return (
     <DragDropContext onDragEnd={handleDrop}>
-      <Grid container>
-        <Grid item columns={1} key={"trash"} style={{ marginTop: "70vh" }}>
+      <Grid2 container>
+        <Grid2 columns={1} key={"trash"} style={{ marginTop: "70vh" }}>
           <Droppable key={trashId} droppableId={trashId}>
             {(provided): ReactElement => (
               <div ref={provided.innerRef}>
@@ -252,36 +258,35 @@ export default function MergeDragDrop(): ReactElement {
               </div>
             )}
           </Droppable>
-        </Grid>
-        <Grid item sm={11} xs={10 /* Allow trash icon more space. */}>
-          <ImageList rowHeight="auto" cols={colCount} style={{ width: "90vw" }}>
-            {Object.keys(words).map((key) => (
-              <ImageListItem
-                key={key}
-                style={{ height: "70vh", margin: theme.spacing(1) }}
-              >
-                <DropWord wordId={key} />
-              </ImageListItem>
-            ))}
-            <ImageListItem key={newId} style={{ margin: theme.spacing(1) }}>
-              <DropWord wordId={newId} />
+        </Grid2>
+
+        <ImageList rowHeight="auto" cols={colCount} style={{ width: "90vw" }}>
+          {Object.keys(words).map((key) => (
+            <ImageListItem
+              key={key}
+              style={{ height: "70vh", margin: theme.spacing(1) }}
+            >
+              <DropWord wordId={key} />
             </ImageListItem>
-            {renderSidebar()}
-            <CancelConfirmDialog
-              open={!!override}
-              text={override?.protectReason ?? ""}
-              handleCancel={() => setOverride(undefined)}
-              handleConfirm={onConfirmOverride}
-            />
-            <CancelConfirmDialog
-              open={!!srcToDelete}
-              text="mergeDups.helpText.deleteDialog"
-              handleCancel={() => setSrcToDelete(undefined)}
-              handleConfirm={onConfirmDelete}
-            />
-          </ImageList>
-        </Grid>
-      </Grid>
+          ))}
+          <ImageListItem key={newId} style={{ margin: theme.spacing(1) }}>
+            <DropWord wordId={newId} />
+          </ImageListItem>
+          {renderSidebar()}
+          <CancelConfirmDialog
+            open={!!override}
+            text={override?.protectReason ?? ""}
+            handleCancel={() => setOverride(undefined)}
+            handleConfirm={onConfirmOverride}
+          />
+          <CancelConfirmDialog
+            open={!!srcToDelete}
+            text="mergeDups.helpText.deleteDialog"
+            handleCancel={() => setSrcToDelete(undefined)}
+            handleConfirm={onConfirmDelete}
+          />
+        </ImageList>
+      </Grid2>
     </DragDropContext>
   );
 }

--- a/src/goals/MergeDuplicates/MergeDupsStep/SaveDeferButtons.tsx
+++ b/src/goals/MergeDuplicates/MergeDupsStep/SaveDeferButtons.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, FormControlLabel, Grid } from "@mui/material";
+import { Checkbox, FormControlLabel, Grid2 } from "@mui/material";
 import { ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -13,7 +13,6 @@ import {
 import { asyncAdvanceStep } from "goals/Redux/GoalActions";
 import { useAppDispatch, useAppSelector } from "rootRedux/hooks";
 import { StoreState } from "rootRedux/types";
-import theme from "types/theme";
 
 export default function SaveDeferButtons(): ReactElement {
   const dispatch = useAppDispatch();
@@ -52,43 +51,41 @@ export default function SaveDeferButtons(): ReactElement {
   };
 
   return (
-    <Grid container justifyContent="flex-start">
-      <Grid item>
-        <LoadingButton
-          loading={isSaving}
-          buttonProps={{
-            style: { marginInlineEnd: theme.spacing(3) },
-            onClick: saveContinue,
-            title: t("mergeDups.helpText.saveAndContinue"),
-            id: "merge-save",
-          }}
-        >
-          {t("buttons.saveAndContinue")}
-        </LoadingButton>
-        <LoadingButton
-          loading={isDeferring}
-          buttonProps={{
-            color: "secondary",
-            style: { marginInlineEnd: theme.spacing(3) },
-            onClick: defer,
-            title: t("mergeDups.helpText.defer"),
-            id: "merge-defer",
-          }}
-        >
-          {t("buttons.defer")}
-        </LoadingButton>
-        {hasProtected && (
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={overrideProtection}
-                onChange={() => dispatch(toggleOverrideProtection())}
-              />
-            }
-            label={t("mergeDups.helpText.protectedOverride")}
-          />
-        )}
-      </Grid>
-    </Grid>
+    <Grid2 container spacing={3}>
+      <LoadingButton
+        loading={isSaving}
+        buttonProps={{
+          onClick: saveContinue,
+          title: t("mergeDups.helpText.saveAndContinue"),
+          id: "merge-save",
+        }}
+      >
+        {t("buttons.saveAndContinue")}
+      </LoadingButton>
+
+      <LoadingButton
+        loading={isDeferring}
+        buttonProps={{
+          color: "secondary",
+          onClick: defer,
+          title: t("mergeDups.helpText.defer"),
+          id: "merge-defer",
+        }}
+      >
+        {t("buttons.defer")}
+      </LoadingButton>
+
+      {hasProtected && (
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={overrideProtection}
+              onChange={() => dispatch(toggleOverrideProtection())}
+            />
+          }
+          label={t("mergeDups.helpText.protectedOverride")}
+        />
+      )}
+    </Grid2>
   );
 }

--- a/src/goals/MergeDuplicates/MergeDupsStep/index.tsx
+++ b/src/goals/MergeDuplicates/MergeDupsStep/index.tsx
@@ -18,7 +18,13 @@ export default function MergeDupsStep(): ReactElement {
 
   return wordCount ? (
     <>
-      <div style={{ background: "#eee", padding: theme.spacing(1) }}>
+      <div
+        style={{
+          background: "#eee",
+          padding: theme.spacing(1),
+          paddingBottom: 0,
+        }}
+      >
         <MergeDragDrop />
       </div>
       <SaveDeferButtons />

--- a/src/goals/ReviewEntries/ReviewEntriesCompleted.tsx
+++ b/src/goals/ReviewEntries/ReviewEntriesCompleted.tsx
@@ -1,5 +1,5 @@
 import { ArrowRightAlt } from "@mui/icons-material";
-import { Grid, List, ListItem, Typography } from "@mui/material";
+import { Box, List, ListItem, Stack, Typography } from "@mui/material";
 import { ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
@@ -65,31 +65,36 @@ function EditedEntry(props: { edit: EntryEdit }): ReactElement {
 
   return (
     <ListItem>
-      <Grid container rowSpacing={4} wrap="nowrap">
-        <Grid item>{!!oldWord && <WordCard word={oldWord} />}</Grid>
-        <Grid key={"arrow"} style={{ margin: theme.spacing(1) }}>
-          <ArrowRightAlt
-            fontSize="large"
-            style={{
-              position: "relative",
-              left: "50%",
-              top: "50%",
-              transform: "translate(-50%, -50%)",
-            }}
+      <Stack direction="row" spacing={theme.spacing(1)}>
+        {!!oldWord && (
+          <Box>
+            <WordCard word={oldWord} />
+          </Box>
+        )}
+
+        <Box alignContent="center">
+          <ArrowRightAlt fontSize="large" />
+        </Box>
+
+        {!!newWord && (
+          <Box>
+            <WordCard word={newWord} />
+          </Box>
+        )}
+
+        <Box alignContent="center">
+          <UndoButton
+            buttonIdEnabled={`edit-undo-${props.edit.newId}`}
+            buttonIdCancel="edit-undo-cancel"
+            buttonIdConfirm="edit-undo-confirm"
+            textIdDialog="reviewEntries.undo.undoDialog"
+            textIdDisabled="reviewEntries.undo.undoDisabled"
+            textIdEnabled="reviewEntries.undo.undo"
+            isUndoAllowed={() => isInFrontier(newId)}
+            undo={() => undoEdit(props.edit)}
           />
-        </Grid>
-        <Grid item>{!!newWord && <WordCard word={newWord} />}</Grid>
-        <UndoButton
-          buttonIdEnabled={`edit-undo-${props.edit.newId}`}
-          buttonIdCancel="edit-undo-cancel"
-          buttonIdConfirm="edit-undo-confirm"
-          textIdDialog="reviewEntries.undo.undoDialog"
-          textIdDisabled="reviewEntries.undo.undoDisabled"
-          textIdEnabled="reviewEntries.undo.undo"
-          isUndoAllowed={() => isInFrontier(newId)}
-          undo={() => undoEdit(props.edit)}
-        />
-      </Grid>
+        </Box>
+      </Stack>
     </ListItem>
   );
 }

--- a/src/goals/ReviewEntries/ReviewEntriesTable/Cells/DomainsCell.tsx
+++ b/src/goals/ReviewEntries/ReviewEntriesTable/Cells/DomainsCell.tsx
@@ -1,4 +1,4 @@
-import { Chip, Grid } from "@mui/material";
+import { Chip, Grid2 } from "@mui/material";
 import { type ReactElement } from "react";
 
 import { type SemanticDomain, type Sense } from "api/models";
@@ -19,12 +19,14 @@ export function gatherDomains(senses: Sense[]): SemanticDomain[] {
 
 export default function DomainsCell(props: CellProps): ReactElement {
   return (
-    <Grid container direction="row" spacing={1}>
+    <Grid2 container spacing={1}>
       {gatherDomains(props.word.senses).map((dom) => (
-        <Grid item key={`${dom.id}-${dom.name}`}>
-          <Chip label={`${dom.id}: ${dom.name}`} style={{ color: "inherit" }} />
-        </Grid>
+        <Chip
+          key={`${dom.id}-${dom.name}`}
+          label={`${dom.id}: ${dom.name}`}
+          style={{ color: "inherit" }}
+        />
       ))}
-    </Grid>
+    </Grid2>
   );
 }

--- a/src/goals/ReviewEntries/ReviewEntriesTable/Cells/EditCell/EditDialog.tsx
+++ b/src/goals/ReviewEntries/ReviewEntriesTable/Cells/EditCell/EditDialog.tsx
@@ -13,10 +13,11 @@ import {
   Dialog,
   DialogContent,
   DialogTitle,
-  Grid,
+  Grid2,
   IconButton,
   MenuItem,
   Select,
+  Stack,
   type SelectChangeEvent,
 } from "@mui/material";
 import { grey, yellow } from "@mui/material/colors";
@@ -351,151 +352,135 @@ export default function EditDialog(props: EditDialogProps): ReactElement {
       />
       <Dialog fullWidth maxWidth="lg" open>
         <DialogTitle>
-          <Grid container justifyContent="space-between">
-            <Grid item>
-              {t("reviewEntries.columns.edit")}
-              {" : "}
-              {props.word.vernacular}
-            </Grid>
-            <Grid item>
+          <Grid2 container justifyContent="space-between">
+            {`${t("reviewEntries.columns.edit")} : ${props.word.vernacular}`}
+
+            <div>
               <IconButton id={EditDialogId.ButtonSave} onClick={saveAndClose}>
                 <Check style={{ color: themeColors.success }} />
               </IconButton>
+
               <IconButton
                 id={EditDialogId.ButtonCancel}
                 onClick={conditionalCancel}
               >
                 <Close style={{ color: themeColors.error }} />
               </IconButton>
-            </Grid>
-          </Grid>
+            </div>
+          </Grid2>
         </DialogTitle>
+
         <DialogContent>
-          <Grid
-            container
-            direction="column"
-            justifyContent="flex-start"
-            spacing={3}
-          >
+          <Stack spacing={3}>
             {/* Vernacular */}
-            <Grid item>
-              <Card sx={bgStyle(EditField.Vernacular)}>
-                <CardHeader title={t("reviewEntries.columns.vernacular")} />
-                <CardContent>
-                  <TextFieldWithFont
-                    id={EditDialogId.TextFieldVernacular}
-                    label={vernLang}
-                    onChange={(e) =>
-                      setNewWord((prev) => ({
-                        ...prev,
-                        vernacular: e.target.value,
-                      }))
-                    }
-                    value={newWord.vernacular}
-                    vernacular
-                  />
-                </CardContent>
-              </Card>
-            </Grid>
+            <Card sx={bgStyle(EditField.Vernacular)}>
+              <CardHeader title={t("reviewEntries.columns.vernacular")} />
+              <CardContent>
+                <TextFieldWithFont
+                  id={EditDialogId.TextFieldVernacular}
+                  label={vernLang}
+                  onChange={(e) =>
+                    setNewWord((prev) => ({
+                      ...prev,
+                      vernacular: e.target.value,
+                    }))
+                  }
+                  value={newWord.vernacular}
+                  vernacular
+                />
+              </CardContent>
+            </Card>
 
             {/* Senses */}
-            <Grid item>
-              <Card sx={bgStyle(EditField.Senses)}>
-                <CardHeader
-                  action={
-                    newWord.senses.length > 1 && (
-                      <IconButton
-                        id={EditDialogId.ButtonSensesViewToggle}
-                        onClick={() => setShowSenses((prev) => !prev)}
-                      >
-                        {showSenses ? (
-                          <CloseFullscreen sx={{ color: "gray" }} />
-                        ) : (
-                          <OpenInFull sx={{ color: "gray" }} />
-                        )}
-                      </IconButton>
-                    )
-                  }
-                  title={t("reviewEntries.columns.senses")}
-                />
-                <EditSensesCardContent
-                  moveSense={moveSense}
-                  newSenses={newWord.senses}
-                  oldSenses={props.word.senses}
-                  showSenses={showSenses}
-                  toggleSenseDeleted={toggleSenseDeleted}
-                  updateOrAddSense={updateOrAddSense}
-                />
-              </Card>
-            </Grid>
+            <Card sx={bgStyle(EditField.Senses)}>
+              <CardHeader
+                action={
+                  newWord.senses.length > 1 && (
+                    <IconButton
+                      id={EditDialogId.ButtonSensesViewToggle}
+                      onClick={() => setShowSenses((prev) => !prev)}
+                    >
+                      {showSenses ? (
+                        <CloseFullscreen sx={{ color: "gray" }} />
+                      ) : (
+                        <OpenInFull sx={{ color: "gray" }} />
+                      )}
+                    </IconButton>
+                  )
+                }
+                title={t("reviewEntries.columns.senses")}
+              />
+              <EditSensesCardContent
+                moveSense={moveSense}
+                newSenses={newWord.senses}
+                oldSenses={props.word.senses}
+                showSenses={showSenses}
+                toggleSenseDeleted={toggleSenseDeleted}
+                updateOrAddSense={updateOrAddSense}
+              />
+            </Card>
 
             {/* Pronunciations */}
-            <Grid item>
-              <Card sx={bgStyle(EditField.Pronunciations)}>
-                <CardHeader title={t("reviewEntries.columns.pronunciations")} />
-                <CardContent>
-                  <PronunciationsFrontend
-                    elemBetweenRecordAndPlay={
-                      <PronunciationsBackend
-                        audio={newWord.audio}
-                        deleteAudio={delOldAudio}
-                        overrideMemo
-                        playerOnly
-                        replaceAudio={repOldAudio}
-                        wordId={newWord.id}
-                      />
-                    }
-                    audio={newAudio}
-                    deleteAudio={delNewAudio}
-                    replaceAudio={repNewAudio}
-                    uploadAudio={uplNewAudio}
-                  />
-                </CardContent>
-              </Card>
-            </Grid>
+            <Card sx={bgStyle(EditField.Pronunciations)}>
+              <CardHeader title={t("reviewEntries.columns.pronunciations")} />
+              <CardContent>
+                <PronunciationsFrontend
+                  elemBetweenRecordAndPlay={
+                    <PronunciationsBackend
+                      audio={newWord.audio}
+                      deleteAudio={delOldAudio}
+                      overrideMemo
+                      playerOnly
+                      replaceAudio={repOldAudio}
+                      wordId={newWord.id}
+                    />
+                  }
+                  audio={newAudio}
+                  deleteAudio={delNewAudio}
+                  replaceAudio={repNewAudio}
+                  uploadAudio={uplNewAudio}
+                />
+              </CardContent>
+            </Card>
 
             {/* Note */}
-            <Grid item>
-              <Card sx={bgStyle(EditField.Note)}>
-                <CardHeader
-                  action={noteLangSelect}
-                  title={t("reviewEntries.columns.note")}
+            <Card sx={bgStyle(EditField.Note)}>
+              <CardHeader
+                action={noteLangSelect}
+                title={t("reviewEntries.columns.note")}
+              />
+              <CardContent>
+                <TextFieldWithFont
+                  analysis
+                  fullWidth
+                  id={EditDialogId.TextFieldNote}
+                  lang={newWord.note.language}
+                  multiline
+                  onChange={(e) => updateNoteText(e.target.value)}
+                  value={newWord.note.text}
                 />
-                <CardContent>
-                  <TextFieldWithFont
-                    analysis
-                    fullWidth
-                    id={EditDialogId.TextFieldNote}
-                    lang={newWord.note.language}
-                    multiline
-                    onChange={(e) => updateNoteText(e.target.value)}
-                    value={newWord.note.text}
-                  />
-                </CardContent>
-              </Card>
-            </Grid>
+              </CardContent>
+            </Card>
 
             {/* Flag */}
-            <Grid item>
-              <Card sx={bgStyle(EditField.Flag)}>
-                <CardHeader title={t("reviewEntries.columns.flag")} />
-                <CardContent>
-                  <IconButton onClick={toggleFlag}>
-                    {newWord.flag.active ? (
-                      <FlagFilled sx={{ color: themeColors.error }} />
-                    ) : (
-                      <FlagOutlined />
-                    )}
-                  </IconButton>
-                  <NormalizedTextField
-                    id={EditDialogId.TextFieldFlag}
-                    onChange={(e) => updateFlag(e.target.value)}
-                    value={newWord.flag.active ? newWord.flag.text : ""}
-                  />
-                </CardContent>
-              </Card>
-            </Grid>
-          </Grid>
+            <Card sx={bgStyle(EditField.Flag)}>
+              <CardHeader title={t("reviewEntries.columns.flag")} />
+              <CardContent>
+                <IconButton onClick={toggleFlag}>
+                  {newWord.flag.active ? (
+                    <FlagFilled sx={{ color: themeColors.error }} />
+                  ) : (
+                    <FlagOutlined />
+                  )}
+                </IconButton>
+                <NormalizedTextField
+                  id={EditDialogId.TextFieldFlag}
+                  onChange={(e) => updateFlag(e.target.value)}
+                  value={newWord.flag.active ? newWord.flag.text : ""}
+                />
+              </CardContent>
+            </Card>
+          </Stack>
         </DialogContent>
       </Dialog>
     </>

--- a/src/goals/ReviewEntries/ReviewEntriesTable/Cells/EditCell/EditSenseDialog.tsx
+++ b/src/goals/ReviewEntries/ReviewEntriesTable/Cells/EditCell/EditSenseDialog.tsx
@@ -7,8 +7,9 @@ import {
   Dialog,
   DialogContent,
   DialogTitle,
-  Grid,
+  Grid2,
   IconButton,
+  Stack,
   Typography,
 } from "@mui/material";
 import { grey, yellow } from "@mui/material/colors";
@@ -184,106 +185,96 @@ export default function EditSenseDialog(
       />
       <Dialog fullWidth maxWidth="sm" open={props.isOpen}>
         <DialogTitle>
-          <Grid container justifyContent="space-between">
-            <Grid item>{t("reviewEntries.editSense")}</Grid>
-            <Grid item>
+          <Grid2 container justifyContent="space-between">
+            {t("reviewEntries.editSense")}
+
+            <div>
               <IconButton
                 id={EditSenseDialogId.ButtonSave}
                 onClick={saveAndClose}
               >
                 <Check sx={{ color: (t) => t.palette.success.main }} />
               </IconButton>
+
               <IconButton
                 id={EditSenseDialogId.ButtonCancel}
                 onClick={conditionalCancel}
               >
                 <Close sx={{ color: (t) => t.palette.error.main }} />
               </IconButton>
-            </Grid>
-          </Grid>
+            </div>
+          </Grid2>
         </DialogTitle>
+
         <DialogContent>
-          <Grid
-            container
-            direction="column"
-            justifyContent="flex-start"
-            spacing={3}
-          >
+          <Stack spacing={3}>
             {/* Definitions */}
             {definitionsEnabled && (
-              <Grid item>
-                <Card sx={bgStyle(EditSenseField.Definitions)}>
-                  <CardHeader title={t("reviewEntries.columns.definitions")} />
-                  <CardContent>
-                    <DefinitionList
-                      defaultLang={analysisWritingSystems[0]}
-                      definitions={newSense.definitions}
-                      error={noDefinitionOrGloss}
-                      onChange={updateDefinitions}
-                      textFieldIdPrefix={
-                        EditSenseDialogId.TextFieldDefinitionPrefix
-                      }
-                    />
-                  </CardContent>
-                </Card>
-              </Grid>
+              <Card sx={bgStyle(EditSenseField.Definitions)}>
+                <CardHeader title={t("reviewEntries.columns.definitions")} />
+                <CardContent>
+                  <DefinitionList
+                    defaultLang={analysisWritingSystems[0]}
+                    definitions={newSense.definitions}
+                    error={noDefinitionOrGloss}
+                    onChange={updateDefinitions}
+                    textFieldIdPrefix={
+                      EditSenseDialogId.TextFieldDefinitionPrefix
+                    }
+                  />
+                </CardContent>
+              </Card>
             )}
 
             {/* Glosses */}
-            <Grid item>
-              <Card sx={bgStyle(EditSenseField.Glosses)}>
-                <CardHeader title={t("reviewEntries.columns.glosses")} />
-                <CardContent>
-                  <GlossList
-                    defaultLang={analysisWritingSystems[0]}
-                    error={noDefinitionOrGloss}
-                    glosses={newSense.glosses}
-                    onChange={updateGlosses}
-                    textFieldIdPrefix={EditSenseDialogId.TextFieldGlossPrefix}
-                  />
-                </CardContent>
-              </Card>
-            </Grid>
+            <Card sx={bgStyle(EditSenseField.Glosses)}>
+              <CardHeader title={t("reviewEntries.columns.glosses")} />
+              <CardContent>
+                <GlossList
+                  defaultLang={analysisWritingSystems[0]}
+                  error={noDefinitionOrGloss}
+                  glosses={newSense.glosses}
+                  onChange={updateGlosses}
+                  textFieldIdPrefix={EditSenseDialogId.TextFieldGlossPrefix}
+                />
+              </CardContent>
+            </Card>
 
             {/* Part of Speech */}
             {grammaticalInfoEnabled && (
-              <Grid item>
-                <Card sx={bgStyle(EditSenseField.GrammaticalInfo)}>
-                  <CardHeader title={t("reviewEntries.columns.partOfSpeech")} />
-                  <CardContent>
-                    {newSense.grammaticalInfo.catGroup ===
-                    GramCatGroup.Unspecified ? (
-                      <Typography>
-                        {t("grammaticalCategory.group.Unspecified")}
-                      </Typography>
-                    ) : (
-                      <PartOfSpeechButton
-                        buttonId={EditSenseDialogId.ButtonPartOfSpeech}
-                        gramInfo={newSense.grammaticalInfo}
-                      />
-                    )}
-                  </CardContent>
-                </Card>
-              </Grid>
+              <Card sx={bgStyle(EditSenseField.GrammaticalInfo)}>
+                <CardHeader title={t("reviewEntries.columns.partOfSpeech")} />
+                <CardContent>
+                  {newSense.grammaticalInfo.catGroup ===
+                  GramCatGroup.Unspecified ? (
+                    <Typography>
+                      {t("grammaticalCategory.group.Unspecified")}
+                    </Typography>
+                  ) : (
+                    <PartOfSpeechButton
+                      buttonId={EditSenseDialogId.ButtonPartOfSpeech}
+                      gramInfo={newSense.grammaticalInfo}
+                    />
+                  )}
+                </CardContent>
+              </Card>
             )}
 
             {/* Semantic Domains */}
-            <Grid item>
-              <Card sx={bgStyle(EditSenseField.SemanticDomains)}>
-                <CardHeader title={t("reviewEntries.columns.domains")} />
-                <CardContent>
-                  <DomainList
-                    buttonIdAdd={EditSenseDialogId.ButtonSemDomAdd}
-                    buttonIdPrefixDelete={
-                      EditSenseDialogId.ButtonSemDomDeletePrefix
-                    }
-                    domains={newSense.semanticDomains}
-                    onChange={updateDomains}
-                  />
-                </CardContent>
-              </Card>
-            </Grid>
-          </Grid>
+            <Card sx={bgStyle(EditSenseField.SemanticDomains)}>
+              <CardHeader title={t("reviewEntries.columns.domains")} />
+              <CardContent>
+                <DomainList
+                  buttonIdAdd={EditSenseDialogId.ButtonSemDomAdd}
+                  buttonIdPrefixDelete={
+                    EditSenseDialogId.ButtonSemDomDeletePrefix
+                  }
+                  domains={newSense.semanticDomains}
+                  onChange={updateDomains}
+                />
+              </CardContent>
+            </Card>
+          </Stack>
         </DialogContent>
       </Dialog>
     </>
@@ -450,21 +441,20 @@ function DomainList(props: DomainListProps): ReactElement {
 
   return (
     <>
-      <Grid container direction="row" spacing={2}>
+      <Grid2 alignItems="center" container spacing={2}>
         {props.domains.length > 0 ? (
           props.domains.map((domain, index) => (
-            <Grid item key={`${domain.id}_${domain.name}`}>
-              <Chip
-                id={`${props.buttonIdPrefixDelete}${index}`}
-                label={`${domain.id}: ${domain.name}`}
-                onDelete={() => deleteDomain(domain.id)}
-              />
-            </Grid>
+            <Chip
+              id={`${props.buttonIdPrefixDelete}${index}`}
+              key={`${domain.id}_${domain.name}`}
+              label={`${domain.id}: ${domain.name}`}
+              onDelete={() => deleteDomain(domain.id)}
+            />
           ))
         ) : (
-          <Grid item xs>
+          <Grid2 size="grow">
             <Chip color="secondary" label={t("reviewEntries.noDomain")} />
-          </Grid>
+          </Grid2>
         )}
         <IconButton
           id={props.buttonIdAdd}
@@ -472,11 +462,11 @@ function DomainList(props: DomainListProps): ReactElement {
             e.currentTarget.blur(); // else dialog reopens when domain selected with Enter
             setAddingDom(true);
           }}
-          size="large"
         >
           <Add />
         </IconButton>
-      </Grid>
+      </Grid2>
+
       <Dialog fullScreen open={addingDom}>
         <TreeView
           exit={() => setAddingDom(false)}

--- a/src/goals/ReviewEntries/ReviewEntriesTable/Cells/EditCell/EditSensesCardContent.tsx
+++ b/src/goals/ReviewEntries/ReviewEntriesTable/Cells/EditCell/EditSensesCardContent.tsx
@@ -8,7 +8,7 @@ import {
 } from "@mui/icons-material";
 import { CardContent, Divider, Grid2, Icon, Stack } from "@mui/material";
 import { grey, yellow } from "@mui/material/colors";
-import { type ReactElement, useEffect, useState } from "react";
+import { Fragment, type ReactElement, useEffect, useState } from "react";
 
 import { type Sense, Status } from "api/models";
 import { IconButtonWithTooltip } from "components/Buttons";
@@ -52,31 +52,27 @@ export default function EditSensesCardContent(
     );
   }, [props.newSenses, props.oldSenses]);
 
-  const sensesAndDividers: ReactElement[] = [];
-  props.newSenses.forEach((s, i) => {
-    sensesAndDividers.push(
-      <EditSense
-        bumpSenseDown={
-          i < props.newSenses.length - 1
-            ? () => props.moveSense(i, i + 1)
-            : undefined
-        }
-        bumpSenseUp={i ? () => props.moveSense(i, i - 1) : undefined}
-        edited={changes[i]}
-        key={s.guid}
-        sense={s}
-        toggleSenseDeleted={() => props.toggleSenseDeleted(i)}
-        updateSense={props.updateOrAddSense}
-      />
-    );
-    sensesAndDividers.push(<Divider key={i} />);
-  });
-
   return (
     <CardContent>
       {props.showSenses ? (
         <Stack spacing={1}>
-          {sensesAndDividers}
+          {props.newSenses.map((s, i) => (
+            <Fragment key={s.guid}>
+              <EditSense
+                bumpSenseDown={
+                  i < props.newSenses.length - 1
+                    ? () => props.moveSense(i, i + 1)
+                    : undefined
+                }
+                bumpSenseUp={i ? () => props.moveSense(i, i - 1) : undefined}
+                edited={changes[i]}
+                sense={s}
+                toggleSenseDeleted={() => props.toggleSenseDeleted(i)}
+                updateSense={props.updateOrAddSense}
+              />
+              <Divider />
+            </Fragment>
+          ))}
 
           <IconButtonWithTooltip
             buttonId={EditSensesId.ButtonSenseAdd}

--- a/src/goals/ReviewEntries/ReviewEntriesTable/Cells/EditCell/EditSensesCardContent.tsx
+++ b/src/goals/ReviewEntries/ReviewEntriesTable/Cells/EditCell/EditSensesCardContent.tsx
@@ -6,7 +6,7 @@ import {
   Edit,
   RestoreFromTrash,
 } from "@mui/icons-material";
-import { CardContent, Divider, Grid, Icon } from "@mui/material";
+import { CardContent, Divider, Grid2, Icon, Stack } from "@mui/material";
 import { grey, yellow } from "@mui/material/colors";
 import { type ReactElement, useEffect, useState } from "react";
 
@@ -52,38 +52,46 @@ export default function EditSensesCardContent(
     );
   }, [props.newSenses, props.oldSenses]);
 
+  const sensesAndDividers: ReactElement[] = [];
+  props.newSenses.forEach((s, i) => {
+    sensesAndDividers.push(
+      <EditSense
+        bumpSenseDown={
+          i < props.newSenses.length - 1
+            ? () => props.moveSense(i, i + 1)
+            : undefined
+        }
+        bumpSenseUp={i ? () => props.moveSense(i, i - 1) : undefined}
+        edited={changes[i]}
+        key={s.guid}
+        sense={s}
+        toggleSenseDeleted={() => props.toggleSenseDeleted(i)}
+        updateSense={props.updateOrAddSense}
+      />
+    );
+    sensesAndDividers.push(<Divider key={i} />);
+  });
+
   return (
     <CardContent>
       {props.showSenses ? (
-        <>
-          {props.newSenses.map((s, i) => (
-            <EditSense
-              bumpSenseDown={
-                i < props.newSenses.length - 1
-                  ? () => props.moveSense(i, i + 1)
-                  : undefined
-              }
-              bumpSenseUp={i ? () => props.moveSense(i, i - 1) : undefined}
-              edited={changes[i]}
-              key={s.guid}
-              sense={s}
-              toggleSenseDeleted={() => props.toggleSenseDeleted(i)}
-              updateSense={props.updateOrAddSense}
-            />
-          ))}
+        <Stack spacing={1}>
+          {sensesAndDividers}
+
           <IconButtonWithTooltip
             buttonId={EditSensesId.ButtonSenseAdd}
             icon={<Add />}
             onClick={() => setAddSense(true)}
             size="small"
           />
+
           <EditSenseDialog
             close={() => setAddSense(false)}
             isOpen={addSense}
             save={props.updateOrAddSense}
             sense={newSense()}
           />
-        </>
+        </Stack>
       ) : (
         <SummarySenseCard
           backgroundColor={
@@ -113,88 +121,74 @@ export function EditSense(props: EditSenseProps): ReactElement {
   const [editing, setEditing] = useState(false);
 
   return (
-    <>
-      <Grid container>
-        {props.bumpSenseDown || props.bumpSenseUp ? (
-          <Grid item>
-            <Grid container direction="column">
-              <Grid item>
-                <IconButtonWithTooltip
-                  buttonId={`${EditSensesId.ButtonSenseBumpUpPrefix}${sense.guid}`}
-                  icon={props.bumpSenseUp ? <ArrowUpward /> : <Icon />}
-                  onClick={props.bumpSenseUp}
-                  size="small"
-                />
-              </Grid>
-              <Grid item>
-                <IconButtonWithTooltip
-                  buttonId={`${EditSensesId.ButtonSenseBumpDownPrefix}${sense.guid}`}
-                  icon={props.bumpSenseDown ? <ArrowDownward /> : <Icon />}
-                  onClick={props.bumpSenseDown}
-                  size="small"
-                />
-              </Grid>
-            </Grid>
-          </Grid>
-        ) : null}
-        <Grid item>
-          <Grid container direction="column">
-            {deleted ? (
-              <Grid item>
-                <IconButtonWithTooltip
-                  buttonId={`${EditSensesId.ButtonSenseRestorePrefix}${sense.guid}`}
-                  icon={<RestoreFromTrash />}
-                  onClick={props.toggleSenseDeleted}
-                  size="small"
-                />
-              </Grid>
-            ) : (
-              <>
-                <Grid item>
-                  <IconButtonWithTooltip
-                    buttonId={`${EditSensesId.ButtonSenseDeletePrefix}${sense.guid}`}
-                    icon={<Delete />}
-                    onClick={
-                      sense.accessibility === Status.Protected
-                        ? undefined
-                        : props.toggleSenseDeleted
-                    }
-                    size="small"
-                    textId={
-                      sense.accessibility === Status.Protected
-                        ? "reviewEntries.deleteDisabled"
-                        : undefined
-                    }
-                  />
-                </Grid>
-                <Grid item>
-                  <IconButtonWithTooltip
-                    buttonId={`${EditSensesId.ButtonSenseEditPrefix}${sense.guid}`}
-                    icon={<Edit />}
-                    onClick={() => setEditing(true)}
-                    size="small"
-                  />
-                </Grid>
-              </>
-            )}
-          </Grid>
-        </Grid>
-        <Grid item sx={{ maxWidth: `calc(100% - 80px)` }}>
-          <SenseCard
-            bgColor={
-              deleted ? grey[500] : props.edited ? yellow[100] : undefined
-            }
-            sense={sense}
+    <Grid2 container>
+      {props.bumpSenseDown || props.bumpSenseUp ? (
+        <Stack>
+          <IconButtonWithTooltip
+            buttonId={`${EditSensesId.ButtonSenseBumpUpPrefix}${sense.guid}`}
+            icon={props.bumpSenseUp ? <ArrowUpward /> : <Icon />}
+            onClick={props.bumpSenseUp}
+            size="small"
           />
-        </Grid>
-        <EditSenseDialog
-          close={() => setEditing(false)}
-          isOpen={editing}
-          save={props.updateSense}
+
+          <IconButtonWithTooltip
+            buttonId={`${EditSensesId.ButtonSenseBumpDownPrefix}${sense.guid}`}
+            icon={props.bumpSenseDown ? <ArrowDownward /> : <Icon />}
+            onClick={props.bumpSenseDown}
+            size="small"
+          />
+        </Stack>
+      ) : null}
+
+      <Stack>
+        {deleted ? (
+          <IconButtonWithTooltip
+            buttonId={`${EditSensesId.ButtonSenseRestorePrefix}${sense.guid}`}
+            icon={<RestoreFromTrash />}
+            onClick={props.toggleSenseDeleted}
+            size="small"
+          />
+        ) : (
+          <>
+            <IconButtonWithTooltip
+              buttonId={`${EditSensesId.ButtonSenseDeletePrefix}${sense.guid}`}
+              icon={<Delete />}
+              onClick={
+                sense.accessibility === Status.Protected
+                  ? undefined
+                  : props.toggleSenseDeleted
+              }
+              size="small"
+              textId={
+                sense.accessibility === Status.Protected
+                  ? "reviewEntries.deleteDisabled"
+                  : undefined
+              }
+            />
+
+            <IconButtonWithTooltip
+              buttonId={`${EditSensesId.ButtonSenseEditPrefix}${sense.guid}`}
+              icon={<Edit />}
+              onClick={() => setEditing(true)}
+              size="small"
+            />
+          </>
+        )}
+      </Stack>
+
+      <div style={{ maxWidth: `calc(100% - 80px)` }}>
+        <SenseCard
+          bgColor={deleted ? grey[500] : props.edited ? yellow[100] : undefined}
           sense={sense}
         />
-      </Grid>
-      <Divider sx={{ mb: 1 }} />
-    </>
+      </div>
+
+      <EditSenseDialog
+        close={() => setEditing(false)}
+        isOpen={editing}
+        save={props.updateSense}
+        sense={sense}
+      />
+    </Grid2>
   );
 }

--- a/src/goals/ReviewEntries/ReviewEntriesTable/Cells/PartOfSpeechCell.tsx
+++ b/src/goals/ReviewEntries/ReviewEntriesTable/Cells/PartOfSpeechCell.tsx
@@ -1,4 +1,4 @@
-import { Grid } from "@mui/material";
+import { Grid2 } from "@mui/material";
 import { type ReactElement } from "react";
 
 import { type GrammaticalInfo, type Sense } from "api/models";
@@ -18,12 +18,13 @@ function gatherGramInfo(senses: Sense[]): GrammaticalInfo[] {
 
 export default function PartOfSpeechCell(props: CellProps): ReactElement {
   return (
-    <Grid container direction="row" spacing={2}>
+    <Grid2 container spacing={2}>
       {gatherGramInfo(props.word.senses).map((gi) => (
-        <Grid item key={`${gi.catGroup}-${gi.grammaticalCategory}`}>
-          <PartOfSpeechButton gramInfo={gi} />
-        </Grid>
+        <PartOfSpeechButton
+          gramInfo={gi}
+          key={`${gi.catGroup}-${gi.grammaticalCategory}`}
+        />
       ))}
-    </Grid>
+    </Grid2>
   );
 }


### PR DESCRIPTION
Part of #3787

Notes for review:

- In most places, replaced `<Grid>` with `<Grid2>`, `<Stack>`, `<Box>`, `<div>`, or nothing, as fit the design need.
- `<Stack direction="row">` can be used in place of `<Grid2>` when we don't want the items in the row to wrap to a second row in a narrow window
- Moved Save and Cancel buttons from bottom of `CharInv` into child component `CharacterEntry` at top
- Do a side-by-side visual comparison between this and `master` (on QA) to make sure appearance is (roughly) the same or (subjectively) improved on all edited components
- Try each edited component with various window widths > 350px (we don't support narrower than that)
- Test `*Completed` components by clicking a completed goal tile in Data Cleanup under "You've completed:"
  - For `MergeDupsCompleted`, first go to Data Cleanup > Merge Duplicates, and merge and/or delete words in various combinations
  - For `WordCard` and `ReviewEntriesCompleted`, first go to Data Cleanup > Review Entries and edit several entries, including adding multiple semantic domains to a sense
- Test with a few different UI languages

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3879)
<!-- Reviewable:end -->
