### PR TITLE
[SiteSettings>UserManagement] Add menu with projects, delete options

### DIFF
--- a/src/components/SiteSettings/UserManagement/UserActionsMenu.tsx
+++ b/src/components/SiteSettings/UserManagement/UserActionsMenu.tsx
@@ -1,0 +1,78 @@
+import { DeleteForever, Folder, MoreVert } from "@mui/icons-material";
+import {
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+} from "@mui/material";
+import { ReactElement, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { User } from "api/models";
+
+const idAffix = "user-actions";
+const idDelete = `${idAffix}-delete`;
+const idProjects = `${idAffix}-projects`;
+
+export interface UserActionsMenuProps {
+  disableDelete?: boolean;
+  onDeleteClick: () => void;
+  onProjectsClick: () => void;
+  user: User;
+}
+
+export default function UserActionsMenu(
+  props: UserActionsMenuProps
+): ReactElement {
+  const [anchorEl, setAnchorEl] = useState<Element | undefined>(undefined);
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <IconButton
+        id={`${idAffix}-${props.user.username}`}
+        onClick={(event) => setAnchorEl(event.currentTarget)}
+        sx={{ minWidth: 0 }}
+      >
+        <MoreVert />
+      </IconButton>
+
+      <Menu
+        id={`${idAffix}-menu-${props.user.username}`}
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={() => setAnchorEl(undefined)}
+      >
+        <MenuItem
+          id={idProjects}
+          onClick={() => {
+            setAnchorEl(undefined);
+            props.onProjectsClick();
+          }}
+        >
+          <ListItemIcon>
+            <Folder />
+          </ListItemIcon>
+
+          <ListItemText>{t("siteSettings.projectList")}</ListItemText>
+        </MenuItem>
+
+        <MenuItem
+          disabled={props.disableDelete}
+          id={idDelete}
+          onClick={() => {
+            setAnchorEl(undefined);
+            props.onDeleteClick();
+          }}
+        >
+          <ListItemIcon>
+            <DeleteForever />
+          </ListItemIcon>
+
+          <ListItemText>{t("buttons.delete")}</ListItemText>
+        </MenuItem>
+      </Menu>
+    </>
+  );
+}

--- a/src/components/SiteSettings/UserManagement/UserList.tsx
+++ b/src/components/SiteSettings/UserManagement/UserList.tsx
@@ -1,6 +1,4 @@
-import { DeleteForever, VpnKey } from "@mui/icons-material";
 import {
-  Button,
   List,
   ListItem,
   ListItemAvatar,
@@ -20,12 +18,14 @@ import SortOptions, {
   getUserCompare,
 } from "components/ProjectUsers/SortOptions";
 import UserAvatar from "components/ProjectUsers/UserAvatar";
+import UserActionsMenu from "components/SiteSettings/UserManagement/UserActionsMenu";
 import { doesTextMatchUser } from "types/user";
 import { NormalizedTextField } from "utilities/fontComponents";
 
 interface UserListProps {
   allUsers: User[];
-  handleOpenModal: (user: User) => void;
+  handleOpenDeleteModal: (user: User) => void;
+  handleOpenProjectsModal: (user: User) => void;
 }
 
 export default function UserList(props: UserListProps): ReactElement {
@@ -55,24 +55,17 @@ export default function UserList(props: UserListProps): ReactElement {
     );
   }, [filterInput, props.allUsers]);
 
