### PR TITLE
Use NUnit Analyzers

### DIFF
--- a/Backend.Tests/Backend.Tests.csproj
+++ b/Backend.Tests/Backend.Tests.csproj
@@ -7,6 +7,7 @@
     <CoverletOutputFormat>cobertura</CoverletOutputFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AnalysisMode>Recommended</AnalysisMode>
+    <CodeAnalysisRuleSet>NUnit.Analyzers.Suppressions.ruleset</CodeAnalysisRuleSet>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CA1305;CA1859;CS1591</NoWarn>
@@ -15,6 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq.Contrib.HttpClient" Version="1.4.0" />
     <PackageReference Include="NUnit" Version="4.4.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.11.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4"/>
     <PackageReference Include="coverlet.msbuild" Version="6.0.4"/>

--- a/Backend.Tests/Models/WordTests.cs
+++ b/Backend.Tests/Models/WordTests.cs
@@ -80,11 +80,11 @@ namespace Backend.Tests.Models
             // Confirm content is appended.
             var updatedSense = oldWord.Senses.Find(s => s.Guid == newSense.Guid);
             Assert.That(updatedSense, Is.Not.Null);
-            var updatedDom = updatedSense!.SemanticDomains.Find(dom => dom.Id == newSemDom.Id);
+            var updatedDom = updatedSense.SemanticDomains.Find(dom => dom.Id == newSemDom.Id);
             Assert.That(updatedDom, Is.Not.Null);
             Assert.That(oldWord.Flag, Is.EqualTo(newFlag).UsingPropertiesComparer());
             Assert.That(oldWord.Note, Is.EqualTo(newNote).UsingPropertiesComparer());
-            Assert.That(oldWord.Audio.Any(p => p.FileName.Equals(Text, System.StringComparison.Ordinal)), Is.True);
+            Assert.That(oldWord.Audio.Any(p => p.FileName.Equals(Text, StringComparison.Ordinal)), Is.True);
             Assert.That(oldWord.EditedBy.Contains(Text), Is.True);
             Assert.That(oldWord.History.Contains(Text), Is.True);
         }

--- a/Backend.Tests/NUnit.Analyzers.Suppressions.ruleset
+++ b/Backend.Tests/NUnit.Analyzers.Suppressions.ruleset
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- https://github.com/nunit/nunit.analyzers/blob/4.11.2/src/nunit.analyzers/DiagnosticSuppressors/NUnit.Analyzers.Suppressions.ruleset -->
+<RuleSet Name="NUnit.Analyzer Suppressions" Description="DiagnosticSuppression Rules" ToolsVersion="12.0">
+  <Rules AnalyzerId="DiagnosticSuppressors" RuleNamespace="NUnit.NUnitAnalyzers">
+    <Rule Id="NUnit3001" Action="Info" /> <!-- Possible Null Reference -->
+    <Rule Id="NUnit3002" Action="Info" /> <!-- NonNullableField/Property is Uninitialized -->
+    <Rule Id="NUnit3003" Action="Info" /> <!-- Avoid Uninstantiated Internal Classes -->
+    <Rule Id="NUnit3004" Action="Info" /> <!-- Types that own disposable fields should be disposable -->
+  </Rules>
+</RuleSet>

--- a/Backend.Tests/Otel/OtelServiceTests.cs
+++ b/Backend.Tests/Otel/OtelServiceTests.cs
@@ -17,11 +17,11 @@ namespace Backend.Tests.Otel
 
             // Act
             var activity = OtelService.StartActivityWithTag("test key", "test val");
-            var tag = activity?.GetTagItem("test key");
-            var wrongTag = activity?.GetTagItem("wrong key");
+            Assert.That(activity, Is.Not.Null);
+            var tag = activity.GetTagItem("test key");
+            var wrongTag = activity.GetTagItem("wrong key");
 
             // Assert
-            Assert.That(activity, Is.Not.Null);
             Assert.That(tag, Is.Not.Null);
             Assert.That(wrongTag, Is.Null);
         }

--- a/Backend.Tests/Services/MergeServiceTests.cs
+++ b/Backend.Tests/Services/MergeServiceTests.cs
@@ -35,6 +35,12 @@ namespace Backend.Tests.Services
             _mergeService = new MergeService(_cache, _mergeBlacklistRepo, _mergeGraylistRepo, _wordRepo, _wordService);
         }
 
+        [TearDown]
+        public void TearDown()
+        {
+            _cache?.Dispose();
+        }
+
         [Test]
         public void MergeWordsOneChildTest()
         {


### PR DESCRIPTION
Also: Fix one thing caught by the analyzers.

The rule suppression allows us to drop use of `?` and `!` after `Assert.That(..., Is.Not.Null)`.

This pr only takes advantage of that in two test files as proof-of-concept test cases. All other instances can be handled elsewhere.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4163)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test code quality with improved null-checking patterns and stronger assertions across multiple test suites
  * Added proper resource cleanup in test teardown to ensure test isolation and prevent resource leaks
  * Integrated NUnit.Analyzers package and configuration for improved diagnostic analysis during test execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->