### PR TITLE
Add missing Word Controller/Service tests

### DIFF
--- a/Backend.Tests/Controllers/WordControllerTests.cs
+++ b/Backend.Tests/Controllers/WordControllerTests.cs
@@ -392,6 +392,22 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
+        public async Task TestRestoreWordAlreadyInFrontier()
+        {
+            var word = await _wordRepo.Create(Util.RandomWord(ProjId));
+
+            Assert.That(await _wordRepo.GetAllWords(ProjId), Does.Contain(word).UsingPropertiesComparer());
+            Assert.That(await _wordRepo.GetFrontier(ProjId), Does.Contain(word).UsingPropertiesComparer());
+            var frontierCount = await _wordRepo.GetFrontierCount(ProjId);
+
+            var result = await _wordController.RestoreWord(ProjId, word.Id);
+
+            Assert.That(result, Is.InstanceOf<OkObjectResult>());
+            Assert.That(((OkObjectResult)result).Value, Is.False);
+            Assert.That(await _wordRepo.GetFrontierCount(ProjId), Is.EqualTo(frontierCount));
+        }
+
+        [Test]
         public async Task TestRestoreWordNoPermission()
         {
             _wordController.ControllerContext.HttpContext = PermissionServiceMock.UnauthorizedHttpContext();

--- a/Backend.Tests/Controllers/WordControllerTests.cs
+++ b/Backend.Tests/Controllers/WordControllerTests.cs
@@ -397,7 +397,7 @@ namespace Backend.Tests.Controllers
             var word = await _wordRepo.Create(Util.RandomWord(ProjId));
 
             Assert.That(await _wordRepo.GetAllWords(ProjId), Does.Contain(word).UsingPropertiesComparer());
-            Assert.That(await _wordRepo.GetFrontier(ProjId), Does.Contain(word).UsingPropertiesComparer());
+            Assert.That(await _wordRepo.GetAllFrontier(ProjId), Does.Contain(word).UsingPropertiesComparer());
             var frontierCount = await _wordRepo.GetFrontierCount(ProjId);
 
             var result = await _wordController.RestoreWord(ProjId, word.Id);

--- a/Backend.Tests/Controllers/WordControllerTests.cs
+++ b/Backend.Tests/Controllers/WordControllerTests.cs
@@ -41,12 +41,16 @@ namespace Backend.Tests.Controllers
         public async Task TestAreInFrontier()
         {
             var wordNotInFrontier = await _wordRepo.Add(Util.RandomWord(ProjId));
-            var emptyResult = await _wordController.AreInFrontier(ProjId, [wordNotInFrontier.Id, "non-id"]);
-            Assert.That(((ObjectResult)emptyResult).Value, Is.Empty);
+            var emptyResult = await _wordController.AreInFrontier(ProjId, [wordNotInFrontier.Id, "non-id"])
+                as OkObjectResult;
+            Assert.That(emptyResult, Is.Not.Null);
+            Assert.That(emptyResult.Value, Is.Empty);
 
             var wordInFrontier = await _wordRepo.AddFrontier(Util.RandomWord(ProjId));
-            var nonemptyResult = await _wordController.AreInFrontier(ProjId, [wordInFrontier.Id, "non-id"]);
-            Assert.That(((OkObjectResult)nonemptyResult).Value, Is.EqualTo(new List<string> { wordInFrontier.Id }));
+            var nonemptyResult = await _wordController.AreInFrontier(ProjId, [wordInFrontier.Id, "non-id"])
+                as OkObjectResult;
+            Assert.That(nonemptyResult, Is.Not.Null);
+            Assert.That(nonemptyResult.Value, Is.EqualTo(new List<string> { wordInFrontier.Id }));
         }
 
         [Test]
@@ -93,15 +97,23 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public async Task TestHasFrontierWords()
+        public async Task TestHasFrontierWordsFalse()
         {
             await _wordRepo.Create(Util.RandomWord("OTHER_PROJECT"));
-            var falseResult = (ObjectResult)await _wordController.HasFrontierWords(ProjId);
-            Assert.That(falseResult.Value, Is.False);
 
+            var result = await _wordController.HasFrontierWords(ProjId) as OkObjectResult;
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Value, Is.False);
+        }
+
+        [Test]
+        public async Task TestHasFrontierWordsTrue()
+        {
             await _wordRepo.Create(Util.RandomWord(ProjId));
-            var trueResult = (ObjectResult)await _wordController.HasFrontierWords(ProjId);
-            Assert.That(trueResult.Value, Is.True);
+
+            var result = await _wordController.HasFrontierWords(ProjId) as OkObjectResult;
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Value, Is.True);
         }
 
         [Test]
