### PR TITLE
[dependabot] Ignore all npm major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,21 +74,3 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "npm" # major updates
-    directory: "/"
-    schedule:
-      interval: "cron"
-      cronjob: "0 0 1 1-7/6 *" # semiannually
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          ["version-update:semver-minor", "version-update:semver-patch"]
-      - dependency-name: "@mui/icons-material"
-      - dependency-name: "@mui/material"
-      - dependency-name: "@mui/x-date-pickers"
-      - dependency-name: "@types/node"
-      - dependency-name: "@types/react"
-      - dependency-name: "@types/react-dom"
-      - dependency-name: "react"
-      - dependency-name: "react-dom"


### PR DESCRIPTION
All four reviewers of #4081 (2 people, 2 bots) missed an invalid configuration, which failed when it was merged into `master`: https://github.com/sillsdev/TheCombine/runs/59809907546

> Dependabot encountered the following error when parsing your .github/dependabot.yml:
```Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Ecosystem 'npm' has overlapping directories. ```

Rather than reverting, this pr has dependabot ignore all major dep updates in the frontend. Most should be handled manually anyway.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4082)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified dependency update automation by consolidating npm configuration to focus on minor and patch version updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->