### PR TITLE
Clean up login/token/user-related things

### DIFF
--- a/Backend.Tests/Controllers/InviteControllerTests.cs
+++ b/Backend.Tests/Controllers/InviteControllerTests.cs
@@ -86,9 +86,9 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public void TestValidateTokenNoTokenNoUser()
+        public void TestValidateInviteTokenNoTokenNoUser()
         {
-            var result = _inviteController.ValidateToken(_projId, "not-a-token").Result;
+            var result = _inviteController.ValidateInviteToken(_projId, "not-a-token").Result;
             Assert.That(result, Is.InstanceOf<OkObjectResult>());
             var value = ((OkObjectResult)result).Value;
             Assert.That(value, Is.InstanceOf<EmailInviteStatus>());
@@ -99,9 +99,9 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public void TestValidateTokenExpiredTokenNoUser()
+        public void TestValidateInviteTokenExpiredTokenNoUser()
         {
-            var result = _inviteController.ValidateToken(_projId, _tokenExpired).Result;
+            var result = _inviteController.ValidateInviteToken(_projId, _tokenExpired).Result;
             Assert.That(result, Is.InstanceOf<OkObjectResult>());
             var value = ((OkObjectResult)result).Value;
             Assert.That(value, Is.InstanceOf<EmailInviteStatus>());
@@ -112,9 +112,9 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public void TestValidateTokenFutureTokenNoUser()
+        public void TestValidateInviteTokenFutureTokenNoUser()
         {
-            var result = _inviteController.ValidateToken(_projId, _tokenFuture).Result;
+            var result = _inviteController.ValidateInviteToken(_projId, _tokenFuture).Result;
             Assert.That(result, Is.InstanceOf<OkObjectResult>());
             var value = ((OkObjectResult)result).Value;
             Assert.That(value, Is.InstanceOf<EmailInviteStatus>());
@@ -125,9 +125,9 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public void TestValidateTokenValidTokenNoUser()
+        public void TestValidateInviteTokenValidTokenNoUser()
         {
-            var result = _inviteController.ValidateToken(_projId, _tokenActive).Result;
+            var result = _inviteController.ValidateInviteToken(_projId, _tokenActive).Result;
             Assert.That(result, Is.InstanceOf<OkObjectResult>());
             var value = ((OkObjectResult)result).Value;
             Assert.That(value, Is.InstanceOf<EmailInviteStatus>());
@@ -138,12 +138,12 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public void TestValidateTokenValidTokenUserAlreadyInProject()
+        public void TestValidateInviteTokenValidTokenUserAlreadyInProject()
         {
             var roles = new Dictionary<string, string> { [_projId] = "role-id" };
             _userRepo.Create(new() { Email = EmailActive, ProjectRoles = roles });
 
-            var result = _inviteController.ValidateToken(_projId, _tokenActive).Result;
+            var result = _inviteController.ValidateInviteToken(_projId, _tokenActive).Result;
             Assert.That(result, Is.InstanceOf<OkObjectResult>());
             var value = ((OkObjectResult)result).Value;
             Assert.That(value, Is.InstanceOf<EmailInviteStatus>());
@@ -154,13 +154,13 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public void TestValidateTokenExpiredTokenUserAvailable()
+        public void TestValidateInviteTokenExpiredTokenUserAvailable()
         {
             _userRepo.Create(new() { Id = "other-user" });
             // User with an email address matching an invite with an expired token.
             _userRepo.Create(new() { Id = "invitee", Email = EmailExpired });
 
-            var result = _inviteController.ValidateToken(_projId, _tokenExpired).Result;
+            var result = _inviteController.ValidateInviteToken(_projId, _tokenExpired).Result;
             Assert.That(result, Is.InstanceOf<OkObjectResult>());
             var value = ((OkObjectResult)result).Value;
             Assert.That(value, Is.InstanceOf<EmailInviteStatus>());
@@ -171,7 +171,7 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public void TestValidateTokenValidTokenUserAvailable()
+        public void TestValidateInviteTokenValidTokenUserAvailable()
         {
             // User with an email address matching an invite with an active token.
             _userRepo.Create(new() { Email = EmailActive });
@@ -179,7 +179,7 @@ namespace Backend.Tests.Controllers
             // No permissions should be required to validate a token.
             _inviteController.ControllerContext.HttpContext = PermissionServiceMock.UnauthorizedHttpContext();
 
-            var result = _inviteController.ValidateToken(_projId, _tokenActive).Result;
+            var result = _inviteController.ValidateInviteToken(_projId, _tokenActive).Result;
             Assert.That(result, Is.InstanceOf<OkObjectResult>());
             var value = ((OkObjectResult)result).Value;
             Assert.That(value, Is.InstanceOf<EmailInviteStatus>());

--- a/Backend.Tests/Controllers/PasswordResetControllerTests.cs
+++ b/Backend.Tests/Controllers/PasswordResetControllerTests.cs
@@ -48,7 +48,8 @@ namespace Backend.Tests.Controllers
 
             _passwordResetService.SetNextBoolResponse(false);
             var falseResult = _passwordResetController.ResetPasswordRequest("username").Result;
-            Assert.That(((StatusCodeResult)falseResult).StatusCode, Is.EqualTo(StatusCodes.Status500InternalServerError));
+            Assert.That(((StatusCodeResult)falseResult).StatusCode,
+                Is.EqualTo(StatusCodes.Status500InternalServerError));
 
             _passwordResetService.SetNextBoolResponse(true);
             var trueResult = _passwordResetController.ResetPasswordRequest("username").Result;

--- a/Backend.Tests/Controllers/UserControllerTests.cs
+++ b/Backend.Tests/Controllers/UserControllerTests.cs
@@ -107,7 +107,7 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public void TestGetMissingUser()
+        public void TestGetUserMissingUser()
         {
             var result = _userController.GetUser("INVALID_USER_ID").Result;
             Assert.That(result, Is.InstanceOf<NotFoundResult>());

--- a/Backend.Tests/Mocks/PasswordResetRepositoryMock.cs
+++ b/Backend.Tests/Mocks/PasswordResetRepositoryMock.cs
@@ -21,7 +21,7 @@ namespace Backend.Tests.Mocks
             return Task.FromResult(_resets.FindAll(x => x.Token == token).SingleOrDefault());
         }
 
-        public List<EmailToken> GetResets()
+        internal List<EmailToken> GetResets()
         {
             return _resets;
         }

--- a/Backend.Tests/Mocks/PasswordResetServiceMock.cs
+++ b/Backend.Tests/Mocks/PasswordResetServiceMock.cs
@@ -15,7 +15,7 @@ namespace Backend.Tests.Mocks
             return Task.FromResult(_boolResponse);
         }
 
-        public Task<bool> ResetPasswordRequest(string EmailOrUsername)
+        public Task<bool> ResetPasswordRequest(string emailOrUsername)
         {
             return Task.FromResult(_boolResponse);
         }

--- a/Backend.Tests/Services/PasswordResetServiceTests.cs
+++ b/Backend.Tests/Services/PasswordResetServiceTests.cs
@@ -16,7 +16,7 @@ namespace Backend.Tests.Services
         private PasswordResetService _passwordResetService = null!;
         private const string Email = "user@domain.com";
         private const string Password = "PasswordResetServiceTestPassword";
-        private readonly TimeSpan _expireTime = TimeSpan.FromMinutes(15);
+        private readonly TimeSpan _expireTime = TimeSpan.FromMinutes(60);
 
         [SetUp]
         public void Setup()

--- a/Backend.Tests/Services/PasswordResetServiceTests.cs
+++ b/Backend.Tests/Services/PasswordResetServiceTests.cs
@@ -16,7 +16,7 @@ namespace Backend.Tests.Services
         private PasswordResetService _passwordResetService = null!;
         private const string Email = "user@domain.com";
         private const string Password = "PasswordResetServiceTestPassword";
-        private readonly TimeSpan _expireTime = TimeSpan.FromDays(7);
+        private readonly TimeSpan _expireTime = TimeSpan.FromMinutes(15);
 
         [SetUp]
         public void Setup()

--- a/Backend/Controllers/InviteController.cs
+++ b/Backend/Controllers/InviteController.cs
@@ -48,9 +48,9 @@ namespace BackendFramework.Controllers
 
         /// <summary> Validates invite token in url and adds user to project </summary>
         [AllowAnonymous]
-        [HttpPut("{projectId}/validate/{token}", Name = "ValidateToken")]
+        [HttpPut("{projectId}/validate/{token}", Name = "ValidateInviteToken")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(EmailInviteStatus))]
-        public async Task<IActionResult> ValidateToken(string projectId, string token)
+        public async Task<IActionResult> ValidateInviteToken(string projectId, string token)
         {
             return Ok(await _inviteService.ValidateProjectToken(projectId, token));
         }

--- a/Backend/Controllers/PasswordResetController.cs
+++ b/Backend/Controllers/PasswordResetController.cs
@@ -31,9 +31,9 @@ namespace BackendFramework.Controllers
         [HttpPost("", Name = "ResetPasswordRequest")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public async Task<IActionResult> ResetPasswordRequest([FromBody, BindRequired] string EmailOrUsername)
+        public async Task<IActionResult> ResetPasswordRequest([FromBody, BindRequired] string emailOrUsername)
         {
-            var result = await _passwordResetService.ResetPasswordRequest(EmailOrUsername);
+            var result = await _passwordResetService.ResetPasswordRequest(emailOrUsername);
             return result ? Ok() : StatusCode(StatusCodes.Status500InternalServerError);
         }
 

--- a/Backend/Interfaces/IPasswordResetService.cs
+++ b/Backend/Interfaces/IPasswordResetService.cs
@@ -5,7 +5,7 @@ namespace BackendFramework.Interfaces
     public interface IPasswordResetService
     {
         Task<bool> ResetPassword(string token, string password);
-        Task<bool> ResetPasswordRequest(string EmailOrUsername);
+        Task<bool> ResetPasswordRequest(string emailOrUsername);
         Task<bool> ValidateToken(string token);
     }
 }

--- a/Backend/Services/InviteService.cs
+++ b/Backend/Services/InviteService.cs
@@ -8,7 +8,6 @@ using static BackendFramework.Helper.Domain;
 
 namespace BackendFramework.Services
 {
-    /// <summary> More complex functions and application logic for <see cref="Project"/>s </summary>
     public class InviteService(IOptions<Startup.Settings> options, IInviteRepository inviteRepo,
         IUserRepository userRepo, IUserRoleRepository userRoleRepo, IEmailService emailService,
         IPermissionService permissionService) : IInviteService

--- a/Backend/Startup.cs
+++ b/Backend/Startup.cs
@@ -32,7 +32,7 @@ namespace BackendFramework
 
         public class Settings
         {
-            public const int DefaultExpirePasswordResetMinutes = 15;
+            public const int DefaultExpirePasswordResetMinutes = 60;
             public const int DefaultExpireProjectInviteDays = 7;
 
             public bool CaptchaEnabled { get; set; } = true;

--- a/deploy/helm/thecombine/charts/backend/values.yaml
+++ b/deploy/helm/thecombine/charts/backend/values.yaml
@@ -35,7 +35,7 @@ global:
   includeResourceLimits: false
 
 persistentVolumeSize: 32Gi
-combineExpirePasswordResetMinutes: 15
+combineExpirePasswordResetMinutes: 60
 combineExpireProjectInviteDays: 7
 combineSmtpAddress: no-reply@thecombine.app
 combineSmtpFrom: "The Combine"

--- a/src/api/api/invite-api.ts
+++ b/src/api/api/invite-api.ts
@@ -108,15 +108,15 @@ export const InviteApiAxiosParamCreator = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    validateToken: async (
+    validateInviteToken: async (
       projectId: string,
       token: string,
       options: any = {}
     ): Promise<RequestArgs> => {
       // verify required parameter 'projectId' is not null or undefined
-      assertParamExists("validateToken", "projectId", projectId);
+      assertParamExists("validateInviteToken", "projectId", projectId);
       // verify required parameter 'token' is not null or undefined
-      assertParamExists("validateToken", "token", token);
+      assertParamExists("validateInviteToken", "token", token);
       const localVarPath = `/v1/invite/{projectId}/validate/{token}`
         .replace(`{${"projectId"}}`, encodeURIComponent(String(projectId)))
         .replace(`{${"token"}}`, encodeURIComponent(String(token)));
@@ -190,7 +190,7 @@ export const InviteApiFp = function (configuration?: Configuration) {
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    async validateToken(
+    async validateInviteToken(
       projectId: string,
       token: string,
       options?: any
@@ -200,11 +200,12 @@ export const InviteApiFp = function (configuration?: Configuration) {
         basePath?: string
       ) => AxiosPromise<EmailInviteStatus>
     > {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.validateToken(
-        projectId,
-        token,
-        options
-      );
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.validateInviteToken(
+          projectId,
+          token,
+          options
+        );
       return createRequestFunction(
         localVarAxiosArgs,
         globalAxios,
@@ -247,13 +248,13 @@ export const InviteApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    validateToken(
+    validateInviteToken(
       projectId: string,
       token: string,
       options?: any
     ): AxiosPromise<EmailInviteStatus> {
       return localVarFp
-        .validateToken(projectId, token, options)
+        .validateInviteToken(projectId, token, options)
         .then((request) => request(axios, basePath));
     },
   };
@@ -274,22 +275,22 @@ export interface InviteApiEmailInviteToProjectRequest {
 }
 
 /**
- * Request parameters for validateToken operation in InviteApi.
+ * Request parameters for validateInviteToken operation in InviteApi.
  * @export
- * @interface InviteApiValidateTokenRequest
+ * @interface InviteApiValidateInviteTokenRequest
  */
-export interface InviteApiValidateTokenRequest {
+export interface InviteApiValidateInviteTokenRequest {
   /**
    *
    * @type {string}
-   * @memberof InviteApiValidateToken
+   * @memberof InviteApiValidateInviteToken
    */
   readonly projectId: string;
 
   /**
    *
    * @type {string}
-   * @memberof InviteApiValidateToken
+   * @memberof InviteApiValidateInviteToken
    */
   readonly token: string;
 }
@@ -319,17 +320,17 @@ export class InviteApi extends BaseAPI {
 
   /**
    *
-   * @param {InviteApiValidateTokenRequest} requestParameters Request parameters.
+   * @param {InviteApiValidateInviteTokenRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof InviteApi
    */
-  public validateToken(
-    requestParameters: InviteApiValidateTokenRequest,
+  public validateInviteToken(
+    requestParameters: InviteApiValidateInviteTokenRequest,
     options?: any
   ) {
     return InviteApiFp(this.configuration)
-      .validateToken(
+      .validateInviteToken(
         requestParameters.projectId,
         requestParameters.token,
         options

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -240,12 +240,13 @@ export async function emailInviteToProject(
   return resp.data;
 }
 
-export async function validateLink(
+export async function validateInviteToken(
   projectId: string,
   token: string
 ): Promise<EmailInviteStatus> {
-  return (await inviteApi.validateToken({ projectId, token }, defaultOptions()))
-    .data;
+  return (
+    await inviteApi.validateInviteToken({ projectId, token }, defaultOptions())
+  ).data;
 }
 
 /* LiftController.cs */

--- a/src/components/InvalidLink/index.tsx
+++ b/src/components/InvalidLink/index.tsx
@@ -5,6 +5,7 @@ import {
   CardContent,
   CardHeader,
   Grid2,
+  Stack,
   Typography,
 } from "@mui/material";
 import { ReactElement } from "react";
@@ -15,7 +16,8 @@ import { Path } from "types/path";
 import { openUserGuide } from "utilities/pathUtilities";
 
 export interface InvalidLinkProps {
-  textId: string;
+  bodyTextId?: string;
+  titleTextId: string;
 }
 
 export default function InvalidLink(props: InvalidLinkProps): ReactElement {
@@ -29,40 +31,46 @@ export default function InvalidLink(props: InvalidLinkProps): ReactElement {
         <CardHeader
           title={
             <Typography align="center" variant="h5">
-              {t(props.textId)}
+              {t(props.titleTextId)}
             </Typography>
           }
         />
 
         <CardContent>
-          {/* User Guide, Sign Up, and Log In buttons */}
-          <Grid2 container spacing={2}>
-            <Grid2 size="grow">
-              <Button id={`${idAffix}-guide`} onClick={() => openUserGuide()}>
-                <Help />
+          <Stack spacing={2}>
+            {props.bodyTextId ? (
+              <Typography>{t(props.bodyTextId)}</Typography>
+            ) : null}
+
+            {/* User Guide, Sign Up, and Log In buttons */}
+            <Grid2 container spacing={2}>
+              <Grid2 size="grow">
+                <Button id={`${idAffix}-guide`} onClick={() => openUserGuide()}>
+                  <Help />
+                </Button>
+              </Grid2>
+
+              <Button
+                id={`${idAffix}-signUp`}
+                onClick={() => {
+                  navigate(Path.Signup);
+                }}
+                variant="contained"
+              >
+                {t("login.signUp")}
+              </Button>
+
+              <Button
+                id={`${idAffix}-login`}
+                onClick={() => {
+                  navigate(Path.Login);
+                }}
+                variant="contained"
+              >
+                {t("login.login")}
               </Button>
             </Grid2>
-
-            <Button
-              id={`${idAffix}-signUp`}
-              onClick={() => {
-                navigate(Path.Signup);
-              }}
-              variant="contained"
-            >
-              {t("login.signUp")}
-            </Button>
-
-            <Button
-              id={`${idAffix}-login`}
-              onClick={() => {
-                navigate(Path.Login);
-              }}
-              variant="contained"
-            >
-              {t("login.login")}
-            </Button>
-          </Grid2>
+          </Stack>
         </CardContent>
       </Card>
     </Grid2>

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -33,7 +33,7 @@ import { Path } from "types/path";
 import { RuntimeConfig } from "types/runtimeConfig";
 import { NormalizedTextField } from "utilities/fontComponents";
 import { openUserGuide } from "utilities/pathUtilities";
-import { meetsPasswordRequirements } from "utilities/utilities";
+import { meetsPasswordRequirements } from "utilities/userUtilities";
 
 export enum LoginId {
   ButtonLogIn = "login-log-in-button",

--- a/src/components/Login/ProjectInvite.tsx
+++ b/src/components/Login/ProjectInvite.tsx
@@ -20,7 +20,7 @@ export default function ProjectInvite(): ReactElement {
       }
       setIsValidLink(status.isTokenValid);
     }
-  }, [project, token, navigate]);
+  }, [navigate, project, token]);
 
   useEffect(() => {
     validateLink();

--- a/src/components/Login/ProjectInvite.tsx
+++ b/src/components/Login/ProjectInvite.tsx
@@ -1,7 +1,7 @@
 import { ReactElement, useCallback, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 
-import * as backend from "backend";
+import { validateInviteToken } from "backend";
 import InvalidLink from "components/InvalidLink";
 import Signup from "components/Login/Signup";
 import { Path } from "types/path";
@@ -13,7 +13,7 @@ export default function ProjectInvite(): ReactElement {
 
   const validateLink = useCallback(async (): Promise<void> => {
     if (project && token) {
-      const status = await backend.validateLink(project, token);
+      const status = await validateInviteToken(project, token);
       if (status.isTokenValid && status.isUserValid) {
         navigate(Path.Login);
         return;
@@ -24,11 +24,11 @@ export default function ProjectInvite(): ReactElement {
 
   useEffect(() => {
     validateLink();
-  });
+  }, [validateLink]);
 
   return isValidLink ? (
-    <Signup returnToEmailInvite={validateLink} />
+    <Signup onSignup={() => validateInviteToken(project!, token!)} />
   ) : (
-    <InvalidLink textId="invite.invalidInvitationURL" />
+    <InvalidLink titleTextId="invite.invalidInvitationURL" />
   );
 }

--- a/src/components/Login/Signup.tsx
+++ b/src/components/Login/Signup.tsx
@@ -31,7 +31,8 @@ import { NormalizedTextField } from "utilities/fontComponents";
 import {
   meetsPasswordRequirements,
   meetsUsernameRequirements,
-} from "utilities/utilities";
+  normalizeEmail,
+} from "utilities/userUtilities";
 
 export enum SignupField {
   Email = "email",
@@ -86,13 +87,8 @@ export const signupFieldId: Record<SignupField, SignupId> = {
   [SignupField.Username]: SignupId.FieldUsername,
 };
 
-// Chrome silently converts non-ASCII characters in a Textfield of type="email".
-// Use punycode.toUnicode() to convert them from punycode back to Unicode.
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const punycode = require("punycode/");
-
 interface SignupProps {
-  returnToEmailInvite?: () => void;
+  onSignup?: () => void;
 }
 
 /** The Signup page (also used for ProjectInvite) */
@@ -151,9 +147,7 @@ export default function Signup(props: SignupProps): ReactElement {
     // Trim whitespace off fields.
     const name = fieldText[SignupField.Name].trim();
     const username = fieldText[SignupField.Username].trim();
-    const email = punycode
-      .toUnicode(fieldText[SignupField.Email].trim())
-      .normalize("NFC");
+    const email = normalizeEmail(fieldText[SignupField.Email]);
     const password1 = fieldText[SignupField.Password1].trim();
     const password2 = fieldText[SignupField.Password2].trim();
 
@@ -170,7 +164,7 @@ export default function Signup(props: SignupProps): ReactElement {
       setFieldError(err);
     } else {
       await dispatch(
-        asyncSignUp(name, username, email, password1, props.returnToEmailInvite)
+        asyncSignUp(name, username, email, password1, props.onSignup)
       );
     }
   };
@@ -227,7 +221,7 @@ export default function Signup(props: SignupProps): ReactElement {
               <TextField
                 {...defaultTextFieldProps(SignupField.Email)}
                 autoComplete="email"
-                type="email"
+                type="email" // silently converts input to punycode
               />
 
               {/* Password field */}

--- a/src/components/PasswordReset/ResetPage.tsx
+++ b/src/components/PasswordReset/ResetPage.tsx
@@ -16,7 +16,7 @@ import { resetPassword, validateResetToken } from "backend";
 import InvalidLink from "components/InvalidLink";
 import { Path } from "types/path";
 import { NormalizedTextField } from "utilities/fontComponents";
-import { meetsPasswordRequirements } from "utilities/utilities";
+import { meetsPasswordRequirements } from "utilities/userUtilities";
 
 export enum PasswordResetIds {
   Password = "PasswordReset.password",
@@ -127,6 +127,6 @@ export default function PasswordReset(): ReactElement {
       </Card>
     </Grid2>
   ) : (
-    <InvalidLink textId="passwordReset.invalidURL" />
+    <InvalidLink titleTextId="passwordReset.invalidURL" />
   );
 }

--- a/src/components/ProjectSettings/tests/index.test.tsx
+++ b/src/components/ProjectSettings/tests/index.test.tsx
@@ -9,7 +9,6 @@ import { Store } from "redux";
 import configureMockStore from "redux-mock-store";
 
 import { Permission } from "api/models";
-import { defaultState as exportProjectState } from "components/ProjectExport/Redux/ExportProjectReduxTypes";
 import ProjectSettings, {
   ProjectSettingsTab,
   Setting,
@@ -18,6 +17,7 @@ import {
   whichSettings,
   whichTabs,
 } from "components/ProjectSettings/tests/SettingsTabTypes";
+import { defaultState } from "rootRedux/types";
 import { randomProject } from "types/project";
 import theme from "types/theme";
 import { setMatchMedia } from "utilities/testingLibraryUtilities";
@@ -33,9 +33,7 @@ jest.mock("backend", () => ({
   getUserRoles: () => Promise.resolve([]),
   hasFrontierWords: () => Promise.resolve(false),
 }));
-jest.mock("components/Project/ProjectActions");
-// Mock "i18n", else `thrown: "Error: Error: connect ECONNREFUSED ::1:80 [...]`
-jest.mock("i18n", () => ({ language: "" }));
+jest.mock("i18n", () => ({ language: "" })); // else `thrown: "Error: AggregateError`
 jest.mock("rootRedux/hooks", () => {
   return {
     ...jest.requireActual("rootRedux/hooks"),
@@ -51,8 +49,8 @@ const createMockStore = (hasSchedule = false): Store => {
     project.workshopSchedule = [new Date().toString()];
   }
   return configureMockStore()({
-    currentProjectState: { project, users: [] },
-    exportProjectState,
+    ...defaultState,
+    currentProjectState: { ...defaultState.currentProjectState, project },
   });
 };
 

--- a/src/components/UserSettings/tests/UserSettings.test.tsx
+++ b/src/components/UserSettings/tests/UserSettings.test.tsx
@@ -16,11 +16,6 @@ const mockIsEmailOrUsernameAvailable = jest.fn();
 const mockSetUser = jest.fn();
 const mockUpdateUser = jest.fn();
 
-jest.mock("notistack", () => ({
-  ...jest.requireActual("notistack"),
-  enqueueSnackbar: jest.fn(),
-}));
-
 jest.mock("backend", () => ({
   getUserIdByEmailOrUsername: (emailOrUsername: string) =>
     mockGetUserIdByEmailOrUsername(emailOrUsername),

--- a/src/utilities/userUtilities.ts
+++ b/src/utilities/userUtilities.ts
@@ -1,0 +1,18 @@
+// Chrome silently converts non-ASCII characters in a Textfield of type="email".
+// Use punycode.toUnicode() to convert them from punycode back to Unicode.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const punycode = require("punycode/");
+
+export function meetsPasswordRequirements(password: string): boolean {
+  return password.length >= 8;
+}
+
+export function meetsUsernameRequirements(username: string): boolean {
+  return username.length >= 3;
+}
+
+/** Text field of type="email" silently converted its input from Unicode to punycode.
+This function trims whitespace, and converts to normalized Unicode. */
+export function normalizeEmail(email: string): string {
+  return punycode.toUnicode(email.trim()).normalize("NFC");
+}

--- a/src/utilities/userUtilities.ts
+++ b/src/utilities/userUtilities.ts
@@ -1,5 +1,3 @@
-// Chrome silently converts non-ASCII characters in a Textfield of type="email".
-// Use punycode.toUnicode() to convert them from punycode back to Unicode.
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const punycode = require("punycode/");
 

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -1,13 +1,5 @@
 import { colorblindSafePalette, HEX } from "types/theme";
 
-export function meetsPasswordRequirements(password: string): boolean {
-  return password.length >= 8;
-}
-
-export function meetsUsernameRequirements(username: string): boolean {
-  return username.length >= 3;
-}
-
 export function randElement<T>(arr: T[]): T {
   return arr[Math.floor(Math.random() * arr.length)];
 }


### PR DESCRIPTION
Sequel to #3920 

Prequel to #3877 

Changes:

- `InviteController`: method `ValidateToken` -> `ValidateInviteToken` (to avoid ambiguity in OpenAPI with other tokens)
- `PasswordResetService`:
  - param `EmailOrUsername` -> `emailOrUsername`
  - remove unnecessary method `ExpirePasswordReset`
  - email title "Combine ..." -> "The Combine ..."
- `InvalidLink` component: add prop for optional body text
- `ProjectInvite` component: remove extraneous executions of `validateLink`
- `SignUp` component: prop `returnToEmailInvite` -> `onSignup` (for more general use)
- `UserSettings` component: set `email` state from normalization of new `emailPunycode` state (to only normalize in one place)
- `userUtilities`:
  - created from two `utilities` functions and one `UserSettings` function
  - `enqueueSnackbar` -> `toast.success`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3938)
<!-- Reviewable:end -->
