### PR TITLE
[export] Only export as deleted entries explicitly so

### DIFF
--- a/Backend/Services/LiftService.cs
+++ b/Backend/Services/LiftService.cs
@@ -283,6 +283,8 @@ namespace BackendFramework.Services
             // Get every word with all of its information.
             var allWords = await wordRepo.GetAllWords(projectId);
             var frontier = await wordRepo.GetAllFrontier(projectId);
+            // All words in the frontier with any senses are considered current.
+            // The Combine does not import senseless entries and the interface is supposed to prevent creating them.
             var activeWords = frontier.Where(
                 x => x.Senses.Any(s => s.Accessibility == Status.Active || s.Accessibility == Status.Protected)).ToList();
             var hasFlags = activeWords.Any(w => w.Flag.Active);
@@ -308,11 +310,11 @@ namespace BackendFramework.Services
             // Get all project speakers for exporting audio and consents.
             var projSpeakers = await speakerRepo.GetAllSpeakers(projectId);
 
-            // All words in the frontier with any senses are considered current.
-            // The Combine does not import senseless entries and the interface is supposed to prevent creating them.
-            // So the words found in allWords with no matching guid in activeWords are exported as 'deleted'.
-            var deletedWords = allWords.Where(
-                x => activeWords.All(w => w.Guid != x.Guid)).DistinctBy(w => w.Guid).ToList();
+            // Deleted words found in allWords with no matching guid in activeWords are exported as 'deleted'.
+            var activeWordGuids = activeWords.Select(w => w.Guid).ToHashSet();
+            var deletedWords = allWords
+                .Where(w => w.Accessibility == Status.Deleted && !activeWordGuids.Contains(w.Guid))
+                .DistinctBy(w => w.Guid).ToList();
             var englishSemDoms = await semDomRepo.GetAllSemanticDomainTreeNodes("en") ?? [];
             var semDomNames = englishSemDoms.ToDictionary(x => x.Id, x => x.Name);
 


### PR DESCRIPTION
If a word is removed from the frontier by some unforeseen bug, we don't want that word deleted from the user's FieldWorks project. So this pr will add a guard against that.

Required database update to go with this pr:

- [ ] Add Deleted copies of any words with GUID missing from the Frontier.

Reason: Prior to #4155, merge children were not marked as deleted in the database, so without the database update, this change would result in the children of merges not being deleted in FW, which would undermine the cleanup done in TC.

Side-effect: We cannot distinguish between words that were wrongfully lost from the fronter and words that were deleted (not merged) with the Merge Duplicates tool. So any of the former (which are so far only known to exist in one project), will be cemented as Deleted.

The database update will be easier after #4179 (and it's associated database update) is complete.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4178)
<!-- Reviewable:end -->
