### PR TITLE
[LiftService] Extract internal methods for testing

### DIFF
--- a/Backend.Tests/Services/LiftServiceTests.cs
+++ b/Backend.Tests/Services/LiftServiceTests.cs
@@ -1,7 +1,11 @@
 using System;
+using System.Linq;
+using BackendFramework.Helper;
 using BackendFramework.Interfaces;
+using BackendFramework.Models;
 using BackendFramework.Services;
 using NUnit.Framework;
+using SIL.DictionaryServices.Model;
 
 namespace Backend.Tests.Services
 {
@@ -73,6 +77,271 @@ namespace Backend.Tests.Services
             Assert.That(_liftService.RetrieveImport(UserId), Is.EqualTo(FileName));
             Assert.That(_liftService.DeleteImport(UserId), Is.True);
             Assert.That(_liftService.RetrieveImport(UserId), Is.Null);
+        }
+
+        [Test]
+        public void TestCreateLexEntryWithoutAudio()
+        {
+            var project = Util.RandomProject();
+            var word = Util.RandomWord(project.Id);
+            word.Vernacular = "test'vern-with.punct&which;will\tbe\"escaped/later<by*lift writer";
+            word.Created = "2020-01-01T00:00:00.000Z";
+            word.Modified = "2021-02-03T04:05:06.789Z";
+            word.Flag = new("flag text");
+            word.Note = new("en", "note text");
+
+            var entry = LiftService.CreateLexEntryWithoutAudio(project, word, []);
+
+            Assert.That(entry.Id, Does.StartWith(word.Vernacular));
+            Assert.That(entry.Id, Does.EndWith(word.Guid.ToString()));
+            Assert.That(entry.Guid, Is.EqualTo(word.Guid));
+            Assert.That(entry.CreationTime, Is.Not.EqualTo(default(DateTime)));
+            Assert.That(entry.ModificationTime, Is.Not.EqualTo(default(DateTime)));
+            Assert.That(entry.ModifiedTimeIsLocked, Is.True);
+
+            // Check vernacular
+            var vernBcp47 = project.VernacularWritingSystem.Bcp47;
+            var vernForm = entry.LexicalForm.Find(vernBcp47);
+            Assert.That(vernForm, Is.Not.Null);
+            Assert.That(vernForm.Form, Is.EqualTo(word.Vernacular));
+
+            // Check note
+            Assert.That(entry.Notes, Has.Count.EqualTo(1));
+            var noteForms = entry.Notes.First().Forms;
+            Assert.That(noteForms, Has.Length.EqualTo(1));
+            Assert.That(noteForms.First().Form, Is.EqualTo(word.Note.Text));
+
+            // Check flag
+            var flagField = entry.Fields.FirstOrDefault(f => f.Type == LiftHelper.FlagFieldTag);
+            Assert.That(flagField, Is.Not.Null);
+            Assert.That(flagField.Forms, Has.Length.EqualTo(1));
+            Assert.That(flagField.Forms.First().Form, Is.EqualTo(word.Flag.Text));
+
+            // Check senses
+            Assert.That(entry.Senses, Has.Count.EqualTo(word.Senses.Count));
+
+            Assert.That(entry.Pronunciations, Is.Empty);
+        }
+
+        [Test]
+        public void TestCreateLexEntryWithoutAudioDeleted()
+        {
+            var project = Util.RandomProject();
+            var word = Util.RandomWord(project.Id);
+
+            var entry = LiftService.CreateLexEntryWithoutAudio(project, word, [], isDeleted: true);
+
+            // Deleted entries only need minimal metadata
+            Assert.That(entry.Guid, Is.EqualTo(word.Guid));
+            Assert.That(entry.CreationTime, Is.Not.EqualTo(default(DateTime)));
+            Assert.That(entry.ModificationTime, Is.Not.EqualTo(default(DateTime)));
+            Assert.That(entry.ModifiedTimeIsLocked, Is.False);
+
+            // Don't populate fields unused in the lift writer's AddDeletedEntry
+            Assert.That(entry.CitationForm, Is.Empty);
+            Assert.That(entry.Fields, Is.Empty);
+            Assert.That(entry.LexicalForm, Is.Empty);
+            Assert.That(entry.Pronunciations, Is.Empty);
+            Assert.That(entry.Notes, Is.Empty);
+            Assert.That(entry.Senses, Is.Empty);
+        }
+
+        [Test]
+        public void TestCreateLexEntryWithoutAudioCitationForm()
+        {
+            var project = Util.RandomProject();
+            var word = Util.RandomWord(project.Id);
+            word.Vernacular = "citation-form-of-entry";
+            word.UsingCitationForm = true;
+
+            var entry = LiftService.CreateLexEntryWithoutAudio(project, word, []);
+
+            var vernBcp47 = project.VernacularWritingSystem.Bcp47;
+            var citationForm = entry.CitationForm.Find(vernBcp47);
+            Assert.That(citationForm, Is.Not.Null);
+            Assert.That(citationForm.Form, Is.EqualTo("citation-form-of-entry"));
+            Assert.That(entry.LexicalForm.Find(vernBcp47), Is.Null);
+        }
+
+        [Test]
+        public void TestCreateLexEntryWithoutAudioFlagInactive()
+        {
+            var project = Util.RandomProject();
+            var word = Util.RandomWord(project.Id);
+            word.Flag = new() { Active = false, Text = "should not appear" };
+
+            var entry = LiftService.CreateLexEntryWithoutAudio(project, word, []);
+
+            var flagField = entry.Fields.FirstOrDefault(f => f.Type == LiftHelper.FlagFieldTag);
+            Assert.That(flagField, Is.Null);
+        }
+
+        [Test]
+        public void TestCreateLexEntryWithoutAudioFlagTextEmptyFiller()
+        {
+            var project = Util.RandomProject();
+            var word = Util.RandomWord(project.Id);
+            word.Flag = new() { Active = true, Text = "   " };
+
+            var entry = LiftService.CreateLexEntryWithoutAudio(project, word, []);
+
+            var flagField = entry.Fields.FirstOrDefault(f => f.Type == LiftHelper.FlagFieldTag);
+            Assert.That(flagField, Is.Not.Null);
+            Assert.That(flagField.Forms, Has.Length.EqualTo(1));
+            Assert.That(flagField.Forms.First().Form, Is.EqualTo("***"));
+        }
+
+        [Test]
+        public void TestCreateLexEntryWithoutAudioBlankNote()
+        {
+            var project = Util.RandomProject();
+            var word = Util.RandomWord(project.Id);
+            word.Note = new();
+
+            var entry = LiftService.CreateLexEntryWithoutAudio(project, word, []);
+
+            Assert.That(entry.Notes, Is.Empty);
+        }
+
+        [Test]
+        public void TestCreateLexSense()
+        {
+            var sense = Util.RandomSense();
+            sense.Definitions.Add(new() { Language = "fr", Text = "defr" });
+            sense.Glosses.AddRange([new() { Language = "en", Def = "gen" }, new() { Language = "es", Def = "ges" }]);
+            sense.GrammaticalInfo = new() { CatGroup = GramCatGroup.Noun, GrammaticalCategory = "n" };
+            sense.SemanticDomains = [new() { Id = "1", Name = "Universe" }];
+
+            var lexSense = LiftService.CreateLexSense(sense, []);
+
+            Assert.That(lexSense.Id, Is.EqualTo(sense.Guid.ToString()));
+
+            // Check definition
+            var frDef = lexSense.Definition.Find("fr");
+            Assert.That(frDef, Is.Not.Null);
+            Assert.That(frDef.Form, Is.EqualTo("defr"));
+
+            // Check glosses
+            var enGloss = lexSense.Gloss.Find("en");
+            Assert.That(enGloss, Is.Not.Null);
+            Assert.That(enGloss.Form, Is.EqualTo("gen"));
+            var esGloss = lexSense.Gloss.Find("es");
+            Assert.That(esGloss, Is.Not.Null);
+            Assert.That(esGloss.Form, Is.EqualTo("ges"));
+
+            // Check grammatical info
+            var hasPos = lexSense.Properties.Any(p => p.Key == LexSense.WellKnownProperties.PartOfSpeech);
+            Assert.That(hasPos, Is.True);
+
+            // Check semantic domains
+            var semDomProps = lexSense.Properties
+                .Where(p => p.Key == LexSense.WellKnownProperties.SemanticDomainDdp4).ToList();
+            Assert.That(semDomProps, Has.Count.EqualTo(1));
+            Assert.That(semDomProps.First().Value.ToString(), Is.EqualTo("1 Universe"));
+        }
+
+        [Test]
+        public void TestCreateLexSenseDuplicatesInALanguage()
+        {
+            var sense = new Sense
+            {
+                Definitions = [new() { Language = "en", Text = "1st" }, new() { Language = "en", Text = "2nd" }],
+                Glosses = [new() { Language = "es", Def = "1o" }, new() { Language = "es", Def = "2o" }]
+            };
+
+            var lexSense = LiftService.CreateLexSense(sense, []);
+
+            // Both definitions should be merged with default separator
+            var enDef = lexSense.Definition.Find("en");
+            Assert.That(enDef, Is.Not.Null);
+            Assert.That(enDef.Form, Is.EqualTo("1st;2nd"));
+            var esGloss = lexSense.Gloss.Find("es");
+            Assert.That(esGloss, Is.Not.Null);
+            Assert.That(esGloss.Form, Is.EqualTo("1o;2o"));
+        }
+
+        [Test]
+        public void TestCreateLexSenseCustomSeparator()
+        {
+            var sense = new Sense
+            {
+                Definitions = [new() { Language = "en", Text = "1st" }, new() { Language = "en", Text = "2nd" }]
+            };
+
+            var lexSense = LiftService.CreateLexSense(sense, [], separator: " | ");
+
+            var enDef = lexSense.Definition.Find("en");
+            Assert.That(enDef, Is.Not.Null);
+            Assert.That(enDef.Form, Is.EqualTo("1st | 2nd"));
+        }
+
+        [Test]
+        public void TestCreateLexSenseNoGrammaticalInfo()
+        {
+            var sense = new Sense { GrammaticalInfo = new() { CatGroup = GramCatGroup.Unspecified } };
+
+            var lexSense = LiftService.CreateLexSense(sense, []);
+
+            var hasPos = lexSense.Properties.Any(p => p.Key == LexSense.WellKnownProperties.PartOfSpeech);
+            Assert.That(hasPos, Is.False);
+        }
+
+        [Test]
+        public void TestCreateLexSenseSemanticDomainWithoutName()
+        {
+            var sense = new Sense { SemanticDomains = [new() { Id = "9.9" }] };
+
+            // Semantic domain not in dictionary
+            var lexSense = LiftService.CreateLexSense(sense, []);
+
+            var semDomProps = lexSense.Properties
+                .Where(p => p.Key == LexSense.WellKnownProperties.SemanticDomainDdp4).ToList();
+            Assert.That(semDomProps, Has.Count.EqualTo(1));
+            Assert.That(semDomProps.First().Value.ToString(), Is.EqualTo("9.9"));
+        }
+
+        [Test]
+        public void TestCreateLexSenseSemanticDomainPrefersNameFromDictionary()
+        {
+            var sense = new Sense { SemanticDomains = [new() { Id = "9.9", Name = "no!" }] };
+
+            // Semantic domain not in dictionary
+            var lexSense = LiftService.CreateLexSense(sense, new() { ["9.9"] = "yes!" });
+
+            var semDomProps = lexSense.Properties
+                .Where(p => p.Key == LexSense.WellKnownProperties.SemanticDomainDdp4).ToList();
+            Assert.That(semDomProps, Has.Count.EqualTo(1));
+            Assert.That(semDomProps.First().Value.ToString(), Does.EndWith("yes!"));
+        }
+
+        [Test]
+        public void TestCreateLexPhoneticNoSpeaker()
+        {
+            const string audioPath = "path/to/audio.wav";
+
+            var lexPhonetic = LiftService.CreateLexPhonetic(audioPath);
+
+            Assert.That(lexPhonetic.Forms, Has.Length.EqualTo(1));
+            var hrefForm = lexPhonetic.Find("href");
+            Assert.That(hrefForm, Is.Not.Null);
+            Assert.That(hrefForm.Form, Is.EqualTo(audioPath));
+        }
+
+        [Test]
+        public void TestCreateLexPhoneticWithSpeaker()
+        {
+            const string audioPath = "path/to/audio.mp3";
+            var speaker = new Speaker { Id = "speaker1", Name = "Mr. E", ProjectId = "proj1" };
+
+            var lexPhonetic = LiftService.CreateLexPhonetic(audioPath, speaker);
+
+            Assert.That(lexPhonetic.Forms, Has.Length.EqualTo(2));
+            var hrefForm = lexPhonetic.Find("href");
+            Assert.That(hrefForm, Is.Not.Null);
+            Assert.That(hrefForm.Form, Is.EqualTo(audioPath));
+            var speakerForm = lexPhonetic.Find("en");
+            Assert.That(speakerForm, Is.Not.Null);
+            Assert.That(speakerForm.Form, Is.EqualTo("Speaker: Mr. E"));
         }
     }
 }

