### PR TITLE
[ActiveProjectUsers] Clean up state management

### DIFF
--- a/src/components/ProjectUsers/ActiveProjectUsers.tsx
+++ b/src/components/ProjectUsers/ActiveProjectUsers.tsx
@@ -67,6 +67,8 @@ export default function ActiveProjectUsers(props: {
         setUserRoles(roles);
       }
     });
+
+    // Cleanup function to prevent setting state with old data if the useEffect is retriggered.
     return () => {
       canceled = true;
     };

--- a/src/components/ProjectUsers/ProjectSpeakersList.tsx
+++ b/src/components/ProjectUsers/ProjectSpeakersList.tsx
@@ -71,7 +71,7 @@ export function SpeakerListItem(props: ProjSpeakerProps): ReactElement {
       <DeleteSpeakerListItemIcon {...props} />
       <EditSpeakerNameListItemIcon {...props} />
       <SpeakerConsentListItemIcon refresh={refresh} speaker={speaker} />
-      <ListItemText primary={speaker.name} />
+      <ListItemText>{speaker.name}</ListItemText>
     </ListItem>
   );
 }

--- a/src/components/ProjectUsers/UserList.tsx
+++ b/src/components/ProjectUsers/UserList.tsx
@@ -77,7 +77,7 @@ export default function UserList(props: UserListProps): ReactElement {
           <UserAvatar user={user} />
         </ListItemAvatar>
 
-        <ListItemText primary={`${user.name} (${user.username})`} />
+        <ListItemText>{`${user.name} (${user.username})`}</ListItemText>
       </ListItem>
     );
   };
@@ -89,7 +89,8 @@ export default function UserList(props: UserListProps): ReactElement {
         onMouseEnter={() => setHoverUserId(user.id)}
         onMouseLeave={() => setHoverUserId("")}
       >
-        <ListItemText primary={`${user.name} (${user.username})`} />
+        <ListItemText>{`${user.name} (${user.username})`}</ListItemText>
+
         {hoverUserId === user.id && (
           <Button
             onClick={() => props.addToProject(user.id)}
@@ -105,11 +106,13 @@ export default function UserList(props: UserListProps): ReactElement {
   return (
     <div>
       <Typography>{t("projectSettings.invite.searchTitle")}</Typography>
+
       <NormalizedTextField
         onChange={(e) => updateUsers(e.target.value)}
         placeholder={t("projectSettings.invite.searchPlaceholder")}
         value={filterInput}
       />
+
       <List>
         {filteredInProj.map(inProjListItem)}
         {filteredNotInProj.map(notInProjListItem)}

--- a/src/components/SiteSettings/UserManagement/UserList.tsx
+++ b/src/components/SiteSettings/UserManagement/UserList.tsx
@@ -78,9 +78,7 @@ export default function UserList(props: UserListProps): ReactElement {
           <UserAvatar user={user} />
         </ListItemAvatar>
 
-        <ListItemText
-          primary={`${user.name} (${user.username} | ${user.email})`}
-        />
+        <ListItemText>{`${user.name} (${user.username} | ${user.email})`}</ListItemText>
       </ListItem>
     );
   };

--- a/src/components/SiteSettings/UserManagement/UserProjectsList.tsx
+++ b/src/components/SiteSettings/UserManagement/UserProjectsList.tsx
@@ -36,6 +36,8 @@ export default function UserProjectsList(
           toast.warning(t("siteSettings.deleteUser.projectsLoadError"));
         });
     }
+
+    // Cleanup function to prevent setting state with old data if the useEffect is retriggered.
     return () => {
       canceled = true;
     };


### PR DESCRIPTION
Also, with `ListItemText`, prefer child over `primary` (since we're not using `secondary`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4142)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved user-roles loading with cancellable fetches and pre-sorted lists for more reliable display.

* **Bug Fixes**
  * Prevented stale async updates and added render guards to avoid incomplete renders.
  * Tightened management controls so users with Owner role cannot be managed.

* **Style**
  * Standardized list-item rendering and formatting for consistent user information display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->