-  const userListButton = (user: User): ReactElement => {
-    const disabled = user.isAdmin || user.id === getUserId();
-    return (
-      <Button
-        disabled={disabled}
-        id={`user-delete-${user.username}`}
-        onClick={disabled ? undefined : () => props.handleOpenModal(user)}
-        style={{ minWidth: 0 }}
-      >
-        {disabled ? <VpnKey /> : <DeleteForever />}
-      </Button>
-    );
-  };
-
   const userListItem = (user: User): ReactElement => {
     return (
       <ListItem key={user.id}>
-        <ListItemIcon>{userListButton(user)}</ListItemIcon>
+        <ListItemIcon>
+          <UserActionsMenu
+            disableDelete={user.isAdmin || user.id === getUserId()}
+            onDeleteClick={() => props.handleOpenDeleteModal(user)}
+            onProjectsClick={() => props.handleOpenProjectsModal(user)}
+            user={user}
+          />
+        </ListItemIcon>
 
         <ListItemAvatar>
           <UserAvatar user={user} />

--- a/src/components/SiteSettings/UserManagement/UserProjects.tsx
+++ b/src/components/SiteSettings/UserManagement/UserProjects.tsx
@@ -1,0 +1,33 @@
+import { Box, Stack, Typography } from "@mui/material";
+import { Fragment, ReactElement } from "react";
+
+import { User } from "api/models";
+import UserProjectsList from "components/SiteSettings/UserManagement/UserProjectsList";
+
+interface UserProjectsProps {
+  user?: User;
+}
+
+export default function UserProjects(props: UserProjectsProps): ReactElement {
+  if (!props.user) {
+    return <Fragment />;
+  }
+
+  const { email, id, name, username } = props.user;
+
+  return (
+    <Box sx={{ maxWidth: 500 }}>
+      <Stack spacing={2}>
+        <Typography align="center" variant="h4">
+          {name}
+        </Typography>
+
+        <Typography align="center" variant="h5">
+          {`(${username} | ${email})`}
+        </Typography>
+
+        <UserProjectsList userId={id} />
+      </Stack>
+    </Box>
+  );
+}

--- a/src/components/SiteSettings/UserManagement/index.tsx
+++ b/src/components/SiteSettings/UserManagement/index.tsx
@@ -7,6 +7,7 @@ import { User } from "api/models";
 import { deleteUser, getAllUsers } from "backend";
 import ConfirmDeletion from "components/SiteSettings/UserManagement/ConfirmDeletion";
 import UserList from "components/SiteSettings/UserManagement/UserList";
+import UserProjects from "components/SiteSettings/UserManagement/UserProjects";
 
 const customStyles = {
   content: {
@@ -22,7 +23,8 @@ const customStyles = {
 export default function UserManagement(): ReactElement {
   const [allUsers, setAllUsers] = useState<User[]>([]);
   const [openUser, setOpenUser] = useState<User | undefined>();
-  const [showModal, setShowModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showProjectsModal, setShowProjectsModal] = useState(false);
 
   const { t } = useTranslation();
 
@@ -45,40 +47,61 @@ export default function UserManagement(): ReactElement {
     }
   }, [openUser, populateUsers]);
 
-  const handleOpenModal = (user: User): void => {
-    setShowModal(true);
+  const handleOpenDeleteModal = (user: User): void => {
+    setShowProjectsModal(false);
+    setShowDeleteModal(true);
     setOpenUser(user);
   };
-  const handleCloseModal = (): void => setShowModal(false);
+  const handleCloseDeleteModal = (): void => setShowDeleteModal(false);
+
+  const handleOpenProjectsModal = (user: User): void => {
+    setShowDeleteModal(false);
+    setShowProjectsModal(true);
+    setOpenUser(user);
+  };
+  const handleCloseProjectsModal = (): void => setShowProjectsModal(false);
 
   const delUser = (userId: string): void => {
     deleteUser(userId)
       .then(() => {
         toast.success(t("siteSettings.deleteUser.toastSuccess"));
         setOpenUser(undefined);
+        handleCloseDeleteModal();
       })
       .catch((err) => {
         console.error(err);
         toast.error(t("siteSettings.deleteUser.toastFailure"));
       });
-    handleCloseModal();
   };
 
   return (
     <>
-      <UserList allUsers={allUsers} handleOpenModal={handleOpenModal} />
+      <UserList
+        allUsers={allUsers}
+        handleOpenDeleteModal={handleOpenDeleteModal}
+        handleOpenProjectsModal={handleOpenProjectsModal}
+      />
 
       <Modal
-        isOpen={showModal}
+        isOpen={showDeleteModal}
         style={customStyles}
         shouldCloseOnOverlayClick
-        onRequestClose={handleCloseModal}
+        onRequestClose={handleCloseDeleteModal}
       >
         <ConfirmDeletion
           user={openUser}
           deleteUser={delUser}
-          handleCloseModal={handleCloseModal}
+          handleCloseModal={handleCloseDeleteModal}
         />
+      </Modal>
+
+      <Modal
+        isOpen={showProjectsModal}
+        style={customStyles}
+        shouldCloseOnOverlayClick
+        onRequestClose={handleCloseProjectsModal}
+      >
+        <UserProjects user={openUser} />
       </Modal>
     </>
   );

--- a/src/components/SiteSettings/UserManagement/tests/UserActionsMenu.test.tsx
+++ b/src/components/SiteSettings/UserManagement/tests/UserActionsMenu.test.tsx
@@ -1,0 +1,86 @@
+import "@testing-library/jest-dom";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { User } from "api/models";
+import UserActionsMenu, {
+  UserActionsMenuProps,
+} from "components/SiteSettings/UserManagement/UserActionsMenu";
+import { newUser } from "types/user";
+
+const mockOnDeleteClick = jest.fn();
+const mockOnProjectsClick = jest.fn();
+
+const testUser: User = { ...newUser("Test User", "test-user"), id: "test-id" };
+
+const renderUserActionsMenu = async (
+  props?: Partial<UserActionsMenuProps>
+): Promise<void> => {
+  await act(async () => {
+    render(
+      <UserActionsMenu
+        disableDelete={props?.disableDelete}
+        onDeleteClick={mockOnDeleteClick}
+        onProjectsClick={mockOnProjectsClick}
+        user={props?.user ?? testUser}
+      />
+    );
+  });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("UserActionsMenu", () => {
+  it("renders with menu button", async () => {
+    await renderUserActionsMenu();
+    const button = screen.getByRole("button");
+    expect(button).toBeInTheDocument();
+    expect(button).not.toBeDisabled();
+  });
+
+  it("opens menu when clicked and shows Projects and Delete options", async () => {
+    await renderUserActionsMenu();
+
+    await userEvent.click(screen.getByRole("button"));
+
+    const menuItems = screen.getAllByRole("menuitem");
+    expect(menuItems).toHaveLength(2);
+    expect(menuItems[0]).toHaveTextContent(/project/i);
+    expect(menuItems[1]).toHaveTextContent(/delete/i);
+    expect(menuItems[0]).not.toHaveAttribute("aria-disabled", "true");
+    expect(menuItems[1]).not.toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("disables Delete menu item when disableDelete is true", async () => {
+    await renderUserActionsMenu({ disableDelete: true });
+
+    await userEvent.click(screen.getByRole("button"));
+
+    const menuItems = screen.getAllByRole("menuitem");
+    expect(menuItems).toHaveLength(2);
+    expect(menuItems[0]).not.toHaveAttribute("aria-disabled", "true"); // Projects
+    expect(menuItems[1]).toHaveAttribute("aria-disabled", "true"); // Delete
+  });
+
+  it("calls onProjectsClick when Projects menu item is clicked", async () => {
+    await renderUserActionsMenu();
+
+    await userEvent.click(screen.getByRole("button"));
+    await userEvent.click(screen.getByText(/project/i));
+
+    expect(mockOnDeleteClick).not.toHaveBeenCalled();
+    expect(mockOnProjectsClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onDeleteClick when Delete menu item is clicked", async () => {
+    await renderUserActionsMenu();
+
+    await userEvent.click(screen.getByRole("button"));
+    await userEvent.click(screen.getByText(/delete/i));
+
+    expect(mockOnDeleteClick).toHaveBeenCalledTimes(1);
+    expect(mockOnProjectsClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/SiteSettings/UserManagement/tests/UserProjects.test.tsx
+++ b/src/components/SiteSettings/UserManagement/tests/UserProjects.test.tsx
@@ -1,0 +1,34 @@
+import "@testing-library/jest-dom";
+import { act, render, screen } from "@testing-library/react";
+
+import { User } from "api/models";
+import UserProjects from "components/SiteSettings/UserManagement/UserProjects";
+import { newUser } from "types/user";
+
+jest.mock("backend", () => ({
+  getUserProjects: () => Promise.resolve([]),
+}));
+
+const testUser: User = { ...newUser("Test User", "test-user"), id: "test-id" };
+
+const renderUserProjects = async (user?: User): Promise<void> => {
+  await act(async () => {
+    render(<UserProjects user={user} />);
+  });
+};
+
+const typographySelector = '[class*="Typography"]';
+
+describe("UserProjects", () => {
+  it("renders nothing when no user is provided", async () => {
+    await renderUserProjects();
+    expect(document.querySelector(typographySelector)).not.toBeInTheDocument();
+  });
+
+  it("renders name and username when user is provided", async () => {
+    await renderUserProjects(testUser);
+    expect(document.querySelector(typographySelector)).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(testUser.name))).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(testUser.username))).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Resolves #4109 

Squashed from #4110

Co-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4143)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contextual action menu for users with quick access to Projects and Delete actions
  * Dedicated user projects view accessible from user management

* **Improvements**
  * Split user-management flow into separate modals for delete confirmation and project viewing
  * Updated list UI to surface actions via the new menu

* **Tests**
  * Added unit tests for the action menu and user projects view
<!-- end of auto-generated comment: release notes by coderabbit.ai -->