--- a/Backend.Tests/Services/LiftServiceTests.cs
+++ b/Backend.Tests/Services/LiftServiceTests.cs
@@ -124,29 +124,6 @@ namespace Backend.Tests.Services
         }
 
         [Test]
-        public void TestCreateLexEntryWithoutAudioDeleted()
-        {
-            var project = Util.RandomProject();
-            var word = Util.RandomWord(project.Id);
-
-            var entry = LiftService.CreateLexEntryWithoutAudio(project, word, [], isDeleted: true);
-
-            // Deleted entries only need minimal metadata
-            Assert.That(entry.Guid, Is.EqualTo(word.Guid));
-            Assert.That(entry.CreationTime, Is.Not.EqualTo(default(DateTime)));
-            Assert.That(entry.ModificationTime, Is.Not.EqualTo(default(DateTime)));
-            Assert.That(entry.ModifiedTimeIsLocked, Is.False);
-
-            // Don't populate fields unused in the lift writer's AddDeletedEntry
-            Assert.That(entry.CitationForm, Is.Empty);
-            Assert.That(entry.Fields, Is.Empty);
-            Assert.That(entry.LexicalForm, Is.Empty);
-            Assert.That(entry.Pronunciations, Is.Empty);
-            Assert.That(entry.Notes, Is.Empty);
-            Assert.That(entry.Senses, Is.Empty);
-        }
-
-        [Test]
         public void TestCreateLexEntryWithoutAudioCitationForm()
         {
             var project = Util.RandomProject();

--- a/Backend/Services/LiftService.cs
+++ b/Backend/Services/LiftService.cs
@@ -19,6 +19,7 @@ using SIL.DictionaryServices.Model;
 using SIL.Lift;
 using SIL.Lift.Options;
 using SIL.Lift.Parsing;
+using SIL.Linq;
 using SIL.Text;
 using SIL.WritingSystems;
 using Xabe.FFmpeg;
@@ -401,8 +402,8 @@ namespace BackendFramework.Services
 
         /// <summary>
         /// Creates a <see cref="LexEntry"/> without audio from a <see cref="Word"/>.
-        /// Populates Id, Guid, Note, Vernacular, and Senses.
-        /// If isDeleted is false (default), also populates CreationTime, ModificationTime, and Flag.
+        /// Populates Id, Guid, CreationTime, and ModificationTime.
+        /// If isDeleted is false (default), also populates Flag, Note, Vernacular, and Senses.
         /// </summary>
         /// <remarks> Internal only for testing. </remarks>
         /// <returns> A <see cref="LexEntry"/> that still needs audio added. </returns>
@@ -411,29 +412,28 @@ namespace BackendFramework.Services
         {
             var entry = new LexEntry($"{wordEntry.Vernacular}_{wordEntry.Guid}", wordEntry.Guid);
 
+            if (DateTime.TryParse(wordEntry.Created, out var createdTime))
+            {
+                entry.CreationTime = createdTime;
+            }
+
+            if (DateTime.TryParse(wordEntry.Modified, out var modifiedTime))
+            {
+                entry.ModificationTime = modifiedTime;
+            }
+
             if (!isDeleted)
             {
-                if (DateTime.TryParse(wordEntry.Created, out var createdTime))
-                {
-                    entry.CreationTime = createdTime;
-                }
-
-                if (DateTime.TryParse(wordEntry.Modified, out var modifiedTime))
-                {
-                    entry.ModificationTime = modifiedTime;
-                }
-
                 // It is VERY IMPORTANT that the LexEntry's ModificationTime be locked, otherwise anytime the entry
                 // is modified later (e.g. adding Senses) the ModificationTime of the object will be overwritten with
                 // the current time, rather than the modified time stored in the database.
                 entry.ModifiedTimeIsLocked = true;
 
                 AddFlag(entry, wordEntry, project.AnalysisWritingSystems.FirstOrDefault()?.Bcp47 ?? "en");
+                AddNote(entry, wordEntry);
+                AddVern(entry, wordEntry, project.VernacularWritingSystem.Bcp47);
+                AddSenses(entry, wordEntry, semDomNames);
             }
-
-            AddNote(entry, wordEntry);
-            AddVern(entry, wordEntry, project.VernacularWritingSystem.Bcp47);
-            AddSenses(entry, wordEntry, semDomNames);
 
             return entry;
         }
@@ -543,66 +543,73 @@ namespace BackendFramework.Services
         /// <summary> Adds each <see cref="Sense"/> of a word to be written out to lift </summary>
         private static void AddSenses(LexEntry entry, Word wordEntry, Dictionary<string, string> semDomNames)
         {
-            var activeSenses = wordEntry.Senses.Where(
-                s => s.Accessibility == Status.Active || s.Accessibility == Status.Protected).ToList();
-            foreach (var currentSense in activeSenses)
+            wordEntry.Senses
+                .Where(s => s.Accessibility == Status.Active || s.Accessibility == Status.Protected)
+                .ForEach(s => entry.Senses.Add(CreateLexSense(s, semDomNames)));
+        }
+
+        /// <summary>
+        /// Creates a <see cref="LexSense"/> from a <see cref="Sense"/>.
+        /// Populates Id, Definition, Gloss, GrammaticalInfo, and semantic domain properties.
+        /// </summary>
+        internal static LexSense CreateLexSense(
+            Sense sense, Dictionary<string, string> semDomNames, string separator = ";")
+        {
+            var lexSense = new LexSense { Id = sense.Guid.ToString() };
+
+            // Add definitions
+            var defDict = new Dictionary<string, string>();
+            foreach (var def in sense.Definitions)
             {
-                // Merge in senses
-                const string sep = ";";
-                var defDict = new Dictionary<string, string>();
-                foreach (var def in currentSense.Definitions)
+                if (defDict.TryGetValue(def.Language, out var defText))
                 {
-                    if (defDict.TryGetValue(def.Language, out var defText))
-                    {
-                        // This is an unexpected situation but rather than crashing or losing data we
-                        // will just append extra definitions for the language with a separator.
-                        defDict[def.Language] = $"{defText}{sep}{def.Text}";
-                    }
-                    else
-                    {
-                        defDict.Add(def.Language, def.Text);
-                    }
+                    // This is an unexpected situation but rather than crashing or losing data we
+                    // will just append extra definitions for the language with a separator.
+                    defDict[def.Language] = $"{defText}{separator}{def.Text}";
                 }
-                var glossDict = new Dictionary<string, string>();
-                foreach (var gloss in currentSense.Glosses)
+                else
                 {
-                    if (glossDict.TryGetValue(gloss.Language, out var glossDef))
-                    {
-                        // This is an unexpected situation but rather than crashing or losing data we
-                        // will just append extra definitions for the language with a separator.
-                        glossDict[gloss.Language] = $"{glossDef}{sep}{gloss.Def}";
-                    }
-                    else
-                    {
-                        glossDict.Add(gloss.Language, gloss.Def);
-                    }
+                    defDict.Add(def.Language, def.Text);
                 }
-
-                var lexSense = new LexSense();
-                lexSense.Definition.MergeIn(MultiTextBase.Create(defDict));
-                lexSense.Gloss.MergeIn(MultiTextBase.Create(glossDict));
-                lexSense.Id = currentSense.Guid.ToString();
-
-                // Add grammatical info
-                if (currentSense.GrammaticalInfo.CatGroup != GramCatGroup.Unspecified)
-                {
-                    var optionRef = new OptionRef(currentSense.GrammaticalInfo.GrammaticalCategory);
-                    lexSense.Properties.Add(new KeyValuePair<string, IPalasoDataObjectProperty>(
-                        LexSense.WellKnownProperties.PartOfSpeech, optionRef));
-                }
-
-                // Merge in semantic domains
-                foreach (var semDom in currentSense.SemanticDomains)
-                {
-                    var orc = new OptionRefCollection();
-                    semDomNames.TryGetValue(semDom.Id, out string? name);
-                    orc.Add(semDom.Id + " " + (name ?? semDom.Name));
-                    lexSense.Properties.Add(new KeyValuePair<string, IPalasoDataObjectProperty>(
-                        LexSense.WellKnownProperties.SemanticDomainDdp4, orc));
-                }
-
-                entry.Senses.Add(lexSense);
             }
+            lexSense.Definition.MergeIn(MultiTextBase.Create(defDict));
+
+            // Add glosses
+            var glossDict = new Dictionary<string, string>();
+            foreach (var gloss in sense.Glosses)
+            {
+                if (glossDict.TryGetValue(gloss.Language, out var glossDef))
+                {
+                    // This is an unexpected situation but rather than crashing or losing data we
+                    // will just append extra definitions for the language with a separator.
+                    glossDict[gloss.Language] = $"{glossDef}{separator}{gloss.Def}";
+                }
+                else
+                {
+                    glossDict.Add(gloss.Language, gloss.Def);
+                }
+            }
+            lexSense.Gloss.MergeIn(MultiTextBase.Create(glossDict));
+
+            // Add grammatical info
+            if (sense.GrammaticalInfo.CatGroup != GramCatGroup.Unspecified)
+            {
+                var optionRef = new OptionRef(sense.GrammaticalInfo.GrammaticalCategory);
+                lexSense.Properties.Add(new KeyValuePair<string, IPalasoDataObjectProperty>(
+                    LexSense.WellKnownProperties.PartOfSpeech, optionRef));
+            }
+
+            // Add semantic domains
+            foreach (var semDom in sense.SemanticDomains)
+            {
+                var orc = new OptionRefCollection();
+                semDomNames.TryGetValue(semDom.Id, out string? name);
+                orc.Add(semDom.Id + " " + (name ?? semDom.Name));
+                lexSense.Properties.Add(new KeyValuePair<string, IPalasoDataObjectProperty>(
+                    LexSense.WellKnownProperties.SemanticDomainDdp4, orc));
+            }
+
+            return lexSense;
         }
 
         /// <summary> Adds pronunciation audio of a word to be written out to lift </summary>
@@ -612,33 +619,51 @@ namespace BackendFramework.Services
             foreach (var audio in pronunciations)
             {
                 var src = FileStorage.GenerateAudioFilePath(projectId, audio.FileName);
-                if (!File.Exists(src))
+                var href = await CopyAudioConvertingWebmToWav(src, Path.Combine(path, audio.FileName));
+                if (href is not null)
                 {
-                    continue;
+                    var speaker = projectSpeakers.Find(s => s.Id == audio.SpeakerId);
+                    entry.Pronunciations.Add(CreateLexPhonetic(href, speaker));
                 }
-
-                var dest = Path.Combine(path, audio.FileName);
-                if (Path.GetExtension(dest).Equals(".webm", StringComparison.OrdinalIgnoreCase))
-                {
-                    dest = Path.ChangeExtension(dest, ".wav");
-                    await FFmpeg.Conversions.New().Start($"-y -i \"{src}\" \"{dest}\"");
-                }
-                else
-                {
-                    File.Copy(src, dest, true);
-                }
-
-                var lexPhonetic = new LexPhonetic();
-                lexPhonetic.MergeIn(MultiTextBase.Create(new() { { "href", dest } }));
-                // If audio has speaker, include speaker name as a pronunciation label
-                var speaker = projectSpeakers.Find(s => s.Id == audio.SpeakerId);
-                if (speaker is not null)
-                {
-                    lexPhonetic.MergeIn(
-                        MultiTextBase.Create(new() { { "en", $"Speaker: {speaker.Name}" } }));
-                }
-                entry.Pronunciations.Add(lexPhonetic);
             }
+        }
+
+        /// <summary> Copies audio, converting WebM to WAV. </summary>
+        private static async Task<string?> CopyAudioConvertingWebmToWav(string src, string dest)
+        {
+            if (!File.Exists(src))
+            {
+                return null;
+            }
+
+            if (Path.GetExtension(dest).Equals(".webm", StringComparison.OrdinalIgnoreCase))
+            {
+                dest = Path.ChangeExtension(dest, ".wav");
+                await FFmpeg.Conversions.New().Start($"-y -i \"{src}\" \"{dest}\"");
+            }
+            else
+            {
+                File.Copy(src, dest, true);
+            }
+
+            return dest;
+        }
+
+        /// <summary> Creates a <see cref="LexPhonetic"/> object for an audio file. </summary>
+        /// <param name="href"> The file path of the audio. </param>
+        /// <param name="speaker"> The <see cref="Speaker"/> of the audio, if available. </param>
+        internal static LexPhonetic CreateLexPhonetic(string href, Speaker? speaker = null)
+        {
+            var lexPhonetic = new LexPhonetic();
+            lexPhonetic.MergeIn(MultiTextBase.Create(new() { { "href", href } }));
+
+            // If audio has speaker, include speaker name as a pronunciation label
+            if (speaker is not null)
+            {
+                lexPhonetic.MergeIn(MultiTextBase.Create(new() { { "en", $"Speaker: {speaker.Name}" } }));
+            }
+
+            return lexPhonetic;
         }
 
         /// <summary> Exports vernacular language character set to an ldml file </summary>
