### PR TITLE
[maintenance] In rm_project.py, print project being removed

### DIFF
--- a/maintenance/scripts/rm_project.py
+++ b/maintenance/scripts/rm_project.py
@@ -41,9 +41,6 @@ def parse_args() -> argparse.Namespace:
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument("projects", nargs="*", help="Project(s) to be removed from The Combine.")
-    parser.add_argument(
-        "--verbose", action="store_true", help="Print intermediate values to aid in debugging"
-    )
     return parser.parse_args()
 
 
@@ -68,11 +65,10 @@ def main() -> None:
     combine = CombineApp()
 
     for project in args.projects:
+        print(f"Remove project {project}")
         project_id = combine.get_project_id(project)
         if project_id:
-            if args.verbose:
-                print(f"Remove project {project}")
-                print(f"Project ID: {project_id}")
+            print(f"Project ID: {project_id}")
             for collection in collections_with_project_id:
                 combine.db_cmd(db_delete_from_collection(project_id, collection))
             for field in user_fields_with_project_id:


### PR DESCRIPTION
The `--verbosity` flag only results in project name and id being printed. Those should be printed by default, especially since this script is only ever run manually, and not by any other script/process that could benefit from quieter output.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4238)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the project removal maintenance script by removing the `--verbose` command-line flag. Output messages are now displayed unconditionally during script execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->