### PR TITLE
[installer] Ensure NetworkManager is running

### DIFF
--- a/deploy/ansible/roles/network_config/tasks/main.yml
+++ b/deploy/ansible/roles/network_config/tasks/main.yml
@@ -21,6 +21,12 @@
 
 - meta: flush_handlers
 
+- name: Ensure NetworkManager is started and enabled
+  systemd:
+    name: NetworkManager
+    state: started
+    enabled: yes
+
 ###
 # Create a virtual network interface so that k3s can run
 # when no ethernet connection is attached.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4116)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deployment automation now ensures NetworkManager service is automatically started and enabled at system boot, providing reliable network connectivity management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->