### PR TITLE
Make backend copy more granular

### DIFF
--- a/maintenance/scripts/combine_restore.py
+++ b/maintenance/scripts/combine_restore.py
@@ -201,7 +201,17 @@ def main() -> None:
                 ],
             )
 
-        combine.kubectl(["cp", backend_files_subdir, f"{backend_pod}:/home/app", "--no-preserve"])
+        # Iterate through every item in the backend subdirectory
+        remote_subdir = f"{backend_pod}:/home/app/{backend_files_subdir}"
+        logging.info(f"Copying contents of {backend_files_subdir} to {remote_subdir} ...")
+        for item in os.listdir(backend_files_subdir):
+            if item.startswith(".") or item == "lost+found":
+                logging.info(f"Skipping {item} ...")
+                continue
+            logging.info(f"Copying {item} ...")
+            local_item = os.path.join(backend_files_subdir, item)
+            remote_item = f"{remote_subdir}/{item}"
+            combine.kubectl(["cp", local_item, remote_item, "--no-preserve"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Three benefits to this pr:

- Skip unintended system files (esp. `lost+found`)
- When `--verbose` is used, shows copy progress
- If there's a copy error (e.g., permission denied to copy into `.CombineFiles`), `kubectl` will fail more quickly

https://app.devin.ai/review/sillsdev/TheCombine/pull/4230

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4230)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved backend file restoration reliability and transparency through enhanced item-by-item handling and comprehensive operation logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->