### PR TITLE
[README] Add missing restore flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1024,7 +1024,7 @@ Task: Restore the CombineDatabase and the Backend files from a backup stored on 
 Run:
 
 ```bash
-kubectl -n thecombine exec -it deployment/maintenance -- combine_restore.py [--verbose] --file [BACKUP_NAME]
+kubectl -n thecombine exec -it deployment/maintenance -- combine_restore.py [--verbose] [--file BACKUP_NAME]
 ```
 
 Note:

--- a/README.md
+++ b/README.md
@@ -1024,7 +1024,7 @@ Task: Restore the CombineDatabase and the Backend files from a backup stored on 
 Run:
 
 ```bash
-kubectl -n thecombine exec -it deployment/maintenance -- combine_restore.py [--verbose] [BACKUP_NAME]
+kubectl -n thecombine exec -it deployment/maintenance -- combine_restore.py [--verbose] --file [BACKUP_NAME]
 ```
 
 Note:


### PR DESCRIPTION
See script arg here: https://github.com/sillsdev/TheCombine/blob/master/maintenance/scripts/combine_restore.py#L50

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4175)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Restore operation command syntax to require an explicit `--file` flag instead of using a positional argument for the backup name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->