### PR TITLE
[Backend.Tests] Clean up style

### DIFF
--- a/Backend.Tests/Controllers/AvatarControllerTests.cs
+++ b/Backend.Tests/Controllers/AvatarControllerTests.cs
@@ -95,19 +95,20 @@ namespace Backend.Tests.Controllers
             using var stream = File.OpenRead(_filePath);
             var file = new FormFile(stream, 0, stream.Length, "formFileName", FileName);
             var uploadResult = _avatarController.UploadAvatar(file).Result;
-            Assert.That(uploadResult, Is.TypeOf<OkResult>());
+            Assert.That(uploadResult, Is.InstanceOf<OkResult>());
 
             var foundUser = _userRepo.GetUser(_userId).Result;
-            Assert.That(foundUser?.Avatar, Is.Not.Null);
+            Assert.That(foundUser, Is.Not.Null);
+            Assert.That(foundUser.Avatar, Is.Not.Empty);
 
             // No permissions should be required to download an avatar.
             _avatarController.ControllerContext.HttpContext = PermissionServiceMock.UnauthorizedHttpContext();
 
             var fileResult = _avatarController.DownloadAvatar(_userId).Result as FileStreamResult;
-            Assert.That(fileResult, Is.TypeOf<FileStreamResult>());
+            Assert.That(fileResult, Is.Not.Null);
 
             // Clean up.
-            fileResult!.FileStream.Dispose();
+            fileResult.FileStream.Dispose();
             DeleteAvatarFile(_userId);
         }
     }

--- a/Backend.Tests/Controllers/InviteControllerTests.cs
+++ b/Backend.Tests/Controllers/InviteControllerTests.cs
@@ -68,7 +68,8 @@ namespace Backend.Tests.Controllers
         public void TestEmailInviteToProject()
         {
             var data = new EmailInviteData { ProjectId = _projId };
-            var result = (ObjectResult)_inviteController.EmailInviteToProject(data).Result;
+            var result = _inviteController.EmailInviteToProject(data).Result as OkObjectResult;
+            Assert.That(result, Is.Not.Null);
             Assert.That(result.Value, Is.Not.Empty);
         }
 
@@ -91,12 +92,11 @@ namespace Backend.Tests.Controllers
         [Test]
         public void TestValidateInviteTokenNoTokenNoUser()
         {
-            var result = _inviteController.ValidateInviteToken(_projId, "not-a-token").Result;
-            Assert.That(result, Is.InstanceOf<OkObjectResult>());
-            var value = ((OkObjectResult)result).Value;
-            Assert.That(value, Is.InstanceOf<EmailInviteStatus>());
+            var result = _inviteController.ValidateInviteToken(_projId, "not-a-token").Result as OkObjectResult;
+            Assert.That(result, Is.Not.Null);
 
-            var status = (EmailInviteStatus)value!;
+            var status = result.Value as EmailInviteStatus;
+            Assert.That(status, Is.Not.Null);
             Assert.That(status.IsTokenValid, Is.False);
             Assert.That(status.IsUserValid, Is.False);
         }
@@ -104,12 +104,11 @@ namespace Backend.Tests.Controllers
         [Test]
         public void TestValidateInviteTokenExpiredTokenNoUser()
         {
-            var result = _inviteController.ValidateInviteToken(_projId, _tokenExpired).Result;
-            Assert.That(result, Is.InstanceOf<OkObjectResult>());
-            var value = ((OkObjectResult)result).Value;
-            Assert.That(value, Is.InstanceOf<EmailInviteStatus>());
+            var result = _inviteController.ValidateInviteToken(_projId, _tokenExpired).Result as OkObjectResult;
+            Assert.That(result, Is.Not.Null);
 
-            var status = (EmailInviteStatus)value!;
+            var status = result.Value as EmailInviteStatus;
+            Assert.That(status, Is.Not.Null);
             Assert.That(status.IsTokenValid, Is.False);
             Assert.That(status.IsUserValid, Is.False);
         }