@@ -113,15 +125,21 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public async Task TestIsInFrontier()
+        public async Task TestIsInFrontierFalse()
         {
             var wordNotInFrontier = await _wordRepo.Add(Util.RandomWord(ProjId));
-            var falseResult = (ObjectResult)await _wordController.IsInFrontier(ProjId, wordNotInFrontier.Id);
-            Assert.That(falseResult.Value, Is.False);
+            var result = await _wordController.IsInFrontier(ProjId, wordNotInFrontier.Id) as OkObjectResult;
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Value, Is.False);
+        }
 
+        [Test]
+        public async Task TestIsInFrontierTrue()
+        {
             var wordInFrontier = await _wordRepo.AddFrontier(Util.RandomWord(ProjId));
-            var trueResult = (ObjectResult)await _wordController.IsInFrontier(ProjId, wordInFrontier.Id);
-            Assert.That(trueResult.Value, Is.True);
+            var result = await _wordController.IsInFrontier(ProjId, wordInFrontier.Id) as OkObjectResult;
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Value, Is.True);
         }
 
         [Test]
@@ -140,7 +158,9 @@ namespace Backend.Tests.Controllers
             await _wordRepo.Create(Util.RandomWord(ProjId));
             await _wordRepo.Create(Util.RandomWord("OTHER_PROJECT"));
 
-            var count = (int)((ObjectResult)await _wordController.GetFrontierCount(ProjId)).Value!;
+            var countResult = await _wordController.GetFrontierCount(ProjId) as OkObjectResult;
+            Assert.That(countResult, Is.Not.Null);
+            var count = countResult.Value as int?;
             Assert.That(count, Is.EqualTo(2));
         }
 
@@ -159,7 +179,10 @@ namespace Backend.Tests.Controllers
             var inWord2 = await _wordRepo.Create(Util.RandomWord(ProjId));
             await _wordRepo.Create(Util.RandomWord("OTHER_PROJECT"));
 
-            var frontier = (List<Word>)((ObjectResult)await _wordController.GetProjectFrontierWords(ProjId)).Value!;
+            var result = await _wordController.GetProjectFrontierWords(ProjId) as OkObjectResult;
+            Assert.That(result, Is.Not.Null);
+            var frontier = result.Value as List<Word>;
+            Assert.That(frontier, Is.Not.Null);
             Assert.That(frontier, Has.Count.EqualTo(2));
             Assert.That(frontier, Does.Contain(inWord1).UsingPropertiesComparer());
             Assert.That(frontier, Does.Contain(inWord2).UsingPropertiesComparer());
@@ -181,9 +204,9 @@ namespace Backend.Tests.Controllers
             await _wordRepo.Create(Util.RandomWord(ProjId));
             await _wordRepo.Create(Util.RandomWord(ProjId));
 
-            var result = await _wordController.GetWord(ProjId, word.Id);
-            Assert.That(result, Is.InstanceOf<ObjectResult>());
-            Assert.That(((ObjectResult)result).Value, Is.EqualTo(word).UsingPropertiesComparer());
+            var result = await _wordController.GetWord(ProjId, word.Id) as OkObjectResult;
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Value, Is.EqualTo(word).UsingPropertiesComparer());
         }
 
         [Test]
@@ -207,18 +230,18 @@ namespace Backend.Tests.Controllers
         public async Task TestGetDuplicateId()
         {
             var word = await _wordRepo.Create(Util.RandomWord(ProjId));
-            var result = await _wordController.GetDuplicateId(ProjId, word);
-            Assert.That(result, Is.InstanceOf<ObjectResult>());
-            Assert.That(((ObjectResult)result).Value, Is.EqualTo(word.Id));
+            var result = await _wordController.GetDuplicateId(ProjId, word) as OkObjectResult;
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Value, Is.EqualTo(word.Id));
         }
 
         [Test]
         public async Task TestGetDuplicateIdNoneFound()
         {
             var word = Util.RandomWord(ProjId);
-            var result = await _wordController.GetDuplicateId(ProjId, word);
-            Assert.That(result, Is.InstanceOf<ObjectResult>());
-            Assert.That(((ObjectResult)result).Value, Is.EqualTo(""));
+            var result = await _wordController.GetDuplicateId(ProjId, word) as OkObjectResult;
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Value, Is.EqualTo(""));
         }
 
         [Test]
