### PR TITLE
[combine_restore] Prevent nesting

### DIFF
--- a/maintenance/scripts/aws_backup.py
+++ b/maintenance/scripts/aws_backup.py
@@ -21,12 +21,12 @@ class AwsBackup:
     def push(self, src: Path, dest: str) -> subprocess.CompletedProcess[str]:
         """Push a file to the AWS S3 bucket."""
         s3_uri = f"{self.bucket}/{dest}"
-        return run_cmd(["aws", "s3", "cp", str(src), s3_uri])
+        return run_cmd(["aws", "s3", "cp", "--no-progress", str(src), s3_uri])
 
     def pull(self, src: str, dest: Path) -> subprocess.CompletedProcess[str]:
-        """Push a file to the AWS S3 bucket."""
+        """Pull a file from the AWS S3 bucket."""
         s3_uri = f"{self.bucket}/{src}"
-        return run_cmd(["aws", "s3", "cp", s3_uri, str(dest)])
+        return run_cmd(["aws", "s3", "cp", "--no-progress", s3_uri, str(dest)])
 
     def list(self) -> subprocess.CompletedProcess[str]:
         """List the objects in the S3 bucket."""

--- a/maintenance/scripts/combine_restore.py
+++ b/maintenance/scripts/combine_restore.py
@@ -187,14 +187,12 @@ def main() -> None:
             logging.info(f"Cleaning out backend files in {backend_pod} ...")
             # we run the rm command inside a bash shell so that the shell will do wildcard
             # expansion
-            combine.exec(
+            clean_proc = combine.exec(
                 backend_pod,
-                [
-                    "/bin/bash",
-                    "-c",
-                    f"rm -rf /home/app/{backend_files_subdir}/*",
-                ],
+                ["/bin/bash", "-c", f"rm -rf /home/app/{backend_files_subdir}/*"],
             )
+            logging.debug(f"stderr:\n{clean_proc.stderr.strip()}")
+            logging.debug(f"stdout:\n{clean_proc.stdout.strip()}")
 
         # Iterate through every item in the backend subdirectory
         remote_subdir = f"{backend_pod}:/home/app/{backend_files_subdir}/"

--- a/maintenance/scripts/combine_restore.py
+++ b/maintenance/scripts/combine_restore.py
@@ -120,7 +120,9 @@ def main() -> None:
 
         step.print(f"Fetch the selected backup, {backup}.")
 
-        aws.pull(backup, Path(restore_dir) / restore_file)
+        aws_proc = aws.pull(backup, Path(restore_dir) / restore_file)
+        logging.debug(f"stderr:\n{aws_proc.stderr.strip()}")
+        logging.debug(f"stdout:\n{aws_proc.stdout.strip()}")
 
         step.print("Unpack the backup.")
         os.chdir(restore_dir)
@@ -156,35 +158,23 @@ def main() -> None:
         if not db_pod:
             logging.error("Cannot find the database container.")
             sys.exit(1)
+
         logging.debug(f"Copying {db_files_subdir} to {db_pod} ...")
-        combine.kubectl(
-            [
-                "cp",
-                db_files_subdir,
-                f"{db_pod}:/",
-            ]
-        )
+        cp_proc = combine.kubectl(["cp", db_files_subdir, f"{db_pod}:/"])
+        logging.debug(f"stderr:\n{cp_proc.stderr.strip()}")
+        logging.debug(f"stdout:\n{cp_proc.stdout.strip()}")
 
         logging.debug(f"Running mongorestore on {db_pod} ...")
-        mongorestore_cmd = [
-            "mongorestore",
-            "--drop",
-            "--gzip",
-            f"--dir=/{db_files_subdir}",
-        ]
-        if not args.verbose:
-            mongorestore_cmd.append("--quiet")
-        combine.exec(db_pod, mongorestore_cmd)
+        mongorestore_proc = combine.exec(
+            db_pod, ["mongorestore", "--drop", "--gzip", f"--dir=/{db_files_subdir}"]
+        )
+        logging.debug(f"stderr:\n{mongorestore_proc.stderr.strip()}")
+        logging.debug(f"stdout:\n{mongorestore_proc.stdout.strip()}")
 
         logging.debug(f"Removing {db_files_subdir} from {db_pod} ...")
-        combine.exec(
-            db_pod,
-            [
-                "rm",
-                "-rf",
-                f"/{db_files_subdir}",
-            ],
-        )
+        rm_proc = combine.exec(db_pod, ["rm", "-rf", f"/{db_files_subdir}"])
+        logging.debug(f"stderr:\n{rm_proc.stderr.strip()}")
+        logging.debug(f"stdout:\n{rm_proc.stdout.strip()}")
 
         step.print("Copy the backend files.")
         backend_pod = combine.get_pod_id(CombineApp.Component.Backend)

--- a/maintenance/scripts/combine_restore.py
+++ b/maintenance/scripts/combine_restore.py
@@ -202,7 +202,7 @@ def main() -> None:
             )
 
         # Iterate through every item in the backend subdirectory
-        remote_subdir = f"{backend_pod}:/home/app/{backend_files_subdir}"
+        remote_subdir = f"{backend_pod}:/home/app/{backend_files_subdir}/"
         logging.info(f"Copying contents of {backend_files_subdir} to {remote_subdir} ...")
         for item in os.listdir(backend_files_subdir):
             if item.startswith(".") or item == "lost+found":