@@ -117,12 +116,11 @@ namespace Backend.Tests.Controllers
         [Test]
         public void TestValidateInviteTokenFutureTokenNoUser()
         {
-            var result = _inviteController.ValidateInviteToken(_projId, _tokenFuture).Result;
-            Assert.That(result, Is.InstanceOf<OkObjectResult>());
-            var value = ((OkObjectResult)result).Value;
-            Assert.That(value, Is.InstanceOf<EmailInviteStatus>());
+            var result = _inviteController.ValidateInviteToken(_projId, _tokenFuture).Result as OkObjectResult;
+            Assert.That(result, Is.Not.Null);
 
-            var status = (EmailInviteStatus)value!;
+            var status = result.Value as EmailInviteStatus;
+            Assert.That(status, Is.Not.Null);
             Assert.That(status.IsTokenValid, Is.False);
             Assert.That(status.IsUserValid, Is.False);
         }
@@ -130,12 +128,11 @@ namespace Backend.Tests.Controllers
         [Test]
         public void TestValidateInviteTokenValidTokenNoUser()
         {
-            var result = _inviteController.ValidateInviteToken(_projId, _tokenActive).Result;
-            Assert.That(result, Is.InstanceOf<OkObjectResult>());
-            var value = ((OkObjectResult)result).Value;
-            Assert.That(value, Is.InstanceOf<EmailInviteStatus>());
+            var result = _inviteController.ValidateInviteToken(_projId, _tokenActive).Result as OkObjectResult;
+            Assert.That(result, Is.Not.Null);
 
-            var status = (EmailInviteStatus)value!;
+            var status = result.Value as EmailInviteStatus;
+            Assert.That(status, Is.Not.Null);
             Assert.That(status.IsTokenValid, Is.True);
             Assert.That(status.IsUserValid, Is.False);
         }
@@ -144,14 +141,13 @@ namespace Backend.Tests.Controllers
         public void TestValidateInviteTokenValidTokenUserAlreadyInProject()
         {
             var roles = new Dictionary<string, string> { [_projId] = "role-id" };
-            _userRepo.Create(new() { Email = EmailActive, ProjectRoles = roles });
+            _userRepo.Create(new() { Email = EmailActive, ProjectRoles = roles }).Wait();
 
-            var result = _inviteController.ValidateInviteToken(_projId, _tokenActive).Result;
-            Assert.That(result, Is.InstanceOf<OkObjectResult>());
-            var value = ((OkObjectResult)result).Value;
-            Assert.That(value, Is.InstanceOf<EmailInviteStatus>());
+            var result = _inviteController.ValidateInviteToken(_projId, _tokenActive).Result as OkObjectResult;
+            Assert.That(result, Is.Not.Null);
 
-            var status = (EmailInviteStatus)value!;
+            var status = result.Value as EmailInviteStatus;
+            Assert.That(status, Is.Not.Null);
             Assert.That(status.IsTokenValid, Is.True);
             Assert.That(status.IsUserValid, Is.False);
         }
@@ -159,16 +155,15 @@ namespace Backend.Tests.Controllers
         [Test]
         public void TestValidateInviteTokenExpiredTokenUserAvailable()
         {
-            _userRepo.Create(new() { Id = "other-user" });
+            _userRepo.Create(new() { Id = "other-user" }).Wait();
             // User with an email address matching an invite with an expired token.
-            _userRepo.Create(new() { Id = "invitee", Email = EmailExpired });
+            _userRepo.Create(new() { Id = "invitee", Email = EmailExpired }).Wait();
 
-            var result = _inviteController.ValidateInviteToken(_projId, _tokenExpired).Result;
-            Assert.That(result, Is.InstanceOf<OkObjectResult>());
-            var value = ((OkObjectResult)result).Value;
-            Assert.That(value, Is.InstanceOf<EmailInviteStatus>());
+            var result = _inviteController.ValidateInviteToken(_projId, _tokenExpired).Result as OkObjectResult;
+            Assert.That(result, Is.Not.Null);
 
-            var status = (EmailInviteStatus)value!;
+            var status = result.Value as EmailInviteStatus;
+            Assert.That(status, Is.Not.Null);
             Assert.That(status.IsTokenValid, Is.False);
             Assert.That(status.IsUserValid, Is.True);
         }