@@ -724,10 +749,10 @@ namespace BackendFramework.Services
         private sealed class LiftMerger : ILiftMerger
         {
             private readonly string _projectId;
-            private readonly List<SemanticDomainFull> _customSemDoms = new();
+            private readonly List<SemanticDomainFull> _customSemDoms = [];
             private readonly string _vernLang;
             private readonly IWordRepository _wordRepo;
-            private readonly List<Word> _importEntries = new();
+            private readonly List<Word> _importEntries = [];
 
             public LiftMerger(string projectId, string vernLang, IWordRepository wordRepo)
             {

--- a/Backend/Services/LiftService.cs
+++ b/Backend/Services/LiftService.cs
@@ -321,15 +321,13 @@ namespace BackendFramework.Services
             {
                 var entry = CreateLexEntryWithoutAudio(proj, wordEntry, semDomNames);
                 await AddAudio(entry, wordEntry.Audio, audioDir, projectId, projSpeakers);
-
                 liftWriter.Add(entry);
             }
 
             foreach (var wordEntry in deletedWords)
             {
-                var entry = CreateLexEntryWithoutAudio(proj, wordEntry, semDomNames, isDeleted: true);
+                var entry = new LexEntry(CreateLexEntryId(wordEntry), wordEntry.Guid);
                 await AddAudio(entry, wordEntry.Audio, audioDir, projectId, projSpeakers);
-
                 liftWriter.AddDeletedEntry(entry);
             }
 
@@ -400,40 +398,32 @@ namespace BackendFramework.Services
             return destinationFileName;
         }
 
-        /// <summary>
-        /// Creates a <see cref="LexEntry"/> without audio from a <see cref="Word"/>.
-        /// Populates Id, Guid, CreationTime, and ModificationTime.
-        /// If isDeleted is false (default), also populates Flag, Note, Vernacular, and Senses.
-        /// </summary>
-        /// <remarks> Internal only for testing. </remarks>
+        private static string CreateLexEntryId(Word word) => $"{word.Vernacular}_{word.Guid}";
+
+        /// <summary> Creates a <see cref="LexEntry"/> without audio from a <see cref="Word"/>. </summary>
         /// <returns> A <see cref="LexEntry"/> that still needs audio added. </returns>
         internal static LexEntry CreateLexEntryWithoutAudio(
-            Project project, Word wordEntry, Dictionary<string, string> semDomNames, bool isDeleted = false)
+            Project project, Word wordEntry, Dictionary<string, string> semDomNames)
         {
-            var entry = new LexEntry($"{wordEntry.Vernacular}_{wordEntry.Guid}", wordEntry.Guid);
+            var entry = new LexEntry(CreateLexEntryId(wordEntry), wordEntry.Guid);
 
             if (DateTime.TryParse(wordEntry.Created, out var createdTime))
             {
                 entry.CreationTime = createdTime;
             }
-
             if (DateTime.TryParse(wordEntry.Modified, out var modifiedTime))
             {
                 entry.ModificationTime = modifiedTime;
             }
+            // It is VERY IMPORTANT that the LexEntry's ModificationTime be locked, otherwise anytime the entry
+            // is modified later (e.g. adding Senses) the ModificationTime of the object will be overwritten with
+            // the current time, rather than the modified time stored in the database.
+            entry.ModifiedTimeIsLocked = true;
 
-            if (!isDeleted)
-            {
-                // It is VERY IMPORTANT that the LexEntry's ModificationTime be locked, otherwise anytime the entry
-                // is modified later (e.g. adding Senses) the ModificationTime of the object will be overwritten with
-                // the current time, rather than the modified time stored in the database.
-                entry.ModifiedTimeIsLocked = true;
-
-                AddFlag(entry, wordEntry, project.AnalysisWritingSystems.FirstOrDefault()?.Bcp47 ?? "en");
-                AddNote(entry, wordEntry);
-                AddVern(entry, wordEntry, project.VernacularWritingSystem.Bcp47);
-                AddSenses(entry, wordEntry, semDomNames);
-            }
+            AddFlag(entry, wordEntry, project.AnalysisWritingSystems.FirstOrDefault()?.Bcp47 ?? "en");
+            AddNote(entry, wordEntry);
+            AddVern(entry, wordEntry, project.VernacularWritingSystem.Bcp47);
+            AddSenses(entry, wordEntry, semDomNames);
 
             return entry;
         }

