### PR TITLE
Allow getting a word from the Frontier

### DIFF
--- a/Backend.Tests/Controllers/AudioControllerTests.cs
+++ b/Backend.Tests/Controllers/AudioControllerTests.cs
@@ -182,13 +182,13 @@ namespace Backend.Tests.Controllers
             Assert.That(_wordRepo.GetAllWords(_projId).Result, Has.Count.EqualTo(2));
 
             // Get the new word from the database
-            var frontier = _wordRepo.GetFrontier(_projId).Result;
+            var frontier = _wordRepo.GetAllFrontier(_projId).Result;
 
             // Ensure the new word has no audio files
             Assert.That(frontier[0].Audio, Has.Count.EqualTo(0));
 
             // Test the frontier
-            Assert.That(_wordRepo.GetFrontier(_projId).Result, Has.Count.EqualTo(1));
+            Assert.That(_wordRepo.GetAllFrontier(_projId).Result, Has.Count.EqualTo(1));
 
             // Ensure the word with deleted audio is in the frontier
             Assert.That(frontier, Has.Count.EqualTo(1));

--- a/Backend.Tests/Controllers/WordControllerTests.cs
+++ b/Backend.Tests/Controllers/WordControllerTests.cs
@@ -71,7 +71,7 @@ namespace Backend.Tests.Controllers
                 w.Id == wordToDelete.Id ||
                 w.Id == otherWord.Id ||
                 w.Accessibility == Status.Deleted));
-            var updatedFrontier = await _wordRepo.GetFrontier(ProjId);
+            var updatedFrontier = await _wordRepo.GetAllFrontier(ProjId);
             Assert.That(updatedFrontier, Has.Count.EqualTo(1));
             Assert.That(updatedFrontier.First().Id, Is.EqualTo(otherWord.Id));
         }
@@ -248,7 +248,7 @@ namespace Backend.Tests.Controllers
             });
             var reverted = (Dictionary<string, string>)((OkObjectResult)result).Value!;
             Assert.That(reverted, Has.Count.EqualTo(1));
-            var frontierIds = (await _wordRepo.GetFrontier(ProjId)).Select(w => w.Id).ToList();
+            var frontierIds = (await _wordRepo.GetAllFrontier(ProjId)).Select(w => w.Id).ToList();
             Assert.That(frontierIds, Has.Count.EqualTo(2));
             Assert.That(frontierIds, Does.Contain(frontierWord1.Id));
             Assert.That(frontierIds, Does.Contain(reverted[frontierWord0.Id]));
@@ -317,7 +317,7 @@ namespace Backend.Tests.Controllers
             var allWords = await _wordRepo.GetAllWords(ProjId);
             Assert.That(allWords[0], Is.EqualTo(word).UsingPropertiesComparer());
 
-            var frontier = await _wordRepo.GetFrontier(ProjId);
+            var frontier = await _wordRepo.GetAllFrontier(ProjId);
             Assert.That(frontier[0], Is.EqualTo(word).UsingPropertiesComparer());
         }
 
@@ -350,7 +350,7 @@ namespace Backend.Tests.Controllers
             Assert.That(allWords, Does.Contain(origWord).UsingPropertiesComparer());
             Assert.That(allWords, Does.Contain(finalWord).UsingPropertiesComparer());
 
-            var frontier = await _wordRepo.GetFrontier(ProjId);
+            var frontier = await _wordRepo.GetAllFrontier(ProjId);
             Assert.That(frontier, Has.Count.EqualTo(1));
             Assert.That(frontier, Does.Contain(finalWord).UsingPropertiesComparer());
         }
@@ -381,14 +381,14 @@ namespace Backend.Tests.Controllers
             await _wordRepo.DeleteFrontier(ProjId, word.Id);
 
             Assert.That(await _wordRepo.GetAllWords(ProjId), Does.Contain(word).UsingPropertiesComparer());
-            Assert.That(await _wordRepo.GetFrontier(ProjId), Is.Empty);
+            Assert.That(await _wordRepo.GetAllFrontier(ProjId), Is.Empty);
 
             var result = await _wordController.RestoreWord(ProjId, word.Id);
 
             Assert.That(result, Is.InstanceOf<OkObjectResult>());
             Assert.That(((OkObjectResult)result).Value, Is.True);
             Assert.That(await _wordRepo.GetAllWords(ProjId), Does.Contain(word).UsingPropertiesComparer());