@@ -177,17 +172,16 @@ namespace Backend.Tests.Controllers
         public void TestValidateInviteTokenValidTokenUserAvailable()
         {
             // User with an email address matching an invite with an active token.
-            _userRepo.Create(new() { Email = EmailActive });
+            _userRepo.Create(new() { Email = EmailActive }).Wait();
 
             // No permissions should be required to validate a token.
             _inviteController.ControllerContext.HttpContext = PermissionServiceMock.UnauthorizedHttpContext();
 
-            var result = _inviteController.ValidateInviteToken(_projId, _tokenActive).Result;
-            Assert.That(result, Is.InstanceOf<OkObjectResult>());
-            var value = ((OkObjectResult)result).Value;
-            Assert.That(value, Is.InstanceOf<EmailInviteStatus>());
+            var result = _inviteController.ValidateInviteToken(_projId, _tokenActive).Result as OkObjectResult;
+            Assert.That(result, Is.Not.Null);
 
-            var status = (EmailInviteStatus)value!;
+            var status = result.Value as EmailInviteStatus;
+            Assert.That(status, Is.Not.Null);
             Assert.That(status.IsTokenValid, Is.True);
             Assert.That(status.IsUserValid, Is.True);
         }

--- a/Backend.Tests/Controllers/LiftControllerTests.cs
+++ b/Backend.Tests/Controllers/LiftControllerTests.cs
@@ -188,7 +188,8 @@ namespace Backend.Tests.Controllers
 
         private static async Task<string> DownloadAndReadLift(LiftController liftController, string projId)
         {
-            var liftFile = (FileStreamResult)await liftController.DownloadLiftFile(projId, UserId);
+            var liftFile = await liftController.DownloadLiftFile(projId, UserId) as FileStreamResult;
+            Assert.That(liftFile, Is.Not.Null);
 
             // Read contents.
             byte[] contents;
@@ -227,18 +228,19 @@ namespace Backend.Tests.Controllers
         [Test]
         public void TestUploadLiftFileAlreadyImported()
         {
-            var projId = _projRepo.Create(new Project { Name = "already has import", LiftImported = true }).Result!.Id;
-            var result = _liftController.UploadLiftFile(projId, _file).Result;
-            Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
-            Assert.That(((BadRequestObjectResult)result).Value, Contains.Substring("LIFT"));
+            var proj = _projRepo.Create(new Project { Name = "already has import", LiftImported = true }).Result;
+            Assert.That(proj, Is.Not.Null);
+            var result = _liftController.UploadLiftFile(proj.Id, _file).Result as BadRequestObjectResult;
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Value, Contains.Substring("LIFT"));
         }
 
         [Test]
         public void TestUploadLiftFileBadFile()
         {
-            var result = _liftController.UploadLiftFile(_projId, null).Result;
-            Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
-            Assert.That(((BadRequestObjectResult)result).Value, Is.InstanceOf<string>());
+            var result = _liftController.UploadLiftFile(_projId, null).Result as BadRequestObjectResult;
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Value, Is.InstanceOf<string>());
         }
 
         [Test]
@@ -254,9 +256,11 @@ namespace Backend.Tests.Controllers
             using (var fileStream = File.OpenRead(pathToZip))
             {
                 var fileUpload = InitFile(fileStream, fileName);
-                var result = _liftController.UploadLiftFileAndGetWritingSystems(fileUpload, UserId).Result;
-                Assert.That(result, Is.TypeOf<OkObjectResult>());
-                var writingSystems = (result as OkObjectResult)!.Value as List<WritingSystem>;
+                var result = _liftController.UploadLiftFileAndGetWritingSystems(fileUpload, UserId).Result
+                    as OkObjectResult;
+                Assert.That(result, Is.Not.Null);
+                var writingSystems = result.Value as List<WritingSystem>;
+                Assert.That(writingSystems, Is.Not.Null);
                 Assert.That(writingSystems, Has.Count.Not.Zero);
             }
 
