### PR TITLE
Revert TextFieldWithFont changes incompatible with legacy Autocomplete

### DIFF
--- a/src/utilities/fontComponents.tsx
+++ b/src/utilities/fontComponents.tsx
@@ -58,20 +58,15 @@ export function TextFieldWithFont(props: TextFieldWithFontProps): ReactElement {
   const fontContext = useContext(FontContext);
   // Use spread to remove the custom props from what is passed into TextField.
   const { analysis, lang, vernacular, ...textFieldProps } = props;
-  const input = textFieldProps.slotProps?.input;
-  const inputProps = typeof input === "function" ? input({}) : input;
   return (
     <NormalizedTextField
       {...textFieldProps}
-      slotProps={{
-        ...textFieldProps.slotProps,
-        input: {
-          ...inputProps,
-          style: fontContext.addFontToStyle(
-            { analysis, lang, vernacular },
-            inputProps?.style
-          ),
-        },
+      InputProps={{
+        ...textFieldProps.InputProps,
+        style: fontContext.addFontToStyle(
+          { analysis, lang, vernacular },
+          textFieldProps.InputProps?.style
+        ),
       }}
     />
   );


### PR DESCRIPTION
The move away from deprecated `InputProps` (#3941) was to prepare for upgrading MUI v6 to v7. However, we are still using v6 and its `Autocomplete` component still depends on the legacy props handling. So updating `TextFieldWithFont` broke the Autocomplete styling and option-suggesting in both the `GlossWithSuggestions` and `VernWithSuggestions` components in Data Entry. This change can be reintroduced when we do upgrade to MUI v7.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/3957)
<!-- Reviewable:end -->