-            Assert.That(await _wordRepo.GetFrontier(ProjId), Does.Contain(word).UsingPropertiesComparer());
+            Assert.That(await _wordRepo.GetAllFrontier(ProjId), Does.Contain(word).UsingPropertiesComparer());
         }
 
         [Test]

--- a/Backend.Tests/Mocks/WordRepositoryMock.cs
+++ b/Backend.Tests/Mocks/WordRepositoryMock.cs
@@ -13,8 +13,8 @@ namespace Backend.Tests.Mocks
         private readonly List<Word> _words = [];
         private readonly List<Word> _frontier = [];
 
-        private Task<bool>? _getFrontierDelay;
-        private int _getFrontierCallCount;
+        private Task<bool>? _getAllFrontierDelay;
+        private int _getAllFrontierCallCount;
 
         /// <summary>
         /// Sets a delay for the GetFrontier method. The first call to GetFrontier will wait
@@ -22,8 +22,8 @@ namespace Backend.Tests.Mocks
         /// </summary>
         public void SetGetFrontierDelay(Task<bool> delay)
         {
-            _getFrontierDelay = delay;
-            _getFrontierCallCount = 0;
+            _getAllFrontierDelay = delay;
+            _getAllFrontierCallCount = 0;
         }
 
         public Task<List<Word>> GetAllWords(string projectId)
@@ -99,19 +99,26 @@ namespace Backend.Tests.Mocks
             return Task.FromResult(_frontier.Count(w => w.ProjectId == projectId));
         }
 
-        public async Task<List<Word>> GetFrontier(string projectId)
+        public async Task<List<Word>> GetAllFrontier(string projectId)
         {
-            if (_getFrontierDelay is not null)
+            if (_getAllFrontierDelay is not null)
             {
-                var callCount = Interlocked.Increment(ref _getFrontierCallCount);
+                var callCount = Interlocked.Increment(ref _getAllFrontierCallCount);
                 if (callCount == 1)
                 {
                     // First call waits for the signal
-                    await _getFrontierDelay;
+                    await _getAllFrontierDelay;
                 }
             }
 
             return _frontier.Where(w => w.ProjectId == projectId).Select(w => w.Clone()).ToList();
+        }
+
+        public Task<Word?> GetFrontier(string projectId, string wordId, string? audioFileName = null)
+        {
+            var word = _frontier.Find(w => w.ProjectId == projectId && w.Id == wordId &&
+                (string.IsNullOrEmpty(audioFileName) || w.Audio.Any(a => a.FileName == audioFileName)));
+            return Task.FromResult(word?.Clone());
         }
 
         public Task<List<Word>> GetFrontierWithVernacular(string projectId, string vernacular)

--- a/Backend.Tests/Services/MergeServiceTests.cs
+++ b/Backend.Tests/Services/MergeServiceTests.cs
@@ -55,7 +55,7 @@ namespace Backend.Tests.Services
             Util.AssertEqualWordContent(newWords.First(), thisWord, true);
 
             // Check that the only word in the frontier is the new word
-            var frontier = _wordRepo.GetFrontier(ProjId).Result;
+            var frontier = _wordRepo.GetAllFrontier(ProjId).Result;
             Assert.That(frontier, Has.Count.EqualTo(1));
             Assert.That(frontier.First(), Is.EqualTo(newWords.First()).UsingPropertiesComparer());
 
@@ -81,7 +81,7 @@ namespace Backend.Tests.Services
             var newWords = _mergeService.Merge(ProjId, UserId, [mergeObject]).Result;
             // There should be no word added and no words left in the frontier.
             Assert.That(newWords, Is.Empty);
-            var frontier = _wordRepo.GetFrontier(ProjId).Result;
+            var frontier = _wordRepo.GetAllFrontier(ProjId).Result;
             Assert.That(frontier, Is.Empty);
         }
 