@@ -284,21 +288,22 @@ namespace Backend.Tests.Controllers
         {
             var proj = Util.RandomProject();
             proj = _projRepo.Create(proj).Result;
+            Assert.That(proj, Is.Not.Null);
 
             // No extracted import dir stored for user.
             Assert.That(_liftService.RetrieveImport(UserId), Is.Null);
-            var result = _liftController.FinishUploadLiftFile(proj!.Id, UserId).Result;
-            Assert.That(result, Is.TypeOf<BadRequestObjectResult>());
+            var result = _liftController.FinishUploadLiftFile(proj.Id, UserId).Result;
+            Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
 
             // Empty extracted import dir stored for user.
             _liftService.StoreImport(UserId, "  ");
-            result = _liftController.FinishUploadLiftFile(proj!.Id, UserId).Result;
-            Assert.That(result, Is.TypeOf<BadRequestObjectResult>());
+            result = _liftController.FinishUploadLiftFile(proj.Id, UserId).Result;
+            Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
 
             // Nonsense extracted import dir stored for user.
             _liftService.StoreImport(UserId, "not-a-real-path");
-            result = _liftController.FinishUploadLiftFile(proj!.Id, UserId).Result;
-            Assert.That(result, Is.TypeOf<BadRequestObjectResult>());
+            result = _liftController.FinishUploadLiftFile(proj.Id, UserId).Result;
+            Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
             Assert.That(_liftService.RetrieveImport(UserId), Is.Null);
         }
 
@@ -371,7 +376,7 @@ namespace Backend.Tests.Controllers
                     _liftService.SetExportInProgress(UserId, ExportId);
                     await _liftController.CreateLiftExportThenSignal(invalidProjectId, UserId, ExportId);
                 },
-                Throws.TypeOf<MissingProjectException>());
+                Throws.InstanceOf<MissingProjectException>());
         }
 
         [Test]
@@ -433,7 +438,7 @@ namespace Backend.Tests.Controllers
             // Delete the export
             _liftController.DeleteLiftFile(UserId);
             var notFoundResult = await _liftController.DownloadLiftFile(_projId, UserId);
-            Assert.That(notFoundResult, Is.TypeOf<NotFoundObjectResult>());
+            Assert.That(notFoundResult, Is.InstanceOf<NotFoundObjectResult>());
         }
 
         [Test]
@@ -488,30 +493,30 @@ namespace Backend.Tests.Controllers
             }
 
             // Delete everything
-            mockFiles.ForEach(path => File.Delete(path));
+            mockFiles.ForEach(File.Delete);
             File.Delete(exportedFilePath);
             Directory.Delete(exportedDirectory, true);
         }
 
         private static RoundTripObj[] _roundTripCases =
         {
-            new("Gusillaay.zip", "gsl-Qaaa-x-orth", new List<string>(), 8045),
-            new("GusillaayNoTopLevelFolder.zip", "gsl-Qaaa-x-orth", new List<string>(), 8045),
-            new("Lotud.zip", "dtr", new List<string>(), 5400, "", "", true, true),
-            new("Natqgu.zip", "qaa-x-stc-natqgu", new List<string>(), 11570, "", "", true, true),
-            new("Resembli.zip", "ags", new List<string>(), 255, "", "", true, true),
-            new("RWC.zip", "es", new List<string>(), 132, "", "", true),
-            new("Sena.zip", "seh", new List<string>(), 1462, "", "", true, true),
+            new("Gusillaay.zip", "gsl-Qaaa-x-orth", [], 8045),
+            new("GusillaayNoTopLevelFolder.zip", "gsl-Qaaa-x-orth", [], 8045),
+            new("Lotud.zip", "dtr", [], 5400, "", "", true, true),
+            new("Natqgu.zip", "qaa-x-stc-natqgu", [], 11570, "", "", true, true),
+            new("Resembli.zip", "ags", [], 255, "", "", true, true),
+            new("RWC.zip", "es", [], 132, "", "", true),
+            new("Sena.zip", "seh", [], 1462, "", "", true, true),
             new(
-                "SingleEntryLiftWithSound.zip", "ptn", new List<string> { "short.mp3" }, 1,
+                "SingleEntryLiftWithSound.zip", "ptn",  ["short.mp3" ], 1,
                 "50398a34-276a-415c-b29e-3186b0f08d8b" /*guid of the lone entry*/,
                 "e44420dd-a867-4d71-a43f-e472fd3a8f82" /*id of its first sense*/, true),
             new(
-                "SingleEntryLiftWithTwoSound.zip", "ptn", new List<string> { "short.mp3", "short1.mp3" }, 1,
+                "SingleEntryLiftWithTwoSound.zip", "ptn", ["short.mp3", "short1.mp3"], 1,
                 "50398a34-276a-415c-b29e-3186b0f08d8b" /*guid of the lone entry*/,
                 "e44420dd-a867-4d71-a43f-e472fd3a8f82" /*id of its first sense*/, true),
             new(
-                "SingleEntryLiftWithWebmSound.zip", "ptn", new List<string> { "short.webm" }, 1,
+                "SingleEntryLiftWithWebmSound.zip", "ptn", ["short.webm"], 1,
                 "50398a34-276a-415c-b29e-3186b0f08d8b" /*guid of the lone entry*/,
                 "e44420dd-a867-4d71-a43f-e472fd3a8f82" /*id of its first sense*/, true)
         };