@@ -245,8 +268,10 @@ namespace Backend.Tests.Controllers
                 ["non-id"] = frontierWord1.Id, // Cannot revert with key not a word
                 [nonFrontierWord1.Id] = nonFrontierWord2.Id, // Cannot revert with value not in frontier
                 [nonFrontierWord0.Id] = frontierWord0.Id, // Can revert
-            });
-            var reverted = (Dictionary<string, string>)((OkObjectResult)result).Value!;
+            }) as OkObjectResult;
+            Assert.That(result, Is.Not.Null);
+            var reverted = result.Value as Dictionary<string, string>;
+            Assert.That(reverted, Is.Not.Null);
             Assert.That(reverted, Has.Count.EqualTo(1));
             var frontierIds = (await _wordRepo.GetAllFrontier(ProjId)).Select(w => w.Id).ToList();
             Assert.That(frontierIds, Has.Count.EqualTo(2));
@@ -272,10 +297,14 @@ namespace Backend.Tests.Controllers
             var dupWord = origWord.Clone();
             dupWord.Flag = new Flag("New Flag");
             var expectedWord = dupWord.Clone();
-            var result = (ObjectResult)await _wordController.UpdateDuplicate(ProjId, origWord.Id, dupWord);
-            var id = (string)result.Value!;
+
+            var result = await _wordController.UpdateDuplicate(ProjId, origWord.Id, dupWord) as OkObjectResult;
+            Assert.That(result, Is.Not.Null);
+            var id = result.Value as string;
+            Assert.That(id, Is.Not.Null);
             var updatedWord = await _wordRepo.GetWord(ProjId, id);
-            Util.AssertEqualWordContent(updatedWord!, expectedWord, true);
+            Assert.That(updatedWord, Is.Not.Null);
+            Util.AssertEqualWordContent(updatedWord, expectedWord, true);
         }
 
         [Test]
@@ -311,14 +340,17 @@ namespace Backend.Tests.Controllers
         {
             var word = Util.RandomWord(ProjId);
 
-            var id = (string)((ObjectResult)await _wordController.CreateWord(ProjId, word)).Value!;
+            var result = await _wordController.CreateWord(ProjId, word) as OkObjectResult;
+            Assert.That(result, Is.Not.Null);
+            var id = result.Value as string;
+            Assert.That(id, Is.Not.Null);
             word.Id = id;
 
             var allWords = await _wordRepo.GetAllWords(ProjId);
-            Assert.That(allWords[0], Is.EqualTo(word).UsingPropertiesComparer());
+            Assert.That(allWords.FirstOrDefault(), Is.EqualTo(word).UsingPropertiesComparer());
 
             var frontier = await _wordRepo.GetAllFrontier(ProjId);
-            Assert.That(frontier[0], Is.EqualTo(word).UsingPropertiesComparer());
+            Assert.That(frontier.FirstOrDefault(), Is.EqualTo(word).UsingPropertiesComparer());
         }
 
         [Test]
@@ -339,12 +371,14 @@ namespace Backend.Tests.Controllers
             var modWord = origWord.Clone();
             modWord.Vernacular = "NewVernacular";
 
-            var id = (string)((ObjectResult)await _wordController.UpdateWord(
-                ProjId, modWord.Id, modWord)).Value!;
+            var result = await _wordController.UpdateWord(ProjId, modWord.Id, modWord) as OkObjectResult;
+            Assert.That(result, Is.Not.Null);
+            var id = result.Value as string;
+            Assert.That(id, Is.Not.Null);
 
             var finalWord = modWord.Clone();
             finalWord.Id = id;
-            finalWord.History = new List<string> { origWord.Id };
+            finalWord.History = [origWord.Id];
 
             var allWords = await _wordRepo.GetAllWords(ProjId);
             Assert.That(allWords, Does.Contain(origWord).UsingPropertiesComparer());
@@ -383,10 +417,9 @@ namespace Backend.Tests.Controllers
             Assert.That(await _wordRepo.GetAllWords(ProjId), Does.Contain(word).UsingPropertiesComparer());
             Assert.That(await _wordRepo.GetAllFrontier(ProjId), Is.Empty);
 
-            var result = await _wordController.RestoreWord(ProjId, word.Id);
-
-            Assert.That(result, Is.InstanceOf<OkObjectResult>());
-            Assert.That(((OkObjectResult)result).Value, Is.True);
+            var result = await _wordController.RestoreWord(ProjId, word.Id) as OkObjectResult;
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Value, Is.True);
             Assert.That(await _wordRepo.GetAllWords(ProjId), Does.Contain(word).UsingPropertiesComparer());
             Assert.That(await _wordRepo.GetAllFrontier(ProjId), Does.Contain(word).UsingPropertiesComparer());
         }