@@ -105,7 +105,7 @@ namespace Backend.Tests.Services
                 Assert.That(_wordRepo.GetWord(ProjId, id).Result, Is.Not.Null);
                 mergeWords.Children.Add(new MergeSourceWord { SrcWordId = id });
             }
-            Assert.That(_wordRepo.GetFrontier(ProjId).Result, Has.Count.EqualTo(numberOfChildren));
+            Assert.That(_wordRepo.GetAllFrontier(ProjId).Result, Has.Count.EqualTo(numberOfChildren));
 
             var mergeWordsList = new List<MergeWords> { mergeWords };
             var newWords = _mergeService.Merge(ProjId, UserId, mergeWordsList).Result;
@@ -120,7 +120,7 @@ namespace Backend.Tests.Services
 
             // Confirm that parent added to repo and children not in frontier.
             Assert.That(_wordRepo.GetWord(ProjId, dbParent.Id).Result, Is.Not.Null);
-            Assert.That(_wordRepo.GetFrontier(ProjId).Result, Has.Count.EqualTo(1));
+            Assert.That(_wordRepo.GetAllFrontier(ProjId).Result, Has.Count.EqualTo(1));
         }
 
         [Test]
@@ -134,7 +134,7 @@ namespace Backend.Tests.Services
             Assert.That(newWords, Has.Count.EqualTo(wordCount));
             Assert.That(newWords.First().Id, Is.Not.EqualTo(newWords.Last().Id));
 
-            var frontier = _wordRepo.GetFrontier(ProjId).Result;
+            var frontier = _wordRepo.GetAllFrontier(ProjId).Result;
             Assert.That(frontier, Has.Count.EqualTo(wordCount));
             Assert.That(frontier.First().Id, Is.Not.EqualTo(frontier.Last().Id));
             Assert.That(newWords, Does.Contain(frontier.First()).UsingPropertiesComparer());
@@ -165,7 +165,7 @@ namespace Backend.Tests.Services
             var undo = _mergeService.UndoMerge(ProjId, UserId, mergedWord).Result;
             Assert.That(undo, Is.True);
 
-            var frontierWords = _wordRepo.GetFrontier(ProjId).Result;
+            var frontierWords = _wordRepo.GetAllFrontier(ProjId).Result;
             var frontierWordIds = frontierWords.Select(word => word.Id).ToList();
 
             Assert.That(frontierWords, Has.Count.EqualTo(1));
@@ -185,12 +185,12 @@ namespace Backend.Tests.Services
                 Assert.That(_wordRepo.GetWord(ProjId, id).Result, Is.Not.Null);
                 mergeWords.Children.Add(new MergeSourceWord { SrcWordId = id });
             }
-            Assert.That(_wordRepo.GetFrontier(ProjId).Result, Has.Count.EqualTo(numberOfChildren));
+            Assert.That(_wordRepo.GetAllFrontier(ProjId).Result, Has.Count.EqualTo(numberOfChildren));
 
             var mergeWordsList = new List<MergeWords> { mergeWords };
             var newWords = _mergeService.Merge(ProjId, UserId, mergeWordsList).Result;
 
-            Assert.That(_wordRepo.GetFrontier(ProjId).Result, Has.Count.EqualTo(1));
+            Assert.That(_wordRepo.GetAllFrontier(ProjId).Result, Has.Count.EqualTo(1));
 
             var childIds = mergeWords.Children.Select(word => word.SrcWordId).ToList();
             var parentIds = new List<string> { newWords[0].Id };
@@ -198,7 +198,7 @@ namespace Backend.Tests.Services
             var undo = _mergeService.UndoMerge(ProjId, UserId, mergedWord).Result;
             Assert.That(undo, Is.True);
 
-            var frontierWords = _wordRepo.GetFrontier(ProjId).Result;
+            var frontierWords = _wordRepo.GetAllFrontier(ProjId).Result;
             var frontierWordIds = frontierWords.Select(word => word.Id).ToList();
 
             Assert.That(frontierWords, Has.Count.EqualTo(numberOfChildren));