@@ -529,6 +534,7 @@ namespace Backend.Tests.Controllers
             var proj1 = Util.RandomProject();
             proj1.VernacularWritingSystem.Bcp47 = roundTripObj.Language;
             proj1 = _projRepo.Create(proj1).Result;
+            Assert.That(proj1, Is.Not.Null);
 
             // Upload the zip file.
             // Generate api parameter with file stream.
@@ -537,13 +543,13 @@ namespace Backend.Tests.Controllers
                 var fileUpload = InitFile(fileStream, roundTripObj.Filename);
 
                 // Make api call.
-                var result = _liftController.UploadLiftFile(proj1!.Id, fileUpload).Result;
-                Assert.That(result, Is.TypeOf<OkObjectResult>());
+                var result = _liftController.UploadLiftFile(proj1.Id, fileUpload).Result;
+                Assert.That(result, Is.InstanceOf<OkObjectResult>());
             }
 
             proj1 = _projRepo.GetProject(proj1.Id).Result;
             Assert.That(proj1, Is.Not.Null);
-            Assert.That(proj1!.LiftImported, Is.True);
+            Assert.That(proj1.LiftImported, Is.True);
             Assert.That(proj1.DefinitionsEnabled, Is.EqualTo(roundTripObj.HasDefs));
             Assert.That(proj1.GrammaticalInfoEnabled, Is.EqualTo(roundTripObj.HasGramInfo));
 
@@ -556,7 +562,7 @@ namespace Backend.Tests.Controllers
                 var word = allWords[0].Clone();
                 Assert.That(roundTripObj.EntryGuid, Is.Not.EqualTo(""));
                 Assert.That(word.Guid.ToString(), Is.EqualTo(roundTripObj.EntryGuid));
-                if (roundTripObj.SenseGuid != "")
+                if (!string.IsNullOrEmpty(roundTripObj.SenseGuid))
                 {
                     Assert.That(word.Senses[0].Guid.ToString(), Is.EqualTo(roundTripObj.SenseGuid));
                 }
@@ -596,6 +602,7 @@ namespace Backend.Tests.Controllers
             var proj2 = Util.RandomProject();
             proj2.VernacularWritingSystem.Bcp47 = roundTripObj.Language;
             proj2 = _projRepo.Create(proj2).Result;
+            Assert.That(proj2, Is.Not.Null);
 
             // Upload the exported words again.
             // Generate api parameter with file stream.
@@ -604,8 +611,8 @@ namespace Backend.Tests.Controllers
                 var fileUpload = InitFile(fileStream, roundTripObj.Filename);
 
                 // Make api call.
-                var result2 = _liftController.UploadLiftFile(proj2!.Id, fileUpload).Result;
-                Assert.That(result2, Is.TypeOf<OkObjectResult>());
+                var result2 = _liftController.UploadLiftFile(proj2.Id, fileUpload).Result;
+                Assert.That(result2, Is.InstanceOf<OkObjectResult>());
             }
 
             proj2 = _projRepo.GetProject(proj2.Id).Result;
