### PR TITLE
Add IDE warning for unused private members

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,8 @@ dotnet_diagnostic.CA1848.severity = none
 dotnet_diagnostic.CS1591.severity = none
 # IDE0005 requires both EnforceCodeStyleInBuild and GenerateDocumentationFile set to true.
 dotnet_diagnostic.IDE0005.severity = warning
+# Warn for unused private members.
+dotnet_diagnostic.IDE0052.severity = warning
 
 [*.py]
 max_line_length = 99

--- a/Backend.Tests/Services/LiftServiceTests.cs
+++ b/Backend.Tests/Services/LiftServiceTests.cs
@@ -1,5 +1,4 @@
 using System;
-using Backend.Tests.Mocks;
 using BackendFramework.Interfaces;
 using BackendFramework.Services;
 using NUnit.Framework;
@@ -8,8 +7,6 @@ namespace Backend.Tests.Services
 {
     internal sealed class LiftServiceTests : IDisposable
     {
-        private ISemanticDomainRepository _semDomRepo = null!;
-        private ISpeakerRepository _speakerRepo = null!;
         private ILiftService _liftService = null!;
 
         private const string FileName = "file.lift-ranges";
@@ -25,8 +22,6 @@ namespace Backend.Tests.Services
         [SetUp]
         public void Setup()
         {
-            _semDomRepo = new SemanticDomainRepositoryMock();
-            _speakerRepo = new SpeakerRepositoryMock();
             _liftService = new LiftService();
         }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4137)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality diagnostics to flag unused private members as warnings
  * Cleaned up unused test dependencies and mock objects

<!-- end of auto-generated comment: release notes by coderabbit.ai -->