--- a/Backend.Tests/Services/WordServiceTests.cs
+++ b/Backend.Tests/Services/WordServiceTests.cs
@@ -43,7 +43,7 @@ namespace Backend.Tests.Services
         {
             _ = _wordService.Create(UserId, [new() { ProjectId = ProjId }, new() { ProjectId = ProjId }]).Result;
             Assert.That(_wordRepo.GetAllWords(ProjId).Result, Has.Count.EqualTo(2));
-            Assert.That(_wordRepo.GetFrontier(ProjId).Result, Has.Count.EqualTo(2));
+            Assert.That(_wordRepo.GetAllFrontier(ProjId).Result, Has.Count.EqualTo(2));
         }
 
         [Test]
@@ -93,7 +93,7 @@ namespace Backend.Tests.Services
             var oldId = word.Id;
             word.Vernacular = "NewVern";
             Assert.That(_wordService.Update(ProjId, UserId, oldId, word).Result, Is.EqualTo(word.Id));
-            var frontier = _wordRepo.GetFrontier(ProjId).Result;
+            var frontier = _wordRepo.GetAllFrontier(ProjId).Result;
             Assert.That(frontier, Has.Count.EqualTo(1));
             var newWord = frontier.First();
             Assert.That(newWord.Id, Is.Not.EqualTo(oldId));
@@ -131,7 +131,7 @@ namespace Backend.Tests.Services
         {
             var wordNoFrontier = _wordRepo.Add(new Word { ProjectId = ProjId }).Result;
             var wordYesFrontier = _wordRepo.Create(new Word { ProjectId = ProjId }).Result;
-            Assert.That(_wordRepo.GetFrontier(ProjId).Result, Has.Count.EqualTo(1));
+            Assert.That(_wordRepo.GetAllFrontier(ProjId).Result, Has.Count.EqualTo(1));
             Assert.That(
                 _wordService.RestoreFrontierWords(ProjId, [wordNoFrontier.Id, wordYesFrontier.Id]).Result, Is.False);
         }
@@ -141,9 +141,9 @@ namespace Backend.Tests.Services
         {
             var word1 = _wordRepo.Add(new Word { ProjectId = ProjId }).Result;
             var word2 = _wordRepo.Add(new Word { ProjectId = ProjId }).Result;
-            Assert.That(_wordRepo.GetFrontier(ProjId).Result, Is.Empty);
+            Assert.That(_wordRepo.GetAllFrontier(ProjId).Result, Is.Empty);
             Assert.That(_wordService.RestoreFrontierWords(ProjId, [word1.Id, word2.Id]).Result, Is.True);
-            Assert.That(_wordRepo.GetFrontier(ProjId).Result, Has.Count.EqualTo(2));
+            Assert.That(_wordRepo.GetAllFrontier(ProjId).Result, Has.Count.EqualTo(2));
         }
 
         [Test]

--- a/Backend/Controllers/AudioController.cs
+++ b/Backend/Controllers/AudioController.cs
@@ -123,7 +123,7 @@ namespace BackendFramework.Controllers
                 return BadRequest("Empty File");
             }
 
-            var word = await _wordRepo.GetWord(projectId, wordId);
+            var word = await _wordRepo.GetFrontier(projectId, wordId);
             if (word is null)
             {
                 return NotFound($"wordId: {wordId}");

--- a/Backend/Controllers/WordController.cs
+++ b/Backend/Controllers/WordController.cs
@@ -110,7 +110,7 @@ namespace BackendFramework.Controllers
             {
                 return Forbid();
             }
-            return Ok(await _wordRepo.GetFrontier(projectId));
+            return Ok(await _wordRepo.GetAllFrontier(projectId));
         }
 
         /// <summary> Checks if Frontier has <see cref="Word"/> in specified <see cref="Project"/>. </summary>
@@ -191,7 +191,7 @@ namespace BackendFramework.Controllers
             }
             word.ProjectId = projectId;
 
