### PR TITLE
[gha] Allow QA deployments to be manually triggered

### DIFF
--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -2,6 +2,11 @@ name: "Deploy Update to QA Server"
 
 on:
   workflow_dispatch:
+    inputs:
+      confirm_qa_deploy:
+        description: "Type QA to confirm QA deployment"
+        required: true
+        default: ""
   push:
     branches: [master]
 
@@ -104,6 +109,7 @@ jobs:
           fi
   deploy_update:
     needs: build
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.confirm_qa_deploy == 'QA')
     runs-on: [self-hosted, thecombine]
     steps:
       - name: Harden Runner

--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -1,6 +1,7 @@
 name: "Deploy Update to QA Server"
 
 on:
+  workflow_dispatch:
   push:
     branches: [master]
 
@@ -103,8 +104,6 @@ jobs:
           fi
   deploy_update:
     needs: build
-    # Only push to the QA server when built on the master branch
-    if: github.ref_name == 'master'
     runs-on: [self-hosted, thecombine]
     steps:
       - name: Harden Runner

--- a/.github/workflows/installer_release.yml
+++ b/.github/workflows/installer_release.yml
@@ -2,6 +2,11 @@ name: installer_release
 
 on:
   workflow_dispatch:
+    inputs:
+      confirm_upload:
+        description: "Type UP to confirm installer upload"
+        required: true
+        default: ""
   workflow_run:
     workflows: ["Deploy Update to Live Server"]
     types:
@@ -13,7 +18,7 @@ permissions:
 jobs:
   make_installer:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     outputs:
       release_tag: ${{ steps.release.outputs.tag }}
     steps:
@@ -74,6 +79,7 @@ jobs:
 
   upload_installer:
     needs: make_installer
+    if: github.event_name == 'workflow_run' || (github.event_name == 'workflow_dispatch' && github.event.inputs.confirm_upload == 'UP')
     runs-on: ubuntu-latest
     steps:
       # See https://docs.stepsecurity.io/harden-runner/getting-started/ for instructions on


### PR DESCRIPTION
Allow testing of #4216

https://app.devin.ai/review/sillsdev/TheCombine/pull/4227

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4227)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * QA deployment workflow now supports manual triggering with a confirmation gate to allow targeted QA deploys.
  * Installer release workflow now supports manual uploads with a confirmation gate, and updated conditions to run automatically after successful upstream builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->