### PR TITLE
Add folders to the local cleanup script

### DIFF
--- a/scripts/cleanup_local_repo.py
+++ b/scripts/cleanup_local_repo.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-"""Remove all temporary files and folders within the local Git repository.
+"""Remove temporary files and folders within the local Git repository.
 
-The purpose of this script is to get a developer back to a clean baseline in
+The purpose of this script is to get a developer back to a cleaner baseline in
 the event their repository state does not match other developers or CI.
 """
 
@@ -11,7 +11,19 @@ import shutil
 
 
 def main() -> None:
-    dirs_to_remove = (".mypy_cache", ".parcel-cache", ".tox", "dist", "node_modules", "venv")
+    dirs_to_remove = (
+        ".mypy_cache",
+        ".parcel-cache",
+        ".tox",
+        "Backend/bin",
+        "Backend/obj",
+        "Backend.Tests/bin",
+        "Backend.Tests/obj",
+        "dist",
+        "node_modules",
+        "parcel-bundle-reports",
+        "venv",
+    )
     files_to_delete = (".env.backend", ".env.certmgr", ".env.frontend", "docker-compose.yml")
 
     print(


### PR DESCRIPTION
Doesn't get everything, and cannot unless refactored to recursively search (e.g., for `__pycache__` folder, `Chart.lock` and `Chart.yaml` files) and pattern match (e.g. `*.srt` and `*.mps` files).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4235)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the cleanup script to remove additional build artifacts including .NET output directories and parcel bundle reports.
  * Clarified script documentation for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->