-            var duplicatedWord = await _wordRepo.GetWord(word.ProjectId, dupId);
+            var duplicatedWord = await _wordRepo.GetFrontier(word.ProjectId, dupId);
             if (duplicatedWord is null)
             {
                 return NotFound();
@@ -241,7 +241,7 @@ namespace BackendFramework.Controllers
             {
                 return Forbid();
             }
-            var document = await _wordRepo.GetWord(projectId, wordId);
+            var document = await _wordRepo.GetFrontier(projectId, wordId);
             if (document is null)
             {
                 return NotFound();

--- a/Backend/Interfaces/IWordRepository.cs
+++ b/Backend/Interfaces/IWordRepository.cs
@@ -18,7 +18,8 @@ namespace BackendFramework.Interfaces
         Task<bool> IsInFrontier(string projectId, string wordId);
         Task<bool> AreInFrontier(string projectId, List<string> wordIds, int count);
         Task<int> GetFrontierCount(string projectId);
-        Task<List<Word>> GetFrontier(string projectId);
+        Task<List<Word>> GetAllFrontier(string projectId);
+        Task<Word?> GetFrontier(string projectId, string wordId, string? audioFileName = null);
         Task<List<Word>> GetFrontierWithVernacular(string projectId, string vernacular);
         Task<Word> AddFrontier(Word word);
         Task<List<Word>> AddFrontier(List<Word> words);

--- a/Backend/Repositories/WordRepository.cs
+++ b/Backend/Repositories/WordRepository.cs
@@ -229,11 +229,23 @@ namespace BackendFramework.Repositories
         }
 
         /// <summary> Finds all <see cref="Word"/>s in the Frontier for specified <see cref="Project"/> </summary>
-        public async Task<List<Word>> GetFrontier(string projectId)
+        public async Task<List<Word>> GetAllFrontier(string projectId)
         {
             using var activity = OtelService.StartActivityWithTag(otelTagName, "getting all Frontier words");
 
             return await _frontier.Find(GetAllProjectWordsFilter(projectId)).ToListAsync();
+        }
+
+        /// <summary> Gets a specified <see cref="Word"/> from the Frontier </summary>
+        /// <returns> The word, or null if not found. </returns>
+        public async Task<Word?> GetFrontier(string projectId, string wordId, string? audioFileName = null)
+        {
+            using var activity = OtelService.StartActivityWithTag(otelTagName, "getting a word from Frontier");
+
+            return string.IsNullOrEmpty(audioFileName)
+                ? await _frontier.Find(GetProjectWordFilter(projectId, wordId)).FirstOrDefaultAsync()
+                : await _frontier.Find(GetProjectWordWithAudioFilter(projectId, wordId, audioFileName))
+                    .FirstOrDefaultAsync();
         }
 
         /// <summary> Finds all <see cref="Word"/>s in Frontier of specified project with specified vern </summary>

--- a/Backend/Services/LiftService.cs
+++ b/Backend/Services/LiftService.cs
@@ -282,7 +282,7 @@ namespace BackendFramework.Services
 
             // Get every word with all of its information.
             var allWords = await wordRepo.GetAllWords(projectId);
-            var frontier = await wordRepo.GetFrontier(projectId);
+            var frontier = await wordRepo.GetAllFrontier(projectId);
             var activeWords = frontier.Where(
                 x => x.Senses.Any(s => s.Accessibility == Status.Active || s.Accessibility == Status.Protected)).ToList();
             var hasFlags = activeWords.Any(w => w.Flag.Active);

--- a/Backend/Services/MergeService.cs
+++ b/Backend/Services/MergeService.cs
@@ -307,7 +307,7 @@ namespace BackendFramework.Services
             {
                 return 0;
             }
-            var frontierWordIds = (await _wordRepo.GetFrontier(projectId)).Select(word => word.Id);
+            var frontierWordIds = (await _wordRepo.GetAllFrontier(projectId)).Select(word => word.Id);
             var updateCount = 0;
             foreach (var entry in oldBlacklist)
             {
@@ -346,7 +346,7 @@ namespace BackendFramework.Services
             {
                 return 0;
             }
-            var frontierWordIds = (await _wordRepo.GetFrontier(projectId)).Select(word => word.Id);
+            var frontierWordIds = (await _wordRepo.GetAllFrontier(projectId)).Select(word => word.Id);
             var updateCount = 0;
             foreach (var entry in oldGraylist)
             {
@@ -402,7 +402,7 @@ namespace BackendFramework.Services
             {
                 return [];
             }
-            var frontier = await _wordRepo.GetFrontier(projectId);
+            var frontier = await _wordRepo.GetAllFrontier(projectId);
             var wordLists = new List<List<Word>> { Capacity = maxLists };
             foreach (var entry in graylist)
             {
@@ -443,7 +443,7 @@ namespace BackendFramework.Services
         {
             var dupFinder = new DuplicateFinder(maxInList, maxLists, 2);
 
-            var collection = await _wordRepo.GetFrontier(projectId);
+            var collection = await _wordRepo.GetAllFrontier(projectId);
             async Task<bool> isUnavailableSet(List<string> wordIds) =>
                 (await IsInMergeBlacklist(projectId, wordIds, userId)) ||
                 (await IsInMergeGraylist(projectId, wordIds, userId));

--- a/Backend/Services/StatisticsService.cs
+++ b/Backend/Services/StatisticsService.cs
@@ -41,7 +41,7 @@ namespace BackendFramework.Services
 
             var hashMap = new Dictionary<string, int>();
             var domainTreeNodeList = await _domainRepo.GetAllSemanticDomainTreeNodes(lang);
-            var wordList = await _wordRepo.GetFrontier(projectId);
+            var wordList = await _wordRepo.GetAllFrontier(projectId);
 
             if (domainTreeNodeList is null || domainTreeNodeList.Count == 0 || wordList.Count == 0)
             {
@@ -74,7 +74,7 @@ namespace BackendFramework.Services
         {
             using var activity = OtelService.StartActivityWithTag(otelTagName, "getting words per day per user counts");
 
-            var wordList = await _wordRepo.GetFrontier(projectId);
+            var wordList = await _wordRepo.GetAllFrontier(projectId);
             var shortTimeDictionary = new Dictionary<string, WordsPerDayPerUserCount>();
             var userNameIdDictionary = new Dictionary<string, string>();
 
@@ -140,7 +140,7 @@ namespace BackendFramework.Services
             using var activity = OtelService.StartActivityWithTag(otelTagName, "getting progress estimation line chart root");
 
             var LineChartData = new ChartRootData();
-            var wordList = await _wordRepo.GetFrontier(projectId);
+            var wordList = await _wordRepo.GetAllFrontier(projectId);
             var workshopSchedule = new List<string>();
             var totalCountDictionary = new Dictionary<string, int>();
 
@@ -308,7 +308,7 @@ namespace BackendFramework.Services
         {
             using var activity = OtelService.StartActivityWithTag(otelTagName, "getting semantic domain user counts");
 
-            var wordList = await _wordRepo.GetFrontier(projectId);
+            var wordList = await _wordRepo.GetAllFrontier(projectId);
             var resUserMap = new Dictionary<string, SemanticDomainUserCount>();
 
             // Get all users of the project

--- a/Backend/Services/WordService.cs
+++ b/Backend/Services/WordService.cs
@@ -119,8 +119,8 @@ namespace BackendFramework.Services
             using var activity = OtelService.StartActivityWithTag(otelTagName, "updating a word in Frontier");
 
             var oldWordId = word.Id; // Capture the id in case of changes.
-            var oldWord = await _wordRepo.GetWord(word.ProjectId, oldWordId);
-            if (oldWord is null || !await _wordRepo.IsInFrontier(word.ProjectId, oldWordId))
+            var oldWord = await _wordRepo.GetFrontier(word.ProjectId, oldWordId);
+            if (oldWord is null)
             {
                 return null;
             }


### PR DESCRIPTION
Important piece of #4146 (though the payoff of this pr alone is small)

Purpose: Without this, whenever we want a frontier word, it requires a 2-part operation: getting the word from `WordsCollection` then confirming that it's in `FrontierCollection`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4148)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made frontier lookups consistent across audio upload, deletion, and duplicate handling to prevent incorrect audio associations and assertion failures.

* **Refactor**
  * Split frontier access into a bulk retrieval and a targeted lookup to clarify list vs single-item behavior and improve data consistency.

* **Tests**
  * Updated tests and mocks to align with the revised frontier retrieval patterns and ensure assertions reflect the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->