### PR TITLE
Update column order of user statistics table

### DIFF
--- a/src/components/Statistics/UserStatistics.tsx
+++ b/src/components/Statistics/UserStatistics.tsx
@@ -41,15 +41,17 @@ export default function UserStatistics(): ReactElement {
         <TableHead>
           <TableRow>
             <HeadCell titleId={"statistics.column.username"} />
-            <HeadCell titleId={"statistics.column.recentDomain"} />
-            <HeadCell titleId={"statistics.column.domainCount"} />
             <HeadCell titleId={"statistics.column.senseCount"} />
+            <HeadCell titleId={"statistics.column.domainCount"} />
+            <HeadCell titleId={"statistics.column.recentDomain"} />
           </TableRow>
         </TableHead>
         <TableBody>
           {domainUserCountList.map((t) => (
             <TableRow key={t.id}>
               <Cell text={t.username} />
+              <Cell text={t.wordCount} />
+              <Cell text={t.domainCount} />
               <Cell
                 body={
                   t.recentDomain ? (
@@ -60,8 +62,6 @@ export default function UserStatistics(): ReactElement {
                   ) : null
                 }
               />
-              <Cell text={t.domainCount} />
-              <Cell text={t.wordCount} />
             </TableRow>
           ))}
         </TableBody>


### PR DESCRIPTION
Sometimes the domain name can be very long, causing the last columns to overflow the available table width. Moving most-recent-domain to be the last column resolves that.

Should we also consider adding a max width to that column in case more columns are added after it in the future?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4078)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wordCount metric to the user statistics table display.

* **Improvements**
  * Reordered statistics table columns to optimize data layout and removed duplicate column entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->