### PR TITLE
[deploy] Update otel config

### DIFF
--- a/deploy/scripts/setup_files/cluster_config.yaml
+++ b/deploy/scripts/setup_files/cluster_config.yaml
@@ -25,7 +25,7 @@ otel:
     name: otel
     reference: open-telemetry/opentelemetry-collector
     namespace: thecombine
-    version: 0.122.5
+    version: 0.147.1
     wait: true
     # Additional arguments to pass to helm install/upgrade
     # values inside curly braces ({}) are interpreted as

--- a/deploy/scripts/setup_files/collector_config.yaml
+++ b/deploy/scripts/setup_files/collector_config.yaml
@@ -1,8 +1,8 @@
-mode: "deployment"
+mode: deployment
 namespaceOverride: "thecombine"
 image:
   repository: "otel/opentelemetry-collector-k8s"
-  tag: 0.123.0
+  tag: 0.147.0
 config:
   receivers:
     jaeger: null
@@ -23,16 +23,11 @@ config:
     telemetry:
       logs:
         level: "INFO"
-      metrics:
-        address: null
     pipelines:
       traces:
-        receivers:
-          - otlp
-        processors:
-          - batch
-        exporters:
-          - otlp
+        receivers: [otlp]
+        processors: [batch]
+        exporters: [otlp]
       metrics: null
       logs: null
 ports:

--- a/deploy/scripts/setup_files/collector_config.yaml
+++ b/deploy/scripts/setup_files/collector_config.yaml
@@ -2,7 +2,6 @@ mode: deployment
 namespaceOverride: "thecombine"
 image:
   repository: "otel/opentelemetry-collector-k8s"
-  tag: 0.147.0
 config:
   receivers:
     jaeger: null


### PR DESCRIPTION
Newest helm chart is 0.147.1:

- https://artifacthub.io/packages/helm/opentelemetry-helm/opentelemetry-collector

Removed:

- `image.tag`: defaults to application version
- `config.receivers.telemetry.metrics.address`: no longer in chart to override

Devin review: https://app.devin.ai/review/sillsdev/TheCombine/pull/4220

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4220)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated OpenTelemetry Collector Helm chart version from 0.122.5 to 0.147.1.
  * Simplified telemetry configuration by removing unused settings and restructuring pipeline definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->