--- a/Backend/Services/LiftService.cs
+++ b/Backend/Services/LiftService.cs
@@ -592,7 +592,7 @@ namespace BackendFramework.Services
             {
                 var orc = new OptionRefCollection();
                 semDomNames.TryGetValue(semDom.Id, out string? name);
-                orc.Add(semDom.Id + " " + (name ?? semDom.Name));
+                orc.Add($"{semDom.Id} {name ?? semDom.Name}".Trim());
                 lexSense.Properties.Add(new KeyValuePair<string, IPalasoDataObjectProperty>(
                     LexSense.WellKnownProperties.SemanticDomainDdp4, orc));
             }

--- a/Backend/Services/LiftService.cs
+++ b/Backend/Services/LiftService.cs
@@ -326,9 +326,7 @@ namespace BackendFramework.Services
 
             foreach (var wordEntry in deletedWords)
             {
-                var entry = new LexEntry(CreateLexEntryId(wordEntry), wordEntry.Guid);
-                await AddAudio(entry, wordEntry.Audio, audioDir, projectId, projSpeakers);
-                liftWriter.AddDeletedEntry(entry);
+                liftWriter.AddDeletedEntry(new LexEntry(CreateLexEntryId(wordEntry), wordEntry.Guid));
             }
 
             liftWriter.End();

