### PR TITLE
[otel] Log UI language from the backend

### DIFF
--- a/Backend/Controllers/UserController.cs
+++ b/Backend/Controllers/UserController.cs
@@ -87,7 +87,24 @@ namespace BackendFramework.Controllers
             try
             {
                 var user = await _permissionService.Authenticate(cred.EmailOrUsername, cred.Password);
-                return user is null ? Unauthorized(cred.EmailOrUsername) : Ok(user);
+                if (user is null)
+                {
+                    return Unauthorized(cred.EmailOrUsername);
+                }
+
+                // Log UI language for analytics
+                var uiLang = user.UILang;
+                if (string.IsNullOrEmpty(uiLang))
+                {
+                    uiLang = Request.Headers.AcceptLanguage.ToString()
+                        .Split([',', '-', ';', '_']).FirstOrDefault()?.Trim()?.ToLowerInvariant();
+                }
+                if (!string.IsNullOrEmpty(uiLang))
+                {
+                    activity?.SetTag("ui_language", uiLang);
+                }
+
+                return Ok(user);
             }
             catch (KeyNotFoundException)
             {


### PR DESCRIPTION
Alternative to #4062

Triggered by login
Uses `Request.Headers.AcceptLanguage` to infer UI language when not explicitly set by the user...
Thus, can return languages that we don't actually have available, which can be mapped to English in analytics processing
Also, doesn't track when the user changes UI language until the next time they log in

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4063)
<!-- Reviewable:end -->
