### PR TITLE
[installer] Trim whitespace off user-entered variables

### DIFF
--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -34,6 +34,9 @@ set-combine-env () {
     # Collect values from user
     read -p "Enter AWS_ACCESS_KEY_ID: " AWS_ACCESS_KEY_ID
     read -p "Enter AWS_SECRET_ACCESS_KEY: " AWS_SECRET_ACCESS_KEY
+    # Trim whitespace (tabs and newlines cause the installer to fail)
+    AWS_ACCESS_KEY_ID="$(printf '%s' "$AWS_ACCESS_KEY_ID" | xargs)"
+    AWS_SECRET_ACCESS_KEY="$(printf '%s' "$AWS_SECRET_ACCESS_KEY" | xargs)"
     # Write collected values and static values to config file
     cat <<.EOF > ${CONFIG_DIR}/env
     export COMBINE_JWT_SECRET_KEY="${COMBINE_JWT_SECRET_KEY}"


### PR DESCRIPTION
A user running the installer recently encountered this error:
```
INFO:helm install of ingress-controller returned exit status 0x0
Enter AWS_ACCESS_KEY_ID: <redacted>
Enter AWS_SECRET_ACCESS_KEY: <redacted>
Running: helm --kube-context default --dependency-update --namespace=thecombine install thecombine /tmp/selfgz6641/helm/thecombine -f /tmp/tmpu1eqw9on/profile_desktop_thecombine.yaml -f /tmp/tmpu1eqw9on/secrets_thecombine.yaml -f /tmp/tmpu1eqw9on/config_thecombine.yaml --set global.imageTag=v2.8.1 --set global.imageRegistry=public.ecr.aws/thecombine
CalledProcessError returned 1
command: ['helm', '--kube-context', 'default', '--dependency-update', '--namespace=thecombine', 'install', 'thecombine', '/tmp/selfgz6641/helm/thecombine', '-f', '/tmp/tmpu1eqw9on/profile_desktop_thecombine.yaml', '-f', '/tmp/tmpu1eqw9on/secrets_thecombine.yaml', '-f', '/tmp/tmpu1eqw9on/config_thecombine.yaml', '--set', 'global.imageTag=v2.8.1', '--set', 'global.imageRegistry=public.ecr.aws/thecombine']
stdout:
stderr: Error: INSTALLATION FAILED: failed to parse /tmp/tmpu1eqw9on/secrets_thecombine.yaml: error converting YAML to JSON: yaml: control characters are not allowed
```
It appears a control character (likely tab or newline) was accidentally pasted in with one of the `AWS_*` variables, since doing a clean install and being careful to paste without extra whitespace resolved the issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4118)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced installer robustness to prevent credential-related failures during setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->