### PR TITLE
[NoteButton] Use multiline text field for wordwrap

### DIFF
--- a/src/components/Buttons/NoteButton.tsx
+++ b/src/components/Buttons/NoteButton.tsx
@@ -64,6 +64,7 @@ export default function NoteButton(props: NoteButtonProps): ReactElement {
         buttonIdCancel="note-edit-cancel"
         buttonIdClear="note-edit-clear"
         buttonIdConfirm="note-edit-confirm"
+        multiline
         textFieldId="note-text-field"
       />
     </>

--- a/src/components/Dialogs/EditTextDialog.tsx
+++ b/src/components/Dialogs/EditTextDialog.tsx
@@ -71,7 +71,10 @@ export default function EditTextDialog(
 
   function confirmIfEnter(event: KeyboardEvent<any>): void {
     if (event.key === Key.Enter) {
-      event.preventDefault(); // Prevent newline if multiline
+      // Prevent newline in note. If we want to enable newlines (when multiline
+      // is true), we'll need to manage Enter vs (e.g.) Shift+Enter and which
+      // one confirms vs adds a newline.
+      event.preventDefault();
       onConfirm();
     }
   }

--- a/src/components/Dialogs/EditTextDialog.tsx
+++ b/src/components/Dialogs/EditTextDialog.tsx
@@ -31,6 +31,7 @@ interface EditTextDialogProps {
   buttonIdConfirm?: string;
   buttonTextIdCancel?: string;
   buttonTextIdConfirm?: string;
+  multiline?: boolean;
   textFieldId?: string;
 }
 
@@ -70,6 +71,7 @@ export default function EditTextDialog(
 
   function confirmIfEnter(event: KeyboardEvent<any>): void {
     if (event.key === Key.Enter) {
+      event.preventDefault(); // Prevent newline if multiline
       onConfirm();
     }
   }
@@ -101,28 +103,27 @@ export default function EditTextDialog(
           variant="standard"
           autoFocus
           value={text}
+          multiline={props.multiline}
           onChange={(event) => setText(event.target.value)}
-          onKeyPress={confirmIfEnter}
+          onKeyDown={confirmIfEnter}
           slotProps={{ input: { endAdornment } }}
           id={props.textFieldId}
         />
       </DialogContent>
       <DialogActions>
         <Button
-          onClick={onCancel}
-          variant="outlined"
-          color="primary"
           data-testid={props.buttonIdCancel}
           id={props.buttonIdCancel}
+          onClick={onCancel}
+          variant="outlined"
         >
           {t(props.buttonTextIdCancel ?? "buttons.cancel")}
         </Button>
         <Button
-          onClick={onConfirm}
-          variant="outlined"
-          color="primary"
           data-testid={props.buttonIdConfirm}
           id={props.buttonIdConfirm}
+          onClick={onConfirm}
+          variant="contained"
         >
           {t(props.buttonTextIdConfirm ?? "buttons.confirm")}
         </Button>


### PR DESCRIPTION
Resolves #4156 

Also: Removes unnecessary `color="primary"` prop on the dialog buttons and changes the confirm button to `variant="contained"`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4157)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Text input dialogs now support multiline text entry.

* **Improvements**
  * Enhanced keyboard behavior: pressing Enter now confirms the dialog instead of inserting a new line.
  * Updated button styling for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->