@@ -400,10 +433,9 @@ namespace Backend.Tests.Controllers
             Assert.That(await _wordRepo.GetAllFrontier(ProjId), Does.Contain(word).UsingPropertiesComparer());
             var frontierCount = await _wordRepo.GetFrontierCount(ProjId);
 
-            var result = await _wordController.RestoreWord(ProjId, word.Id);
-
-            Assert.That(result, Is.InstanceOf<OkObjectResult>());
-            Assert.That(((OkObjectResult)result).Value, Is.False);
+            var result = await _wordController.RestoreWord(ProjId, word.Id) as OkObjectResult;
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Value, Is.False);
             Assert.That(await _wordRepo.GetFrontierCount(ProjId), Is.EqualTo(frontierCount));
         }
 

--- a/Backend.Tests/Controllers/WordControllerTests.cs
+++ b/Backend.Tests/Controllers/WordControllerTests.cs
@@ -97,7 +97,7 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public async Task TestHasFrontierWordsFalse()
+        public async Task TestHasFrontierWordsReturnsFalse()
         {
             await _wordRepo.Create(Util.RandomWord("OTHER_PROJECT"));
 
@@ -107,7 +107,7 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public async Task TestHasFrontierWordsTrue()
+        public async Task TestHasFrontierWordsReturnsTrue()
         {
             await _wordRepo.Create(Util.RandomWord(ProjId));
 
@@ -125,7 +125,7 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public async Task TestIsInFrontierFalse()
+        public async Task TestIsInFrontierReturnsFalse()
         {
             var wordNotInFrontier = await _wordRepo.Add(Util.RandomWord(ProjId));
             var result = await _wordController.IsInFrontier(ProjId, wordNotInFrontier.Id) as OkObjectResult;
@@ -134,7 +134,7 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
-        public async Task TestIsInFrontierTrue()
+        public async Task TestIsInFrontierReturnsTrue()
         {
             var wordInFrontier = await _wordRepo.AddFrontier(Util.RandomWord(ProjId));
             var result = await _wordController.IsInFrontier(ProjId, wordInFrontier.Id) as OkObjectResult;

--- a/Backend.Tests/Services/WordServiceTests.cs
+++ b/Backend.Tests/Services/WordServiceTests.cs
@@ -107,7 +107,7 @@ namespace Backend.Tests.Services
             Assert.That(allWordIds, Does.Contain(oldId));
             Assert.That(allWordIds, Does.Contain(deletedId!));
 
-            Assert.That(_wordRepo.GetFrontier(ProjId).Result, Is.Empty);
+            Assert.That(_wordRepo.GetAllFrontier(ProjId).Result, Is.Empty);
         }
 
         [Test]

--- a/Backend.Tests/Services/WordServiceTests.cs
+++ b/Backend.Tests/Services/WordServiceTests.cs
@@ -80,6 +80,37 @@ namespace Backend.Tests.Services
         }
 
         [Test]
+        public void TestDeleteFrontierWordNotInFrontierNull()
+        {
+            var wordNotInFrontier = _wordRepo.Add(new Word { ProjectId = ProjId }).Result;
+            Assert.That(_wordService.DeleteFrontierWord(ProjId, UserId, wordNotInFrontier.Id).Result, Is.Null);
+            Assert.That(_wordService.DeleteFrontierWord("wrong-proj", UserId, WordId).Result, Is.Null);
+        }
+
+        [Test]
+        public void TestDeleteFrontierWordCopiesToWordsAndRemovesFrontier()
+        {
+            var oldId = _wordRepo.Create(new Word { ProjectId = ProjId }).Result.Id;
+
+            var deletedId = _wordService.DeleteFrontierWord(ProjId, UserId, oldId).Result;
+
+            Assert.That(deletedId, Is.Not.Null);
+            Assert.That(deletedId, Is.Not.EqualTo(oldId));
+            var deletedWord = _wordRepo.GetWord(ProjId, deletedId!).Result;
+            Assert.That(deletedWord, Is.Not.Null);
+            Assert.That(deletedWord!.Accessibility, Is.EqualTo(Status.Deleted));
+            Assert.That(deletedWord!.History.Last(), Is.EqualTo(oldId));
+            Assert.That(deletedWord!.EditedBy.Last(), Is.EqualTo(UserId));
+
+            var allWordIds = _wordRepo.GetAllWords(ProjId).Result.Select(w => w.Id).ToList();
+            Assert.That(allWordIds, Has.Count.EqualTo(2));
+            Assert.That(allWordIds, Does.Contain(oldId));
+            Assert.That(allWordIds, Does.Contain(deletedId!));
+
+            Assert.That(_wordRepo.GetFrontier(ProjId).Result, Is.Empty);
+        }
+
+        [Test]
         public void TestUpdateNotInFrontierNull()
         {
             Assert.That(_wordService.Update(ProjId, UserId, WordId, new Word()).Result, Is.Null);

--- a/Backend.Tests/Services/WordServiceTests.cs
+++ b/Backend.Tests/Services/WordServiceTests.cs
@@ -96,16 +96,16 @@ namespace Backend.Tests.Services
 
             Assert.That(deletedId, Is.Not.Null);
             Assert.That(deletedId, Is.Not.EqualTo(oldId));
-            var deletedWord = _wordRepo.GetWord(ProjId, deletedId!).Result;
+            var deletedWord = _wordRepo.GetWord(ProjId, deletedId).Result;
             Assert.That(deletedWord, Is.Not.Null);
-            Assert.That(deletedWord!.Accessibility, Is.EqualTo(Status.Deleted));
-            Assert.That(deletedWord!.History.Last(), Is.EqualTo(oldId));
-            Assert.That(deletedWord!.EditedBy.Last(), Is.EqualTo(UserId));
+            Assert.That(deletedWord.Accessibility, Is.EqualTo(Status.Deleted));
+            Assert.That(deletedWord.History.Last(), Is.EqualTo(oldId));
+            Assert.That(deletedWord.EditedBy.Last(), Is.EqualTo(UserId));
 
             var allWordIds = _wordRepo.GetAllWords(ProjId).Result.Select(w => w.Id).ToList();
             Assert.That(allWordIds, Has.Count.EqualTo(2));
             Assert.That(allWordIds, Does.Contain(oldId));
-            Assert.That(allWordIds, Does.Contain(deletedId!));
+            Assert.That(allWordIds, Does.Contain(deletedId));
 
             Assert.That(_wordRepo.GetAllFrontier(ProjId).Result, Is.Empty);
         }

--- a/Backend.Tests/Services/WordServiceTests.cs
+++ b/Backend.Tests/Services/WordServiceTests.cs
@@ -47,7 +47,7 @@ namespace Backend.Tests.Services
         }
 
         [Test]
-        public void TestDeleteAudioBadInputNull()
+        public void TestDeleteAudioBadInputReturnsNull()
         {
             var fileName = "audio.mp3";
             var wordInFrontier = _wordRepo.Create(
@@ -58,7 +58,7 @@ namespace Backend.Tests.Services
         }
 
         [Test]
-        public void TestDeleteAudioNotInFrontierNull()
+        public void TestDeleteAudioNotInFrontierReturnsNull()
         {
             var fileName = "audio.mp3";
             var wordNotInFrontier = _wordRepo.Add(
@@ -80,7 +80,7 @@ namespace Backend.Tests.Services
         }
 
         [Test]
-        public void TestDeleteFrontierWordNotInFrontierNull()
+        public void TestDeleteFrontierWordNotInFrontierReturnsNull()
         {
             var wordNotInFrontier = _wordRepo.Add(new Word { ProjectId = ProjId }).Result;
             Assert.That(_wordService.DeleteFrontierWord(ProjId, UserId, wordNotInFrontier.Id).Result, Is.Null);
@@ -111,7 +111,7 @@ namespace Backend.Tests.Services
         }
 
         [Test]
-        public void TestUpdateNotInFrontierNull()
+        public void TestUpdateNotInFrontierReturnsNull()
         {
             Assert.That(_wordService.Update(UserId, new Word() { Id = WordId, ProjectId = ProjId }).Result, Is.Null);
         }
@@ -168,7 +168,7 @@ namespace Backend.Tests.Services
         }
 
         [Test]
-        public void TestRestoreFrontierWordsTrue()
+        public void TestRestoreFrontierWordsReturnsTrue()
         {
             var word1 = _wordRepo.Add(new Word { ProjectId = ProjId }).Result;
             var word2 = _wordRepo.Add(new Word { ProjectId = ProjId }).Result;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4151)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for word restore and frontier workflows, including restoring a word already present.
  * Added frontier-deletion scenarios: deletion that moves an entry into the main list and clears the frontier, and no-op when not present.
  * Standardized positive-path assertions to explicit OK results and added nullability/value checks.
  * Split frontier/is-in-frontier checks into separate true/false tests and clarified test names for expected outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->