--- a/Backend/Services/LiftService.cs
+++ b/Backend/Services/LiftService.cs
@@ -315,29 +315,10 @@ namespace BackendFramework.Services
                 x => activeWords.All(w => w.Guid != x.Guid)).DistinctBy(w => w.Guid).ToList();
             var englishSemDoms = await semDomRepo.GetAllSemanticDomainTreeNodes("en") ?? [];
             var semDomNames = englishSemDoms.ToDictionary(x => x.Id, x => x.Name);
+
             foreach (var wordEntry in activeWords)
             {
-                var id = MakeSafeXmlAttribute(wordEntry.Vernacular) + "_" + wordEntry.Guid;
-                var entry = new LexEntry(id, wordEntry.Guid);
-                if (DateTime.TryParse(wordEntry.Created, out var createdTime))
-                {
-                    entry.CreationTime = createdTime;
-                }
-
-                if (DateTime.TryParse(wordEntry.Modified, out var modifiedTime))
-                {
-                    entry.ModificationTime = modifiedTime;
-                }
-
-                // It is VERY IMPORTANT that the LexEntry's ModificationTime be locked, otherwise anytime the entry
-                // is modified later (e.g. adding Senses) the ModificationTime of the object will be overwritten with
-                // the current time, rather than the modified time stored in the database.
-                entry.ModifiedTimeIsLocked = true;
-
-                AddFlag(entry, wordEntry, proj.AnalysisWritingSystems.FirstOrDefault()?.Bcp47 ?? "en");
-                AddNote(entry, wordEntry);
-                AddVern(entry, wordEntry, proj.VernacularWritingSystem.Bcp47);
-                AddSenses(entry, wordEntry, semDomNames);
+                var entry = CreateLexEntryWithoutAudio(proj, wordEntry, semDomNames);
                 await AddAudio(entry, wordEntry.Audio, audioDir, projectId, projSpeakers);
 
                 liftWriter.Add(entry);
@@ -345,12 +326,7 @@ namespace BackendFramework.Services
 
             foreach (var wordEntry in deletedWords)
             {
-                var id = MakeSafeXmlAttribute(wordEntry.Vernacular) + "_" + wordEntry.Guid;
-                var entry = new LexEntry(id, wordEntry.Guid);
-
-                AddNote(entry, wordEntry);
-                AddVern(entry, wordEntry, proj.VernacularWritingSystem.Bcp47);
-                AddSenses(entry, wordEntry, semDomNames);
+                var entry = CreateLexEntryWithoutAudio(proj, wordEntry, semDomNames, isDeleted: true);
                 await AddAudio(entry, wordEntry.Audio, audioDir, projectId, projSpeakers);
 
                 liftWriter.AddDeletedEntry(entry);
@@ -421,6 +397,45 @@ namespace BackendFramework.Services
             Directory.Delete(tempExportDir, true);
 
             return destinationFileName;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="LexEntry"/> without audio from a <see cref="Word"/>.
+        /// Populates Id, Guid, Note, Vernacular, and Senses.
+        /// If isDeleted is false (default), also populates CreationTime, ModificationTime, and Flag.
+        /// </summary>
+        /// <remarks> Internal only for testing. </remarks>
+        /// <returns> A <see cref="LexEntry"/> that still needs audio added. </returns>
+        internal static LexEntry CreateLexEntryWithoutAudio(
+            Project project, Word wordEntry, Dictionary<string, string> semDomNames, bool isDeleted = false)
+        {
+            var entry = new LexEntry($"{wordEntry.Vernacular}_{wordEntry.Guid}", wordEntry.Guid);
+
+            if (!isDeleted)
+            {
+                if (DateTime.TryParse(wordEntry.Created, out var createdTime))
+                {
+                    entry.CreationTime = createdTime;
+                }
+
+                if (DateTime.TryParse(wordEntry.Modified, out var modifiedTime))
+                {
+                    entry.ModificationTime = modifiedTime;
+                }
+
+                // It is VERY IMPORTANT that the LexEntry's ModificationTime be locked, otherwise anytime the entry
+                // is modified later (e.g. adding Senses) the ModificationTime of the object will be overwritten with
+                // the current time, rather than the modified time stored in the database.
+                entry.ModifiedTimeIsLocked = true;
+
+                AddFlag(entry, wordEntry, project.AnalysisWritingSystems.FirstOrDefault()?.Bcp47 ?? "en");
+            }
+
+            AddNote(entry, wordEntry);
+            AddVern(entry, wordEntry, project.VernacularWritingSystem.Bcp47);
+            AddSenses(entry, wordEntry, semDomNames);
+
+            return entry;
         }
 
         /// <summary> Copy imported lift-ranges file, if available </summary>


### PR DESCRIPTION
~Wait on #4168 and #4173~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4169)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More reliable lexicon export: standardized entry creation, richer sense/phonetic data handling, and improved audio conversion during exports.
  * Better population and merging of definitions, glosses, grammatical info, and semantic domains for exported entries.

* **Tests**
  * Large suite of new tests increasing coverage around lexicon entry, sense, phonetic, flag/note handling, and audio-related scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->