### PR TITLE
[deploy] Use Helm's `upgrade --install`

### DIFF
--- a/deploy/helm/create-admin-user/templates/job-create-admin-user.yaml
+++ b/deploy/helm/create-admin-user/templates/job-create-admin-user.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
-    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   # keep completed jobs for 24 hrs so that logs are

--- a/deploy/helm/thecombine/charts/database/templates/database.yaml
+++ b/deploy/helm/thecombine/charts/database/templates/database.yaml
@@ -56,6 +56,7 @@ spec:
                   - /bin/sh
                   - -c
                   - |
+                    exec > /data/db/postStart.log 2>&1
                     set -e
                     echo "[postStart] Waiting for mongod to accept connections"
                     attempts=0

--- a/deploy/helm/thecombine/templates/letsencrypt-prod.yaml
+++ b/deploy/helm/thecombine/templates/letsencrypt-prod.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.certManager.enabled }}
+{{- if and .Values.certManager.enabled (eq .Values.certManager.certIssuer "letsencrypt-prod") }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:

--- a/deploy/helm/thecombine/templates/letsencrypt-staging.yaml
+++ b/deploy/helm/thecombine/templates/letsencrypt-staging.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.certManager.enabled }}
+{{- if and .Values.certManager.enabled (eq .Values.certManager.certIssuer "letsencrypt-staging") }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:

--- a/deploy/helm/thecombine/templates/self-signed.yaml
+++ b/deploy/helm/thecombine/templates/self-signed.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.certManager.enabled }}
+{{- if and .Values.certManager.enabled (eq .Values.certManager.certIssuer "self-signed") }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:

--- a/deploy/scripts/enum_types.py
+++ b/deploy/scripts/enum_types.py
@@ -4,16 +4,6 @@ from enum import Enum, unique
 
 
 @unique
-class HelmAction(Enum):
-    """Enumerate helm commands for maintaining The Combine on the target system."""
-
-    INSTALL = "install"
-    """INSTALL is used when the chart is not already installed on the target."""
-    UPGRADE = "upgrade"
-    """UPGRADE is used when the chart is already installed."""
-
-
-@unique
 class ExitStatus(Enum):
     SUCCESS = 0
     FAILURE = 1

--- a/deploy/scripts/helm_utils.py
+++ b/deploy/scripts/helm_utils.py
@@ -45,7 +45,7 @@ def create_secrets(
 
 def get_installed_charts(helm_cmd: List[str], helm_namespace: str) -> List[str]:
     """Create a list of the helm charts that are already installed on the target."""
-    lookup_results = run_cmd(helm_cmd + ["list", "-a", "-n", helm_namespace, "-o", "yaml"])
+    lookup_results = run_cmd(helm_cmd + ["list", "-n", helm_namespace, "-o", "yaml"])
     chart_info: List[Dict[str, str]] = yaml.safe_load(lookup_results.stdout)
     chart_list: List[str] = []
     for chart in chart_info:

--- a/deploy/scripts/helm_utils.py
+++ b/deploy/scripts/helm_utils.py
@@ -45,7 +45,7 @@ def create_secrets(
 
 def get_installed_charts(helm_cmd: List[str], helm_namespace: str) -> List[str]:
     """Create a list of the helm charts that are already installed on the target."""
-    lookup_results = run_cmd(helm_cmd + ["list", "--all", "-n", helm_namespace, "-o", "yaml"])
+    lookup_results = run_cmd(helm_cmd + ["list", "-n", helm_namespace, "-o", "yaml"])
     chart_info: List[Dict[str, str]] = yaml.safe_load(lookup_results.stdout)
     chart_list: List[str] = []
     for chart in chart_info:

--- a/deploy/scripts/helm_utils.py
+++ b/deploy/scripts/helm_utils.py
@@ -45,7 +45,7 @@ def create_secrets(
 
 def get_installed_charts(helm_cmd: List[str], helm_namespace: str) -> List[str]:
     """Create a list of the helm charts that are already installed on the target."""
-    lookup_results = run_cmd(helm_cmd + ["list", "-n", helm_namespace, "-o", "yaml"])
+    lookup_results = run_cmd(helm_cmd + ["list", "--all", "-n", helm_namespace, "-o", "yaml"])
     chart_info: List[Dict[str, str]] = yaml.safe_load(lookup_results.stdout)
     chart_list: List[str] = []
     for chart in chart_info:

--- a/deploy/scripts/setup_cluster.py
+++ b/deploy/scripts/setup_cluster.py
@@ -11,7 +11,7 @@ import sys
 import tempfile
 from typing import Any, Dict, List
 
-from enum_types import ExitStatus, HelmAction
+from enum_types import ExitStatus
 from kube_env import KubernetesEnvironment, add_helm_opts, add_kube_opts
 from utils import init_logging, run_cmd
 import yaml
@@ -102,12 +102,6 @@ def main() -> None:
         # existing repos.
         run_cmd(["helm", "repo", "update"], print_cmd=not args.quiet, print_output=not args.quiet)
 
-    # List current charts
-    chart_list_results = run_cmd(["helm", "list", "-A", "-o", "yaml"])
-    curr_charts: List[str] = []
-    for chart in yaml.safe_load(chart_list_results.stdout):
-        curr_charts.append(chart["name"])
-
     # Add the current script directory to the OS Environment variables
     os.environ["SCRIPTS_DIR"] = str(scripts_dir)
     # Add an empty analytics key if not defined in the OS Environment variables
@@ -121,15 +115,13 @@ def main() -> None:
         chart_spec = config[chart_descr]["chart"]
         # install the chart
         helm_cmd = kube_env.get_helm_cmd()
-        if chart_spec["name"] in curr_charts:
-            helm_action = HelmAction.UPGRADE
-        else:
-            helm_action = HelmAction.INSTALL
         helm_cmd.extend(
             [
                 "-n",
                 chart_spec["namespace"],
-                helm_action.value,
+                "upgrade",
+                "--install",
+                "--create-namespace",
                 chart_spec["name"],
             ]
         )
@@ -146,16 +138,14 @@ def main() -> None:
             # chart is a *.tgz file
             chart_files = list((Path(args.chart_dir).resolve() / chart_spec["name"]).glob("*.tgz"))
             if not chart_files:
-                logging.error(f"No chart file for {chart['name']} in {args.chart_dir}.")
+                logging.error(f"No chart file for {chart_spec['name']} in {args.chart_dir}.")
                 sys.exit(1)
             if len(chart_files) > 1:
                 logging.warning(
-                    f"Expecting 1 chart file for {chart['name']}, found {len(chart_files)}"
+                    f"Expecting 1 chart file for {chart_spec['name']}, found {len(chart_files)}"
                 )
             helm_cmd.append(str(chart_files[0]))
 
-        if helm_action == HelmAction.INSTALL:
-            helm_cmd.append("--create-namespace")
         if ("wait" in chart_spec and chart_spec["wait"]) or args.timeout is not None:
             helm_cmd.append("--wait")
             if args.timeout is not None:
@@ -177,7 +167,7 @@ def main() -> None:
             # command is running
             exit_status = os.waitstatus_to_exitcode(os.system(helm_cmd_str))
             logging.info(
-                f'helm {helm_action.value} of {chart_spec["name"]} '
+                f'helm install/upgrade of {chart_spec["name"]} '
                 + f"returned exit status {hex(exit_status)}"
             )
             if exit_status != 0:

--- a/deploy/scripts/setup_cluster.py
+++ b/deploy/scripts/setup_cluster.py
@@ -139,7 +139,7 @@ def main() -> None:
             chart_files = list((Path(args.chart_dir).resolve() / chart_spec["name"]).glob("*.tgz"))
             if not chart_files:
                 logging.error(f"No chart file for {chart_spec['name']} in {args.chart_dir}.")
-                sys.exit(1)
+                sys.exit(ExitStatus.FAILURE.value)
             if len(chart_files) > 1:
                 logging.warning(
                     f"Expecting 1 chart file for {chart_spec['name']}, found {len(chart_files)}"

--- a/deploy/scripts/setup_combine.py
+++ b/deploy/scripts/setup_combine.py
@@ -207,8 +207,8 @@ def main() -> None:
             # Create the base helm install command
             chart_dir = helm_dir / chart
             helm_install_cmd = helm_cmd + [
-                "--dependency-update",
                 "upgrade",
+                "--dependency-update",
                 "--install",
                 chart,
                 str(chart_dir),

--- a/deploy/scripts/setup_combine.py
+++ b/deploy/scripts/setup_combine.py
@@ -28,7 +28,7 @@ from typing import Any, Dict, List
 from app_release import get_release
 from aws_env import init_aws_environment
 import combine_charts
-from enum_types import ExitStatus, HelmAction
+from enum_types import ExitStatus
 from helm_utils import (
     add_language_overrides,
     add_override_values,
@@ -185,14 +185,10 @@ def main() -> None:
             logging.debug(f"Installed charts: {installed_charts}")
 
             # Set helm_action based on whether chart is already installed
-            helm_action = HelmAction.INSTALL
-            if chart in installed_charts:
-                if args.clean:
-                    # Delete existing chart if --clean specified
-                    delete_cmd = helm_cmd + [f"--namespace={chart_namespace}", "delete", chart]
-                    run_cmd(delete_cmd, print_cmd=not args.quiet, print_output=True)
-                else:
-                    helm_action = HelmAction.UPGRADE
+            if args.clean and chart in installed_charts:
+                # Delete existing chart if --clean specified
+                delete_cmd = helm_cmd + [f"--namespace={chart_namespace}", "delete", chart]
+                run_cmd(delete_cmd, print_cmd=not args.quiet, print_output=True)
 
             # Build the secrets file
             secrets_file = Path(secrets_dir).resolve() / f"secrets_{chart}.yaml"
@@ -207,7 +203,8 @@ def main() -> None:
             helm_install_cmd = helm_cmd + [
                 "--dependency-update",
                 f"--namespace={chart_namespace}",
-                helm_action.value,
+                "upgrade",
+                "--install",
                 chart,
                 str(chart_dir),
             ]

--- a/deploy/scripts/setup_combine.py
+++ b/deploy/scripts/setup_combine.py
@@ -185,15 +185,20 @@ def main() -> None:
                 installed_charts = get_installed_charts(helm_cmd, chart_namespace)
             logging.debug(f"Installed charts: {installed_charts}")
 
-            namespace_cmd = helm_cmd + [f"--namespace={chart_namespace}"]
-            # Set the dry-run option if desired
-            if args.dry_run:
-                namespace_cmd.append("--dry-run")
+            namespace_cmd = helm_cmd + ["--namespace", chart_namespace]
 
-            # Delete existing chart if --clean specified
-            if args.clean and chart in installed_charts:
-                delete_cmd = namespace_cmd + ["delete", chart]
-                run_cmd(delete_cmd, print_cmd=not args.quiet, print_output=True)
+            if chart in installed_charts:
+                # Delete existing chart if --clean specified
+                if args.clean:
+                    delete_cmd = namespace_cmd + ["delete", chart]
+                    if args.dry_run:
+                        delete_cmd.append("--dry-run")
+                    run_cmd(delete_cmd, print_cmd=not args.quiet, print_output=True)
+
+                # Skip existing install-only chart unless --clean specified
+                elif config["charts"][chart].get("install_only", False):
+                    logging.info(f"Skipping install-only chart '{chart}' (already installed)")
+                    continue
 
             # Build the secrets file
             secrets_file = Path(secrets_dir).resolve() / f"secrets_{chart}.yaml"
@@ -204,14 +209,15 @@ def main() -> None:
             )
 
             # Create the base helm install/upgrade command
-            chart_dir = helm_dir / chart
             helm_install_cmd = namespace_cmd + [
                 "upgrade",
                 "--dependency-update",
                 "--install",
                 chart,
-                str(chart_dir),
+                str(helm_dir / chart),
             ]
+            if args.dry_run:
+                helm_install_cmd.append("--dry-run")
 
             # Set wait and timeout options
             if args.wait or args.timeout is not None:

--- a/deploy/scripts/setup_combine.py
+++ b/deploy/scripts/setup_combine.py
@@ -146,6 +146,7 @@ def main() -> None:
     kube_env = KubernetesEnvironment(args)
     # Cache helm command used to alter the target cluster
     helm_cmd = kube_env.get_helm_cmd()
+
     # Check AWS Environment Variables
     init_aws_environment()
 
@@ -184,6 +185,7 @@ def main() -> None:
                 installed_charts = get_installed_charts(helm_cmd, chart_namespace)
             logging.debug(f"Installed charts: {installed_charts}")
 
+            namespace_cmd = helm_cmd + [f"--namespace={chart_namespace}"]
             # Set the dry-run option if desired
             if args.dry_run:
                 helm_cmd.append("--dry-run")
@@ -191,7 +193,7 @@ def main() -> None:
             # Set helm_action based on whether chart is already installed
             if args.clean and chart in installed_charts:
                 # Delete existing chart if --clean specified
-                delete_cmd = helm_cmd + [f"--namespace={chart_namespace}", "delete", chart]
+                delete_cmd = namespace_cmd + ["delete", chart]
                 run_cmd(delete_cmd, print_cmd=not args.quiet, print_output=True)
 
             # Build the secrets file
@@ -206,7 +208,6 @@ def main() -> None:
             chart_dir = helm_dir / chart
             helm_install_cmd = helm_cmd + [
                 "--dependency-update",
-                f"--namespace={chart_namespace}",
                 "upgrade",
                 "--install",
                 chart,

--- a/deploy/scripts/setup_combine.py
+++ b/deploy/scripts/setup_combine.py
@@ -190,9 +190,8 @@ def main() -> None:
             if args.dry_run:
                 helm_cmd.append("--dry-run")
 
-            # Set helm_action based on whether chart is already installed
+            # Delete existing chart if --clean specified
             if args.clean and chart in installed_charts:
-                # Delete existing chart if --clean specified
                 delete_cmd = namespace_cmd + ["delete", chart]
                 run_cmd(delete_cmd, print_cmd=not args.quiet, print_output=True)
 
@@ -204,7 +203,7 @@ def main() -> None:
                 env_vars_req=this_config["env_vars_required"],
             )
 
-            # Create the base helm install command
+            # Create the base helm install/upgrade command
             chart_dir = helm_dir / chart
             helm_install_cmd = helm_cmd + [
                 "upgrade",

--- a/deploy/scripts/setup_combine.py
+++ b/deploy/scripts/setup_combine.py
@@ -184,6 +184,10 @@ def main() -> None:
                 installed_charts = get_installed_charts(helm_cmd, chart_namespace)
             logging.debug(f"Installed charts: {installed_charts}")
 
+            # Set the dry-run option if desired
+            if args.dry_run:
+                helm_cmd.append("--dry-run")
+
             # Set helm_action based on whether chart is already installed
             if args.clean and chart in installed_charts:
                 # Delete existing chart if --clean specified
@@ -208,10 +212,6 @@ def main() -> None:
                 chart,
                 str(chart_dir),
             ]
-
-            # Set the dry-run option if desired
-            if args.dry_run:
-                helm_install_cmd.append("--dry-run")
 
             # Set wait and timeout options
             if args.wait or args.timeout is not None:

--- a/deploy/scripts/setup_combine.py
+++ b/deploy/scripts/setup_combine.py
@@ -188,7 +188,7 @@ def main() -> None:
             namespace_cmd = helm_cmd + [f"--namespace={chart_namespace}"]
             # Set the dry-run option if desired
             if args.dry_run:
-                helm_cmd.append("--dry-run")
+                namespace_cmd.append("--dry-run")
 
             # Delete existing chart if --clean specified
             if args.clean and chart in installed_charts:
@@ -205,7 +205,7 @@ def main() -> None:
 
             # Create the base helm install/upgrade command
             chart_dir = helm_dir / chart
-            helm_install_cmd = helm_cmd + [
+            helm_install_cmd = namespace_cmd + [
                 "upgrade",
                 "--dependency-update",
                 "--install",

--- a/deploy/scripts/setup_files/combine_config.yaml
+++ b/deploy/scripts/setup_files/combine_config.yaml
@@ -156,6 +156,7 @@ charts:
   create-admin-user:
     namespace: thecombine
     install_langs: false
+    install_only: true
     secrets:
       - config_item: awsAccount
         env_var: AWS_ACCOUNT


### PR DESCRIPTION
https://app.devin.ai/review/sillsdev/TheCombine/pull/4207

Goals of this PR:
- Fix setup not working with Rancher Desktop on Ubuntu 24.04
   - Remove `-a`/`--all`, not a valid flag in all settings, and doesn't help us since it lists non-deployed things (e.g., failed), which we don't handle anyway
- No longer unnecessarily dictate upgrade vs install
- Ensure `--clean` respects `--dry-run`
- Only run `create-admin-user` on install, not on upgrade

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4207)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Certificate issuer resources now only activate for the explicitly configured issuer type.
  * Chart discovery now correctly scopes results to the target namespace.

* **Improvements**
  * Chart deployment workflow simplified to a single upgrade/install path for consistency.
  * A create-admin-user job now runs only on initial install; an install-only setting prevents it from re-running on upgrades.
  * Clean installs and dry-run behavior made more consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->