### PR TITLE
[deploy] Fix helm chart values

### DIFF
--- a/deploy/helm/thecombine/charts/backend/templates/backend-config-map.yaml
+++ b/deploy/helm/thecombine/charts/backend/templates/backend-config-map.yaml
@@ -8,12 +8,9 @@ data:
   COMBINE_CAPTCHA_REQUIRED: {{ .Values.global.captchaRequired | quote | lower }}
   COMBINE_CAPTCHA_VERIFY_URL: {{ .Values.captchaVerifyUrl | quote }}
   COMBINE_EMAIL_ENABLED: {{ .Values.global.emailEnabled | quote | lower }}
-  COMBINE_EXPIRE_EMAIL_VERIFY_MINUTES:
-    {{ .Values.global.combineExpireEmailVerifyMinutes | quote | lower }}
-  COMBINE_EXPIRE_PASSWORD_RESET_MINUTES:
-    {{ .Values.global.combineExpirePasswordResetMinutes | quote | lower }}
-  COMBINE_EXPIRE_PROJECT_INVITE_DAYS:
-    {{ .Values.global.combineExpireProjectInviteDays | quote | lower }}
+  COMBINE_EXPIRE_EMAIL_VERIFY_MINUTES: {{ .Values.combineExpireEmailVerifyMinutes | quote }}
+  COMBINE_EXPIRE_PASSWORD_RESET_MINUTES: {{ .Values.combineExpirePasswordResetMinutes | quote }}
+  COMBINE_EXPIRE_PROJECT_INVITE_DAYS: {{ .Values.combineExpireProjectInviteDays | quote }}
   COMBINE_FRONTEND_SERVER_NAME: {{ .Values.global.serverName | quote }}
   COMBINE_SMTP_ADDRESS: {{ .Values.combineSmtpAddress | quote }}
   COMBINE_SMTP_FROM: {{ .Values.combineSmtpFrom | quote }}

--- a/deploy/helm/thecombine/charts/maintenance/templates/aws-s3-credentials.yaml
+++ b/deploy/helm/thecombine/charts/maintenance/templates/aws-s3-credentials.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   creationTimestamp: null
-  name: aws-s3-credentials
+  name: {{ .Values.global.awsS3Access | quote }}
   namespace: {{ .Release.Namespace | quote }}
 type: Opaque
 data:


### PR DESCRIPTION
Backend is broken in new deployments with Rancher. These didn't cause a problem in existing QA and production deployments because the correct environment variables were either grandfathered in or added manually.

3 backend values were being looked for in `global`, but were defined outside `global` in https://github.com/sillsdev/TheCombine/blob/master/deploy/helm/thecombine/charts/backend/values.yaml.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4188)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined backend configuration value references for email verification, password reset, and project invite expiry settings.
  * Enhanced AWS S3 credentials naming to support dynamic environment-specific configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->