@@ -210,8 +210,7 @@ def main() -> None:
                 continue
             logging.info(f"Copying {item} ...")
             local_item = os.path.join(backend_files_subdir, item)
-            remote_item = f"{remote_subdir}/{item}"
-            combine.kubectl(["cp", local_item, remote_item, "--no-preserve"])
+            combine.kubectl(["cp", local_item, remote_subdir, "--no-preserve"])
 
 
 if __name__ == "__main__":

--- a/maintenance/scripts/combine_restore.py
+++ b/maintenance/scripts/combine_restore.py
@@ -82,7 +82,7 @@ def main() -> None:
             backup = args.file
         else:
             # Get the list of backups
-            backup_list_output = aws.list().stdout.strip().split("\n")
+            backup_list_output = [line for line in aws.list().stdout.strip().split("\n") if line]
 
             if len(backup_list_output) == 0:
                 logging.warning(f"No backups available from {aws_bucket}")

--- a/maintenance/scripts/combine_restore.py
+++ b/maintenance/scripts/combine_restore.py
@@ -63,9 +63,9 @@ def main() -> None:
     """Restore The Combine from a backup stored in the AWS S3 service."""
     args = parse_args()
     if args.verbose:
-        logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.INFO)
+        logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.DEBUG)
     else:
-        logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.WARNING)
+        logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.INFO)
     # Look up the required environment variables
     aws_bucket, db_files_subdir, backend_files_subdir = check_env_vars(
         ["aws_bucket", "db_files_subdir", "backend_files_subdir"]
@@ -85,7 +85,7 @@ def main() -> None:
             backup_list_output = aws.list().stdout.strip().split("\n")
 
             if len(backup_list_output) == 0:
-                print(f"No backups available from {aws_bucket}")
+                logging.warning(f"No backups available from {aws_bucket}")
                 sys.exit(0)
 
             # Convert the list of backups to a more useful structure
@@ -154,8 +154,9 @@ def main() -> None:
         step.print("Restore the database.")
         db_pod = combine.get_pod_id(CombineApp.Component.Database)
         if not db_pod:
-            print("Cannot find the database container.", file=sys.stderr)
+            logging.error("Cannot find the database container.")
             sys.exit(1)
+        logging.debug(f"Copying {db_files_subdir} to {db_pod} ...")
         combine.kubectl(
             [
                 "cp",
@@ -164,16 +165,18 @@ def main() -> None:
             ]
         )
 
-        combine.exec(
-            db_pod,
-            [
-                "mongorestore",
-                "--drop",
-                "--gzip",
-                "--quiet",
-                f"--dir=/{db_files_subdir}",
-            ],
-        )
+        logging.debug(f"Running mongorestore on {db_pod} ...")
+        mongorestore_cmd = [
+            "mongorestore",
+            "--drop",
+            "--gzip",
+            f"--dir=/{db_files_subdir}",
+        ]
+        if not args.verbose:
+            mongorestore_cmd.append("--quiet")
+        combine.exec(db_pod, mongorestore_cmd)
+
+        logging.debug(f"Removing {db_files_subdir} from {db_pod} ...")
         combine.exec(
             db_pod,
             [
@@ -186,10 +189,12 @@ def main() -> None:
         step.print("Copy the backend files.")
         backend_pod = combine.get_pod_id(CombineApp.Component.Backend)
         if not backend_pod:
-            print("Cannot find the backend container.", file=sys.stderr)
+            logging.error("Cannot find the backend container.")
             sys.exit(1)
+
         # if --clean option was used, delete the existing backend files
         if args.clean:
+            logging.info(f"Cleaning out backend files in {backend_pod} ...")
             # we run the rm command inside a bash shell so that the shell will do wildcard
             # expansion
             combine.exec(
@@ -203,12 +208,12 @@ def main() -> None:
 
         # Iterate through every item in the backend subdirectory
         remote_subdir = f"{backend_pod}:/home/app/{backend_files_subdir}/"
-        logging.info(f"Copying contents of {backend_files_subdir} to {remote_subdir} ...")
+        logging.debug(f"Copying contents of {backend_files_subdir} to {remote_subdir} ...")
         for item in os.listdir(backend_files_subdir):
             if item.startswith(".") or item == "lost+found":
-                logging.info(f"Skipping {item} ...")
+                logging.debug(f"Skipping {item} ...")
                 continue
-            logging.info(f"Copying {item} ...")
+            logging.debug(f"Copying {item} ...")
             local_item = os.path.join(backend_files_subdir, item)
             combine.kubectl(["cp", local_item, remote_subdir, "--no-preserve"])
 


### PR DESCRIPTION
- Fix a bug introduced in #4230 where folders were accidentally nested when the script was run without `--clean`.
- Fix a pre-existing bug when aws returns an empty list of available backups, which was processed as `[""]` not `[]`.
- Update logging/debugging

This update has been tested both with and without `--clean`.

https://app.devin.ai/review/sillsdev/TheCombine/pull/4241

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4241)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Backend file copy during restore now reliably places items into the correct destination directory.
  * Replaced direct prints with proper warnings/errors when backups are missing or containers are absent.
  * Filtered blank lines from backup listings to avoid spurious entries.

* **Improvements**
  * Logging refined: verbose mode shows detailed debug output for restore steps; normal mode is quieter.
  * Restore operations now capture and record command output for troubleshooting.
  * S3 transfers suppressed progress output for cleaner logs; copy/skip messages are quieter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->