### PR TITLE
[helm] Give backend permission to write to mounted backend-data pvc

### DIFF
--- a/deploy/helm/thecombine/charts/backend/templates/deployment-backend.yaml
+++ b/deploy/helm/thecombine/charts/backend/templates/deployment-backend.yaml
@@ -124,6 +124,8 @@ spec:
             - mountPath: /home/app/.CombineFiles
               name: backend-data
       restartPolicy: Always
+      securityContext:
+        fsGroup: 999
 {{- if ne .Values.global.pullSecretName "None" }}
       imagePullSecrets:
          - name: {{ .Values.global.pullSecretName }}


### PR DESCRIPTION
Something about the spawning of PVCs in a Helm install has changed so that a fresh install on QA doesn't give the backend permission to write to its mounted `backend-data` PVC. That prevents LIFT upload, audio recording, avatars, restore-script, and adding speaker consent.

Here is the permission of `/home/app/.CombineFiles` in the various settings:

| setting | permissions | owner | group | note |
| :--- | :--- | :--- | :--- | :--- |
| prod |  `drwxr-xr-x` | `app` | `app` | don't know how it got this way |
|  qa deployed without this fix | `drwxr-xr-x` | `root` | `root` | permission denied |
| qa deployed with this fix | `drwxrwsr-x` | `root` | `app` | different from prod, but works |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4231)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes deployment configuration with enhanced security settings for file system permissions in the container environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->