### PR TITLE
Fix unstable i18n mock

### DIFF
--- a/src/i18n/tests/reactI18nextMock.ts
+++ b/src/i18n/tests/reactI18nextMock.ts
@@ -2,8 +2,9 @@
  * (For testing components with `Trans`, see i18n/tests/i18nMock.ts instead.)
  * This import should occur before other internal imports that use `react-i18next`. */
 
-const t = (str: string): string => str;
 const i18n = { resolvedLanguage: "" };
+const t = (key: string | string[]): string =>
+  Array.isArray(key) ? key[0] : key;
 
 jest.mock("react-i18next", () => ({
   initReactI18next: { init: jest.fn(), type: "3rdParty" },


### PR DESCRIPTION
If a hook (e.g., `useEffect`) depends on `t` from `const { t } = useTranslation`, this mock could result in that hook triggering an infinite re-render loop. This stabilizes the mock with constant definitions of the `i18n` object and `t` function, rather then having them redefined each time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4133)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored internal testing infrastructure for internationalization mocks to improve test structure and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->