@@ -615,18 +622,18 @@ namespace Backend.Tests.Controllers
             File.Delete(exportedFilePath);
 
             // Ensure that the definitions and grammatical info weren't all lost.
-            Assert.That(proj2!.DefinitionsEnabled, Is.EqualTo(roundTripObj.HasDefs));
+            Assert.That(proj2.DefinitionsEnabled, Is.EqualTo(roundTripObj.HasDefs));
             Assert.That(proj2.GrammaticalInfoEnabled, Is.EqualTo(roundTripObj.HasGramInfo));
 
             allWords = _wordRepo.GetAllWords(proj2.Id).Result;
             Assert.That(allWords, Has.Count.EqualTo(roundTripObj.NumOfWords));
 
             // We are currently only testing guids on the single-entry data sets.
-            if (roundTripObj.EntryGuid != "" && allWords.Count == 1)
+            if (!string.IsNullOrEmpty(roundTripObj.EntryGuid) && allWords.Count == 1)
             {
                 var word = allWords[0];
                 Assert.That(word.Guid.ToString(), Is.EqualTo(roundTripObj.EntryGuid));
-                if (roundTripObj.SenseGuid != "")
+                if (!string.IsNullOrEmpty(roundTripObj.SenseGuid))
                 {
                     Assert.That(word.Senses[0].Guid.ToString(), Is.EqualTo(roundTripObj.SenseGuid));
                 }

--- a/Backend.Tests/Services/InviteServiceTests.cs
+++ b/Backend.Tests/Services/InviteServiceTests.cs
@@ -48,9 +48,10 @@ namespace Backend.Tests.Services
         {
             var invite = _inviteService.CreateProjectInvite(ProjId, Role.Editor, Email).Result;
             var result = _inviteRepo.FindByToken(invite.Token).Result;
-            Assert.That(result?.Email, Is.EqualTo(Email));
-            Assert.That(result?.ProjectId, Is.EqualTo(ProjId));
-            Assert.That(result?.Role, Is.EqualTo(Role.Editor));
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Email, Is.EqualTo(Email));
+            Assert.That(result.ProjectId, Is.EqualTo(ProjId));
+            Assert.That(result.Role, Is.EqualTo(Role.Editor));
         }
 
         [Test]
@@ -59,7 +60,7 @@ namespace Backend.Tests.Services
             var invite = new ProjectInvite(ProjId, Email, Role.Owner);
             Assert.That(
                 () => _inviteService.RemoveTokenAndCreateUserRole(ProjId, _user, invite),
-                Throws.TypeOf<InviteService.InviteException>());
+                Throws.InstanceOf<InviteService.InviteException>());
         }
 
         [Test]
@@ -74,7 +75,9 @@ namespace Backend.Tests.Services
             var userRoles = _userRoleRepo.GetAllUserRoles(ProjId).Result;
             Assert.That(userRoles, Has.Count.EqualTo(1));
             var userRole = userRoles.First();
-            Assert.That(_userRepo.GetUser(_user.Id).Result!.ProjectRoles[ProjId], Is.EqualTo(userRole.Id));
+            var user = _userRepo.GetUser(_user.Id).Result;
+            Assert.That(user, Is.Not.Null);
+            Assert.That(user.ProjectRoles[ProjId], Is.EqualTo(userRole.Id));
         }
 
         [Test]


### PR DESCRIPTION
In NUnit tests:
- Prefer `Is.InstanceOf` over `Is.TypeOf`
- Prefer soft casting (`as T` with `Is.Not.Null` assertion) over explicit casting (`(T)`)
- Prefer `[...].Wait()` over `_ = [...].Result`
- Prefer `Assert.That([...], Is.Not.Null)` over using `?` or `!`

In general:
- Prefer `string.IsNullOrEmpty` over `== ""` (or `!= ""`)
- Prefer `[]` over `new List<T>` where possible

Todo: update style guide.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4165)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability by improving assertion patterns across unit tests.
  * Strengthened null safety checks in tests to catch edge cases more effectively.
  * Updated test validation logic for more robust type checking and result verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->