### PR TITLE
Bump aws-kubectl to 0.4.2 to nix useless variable

### DIFF
--- a/deploy/helm/aws-login/templates/aws-ecr-login-cronjob.yaml
+++ b/deploy/helm/aws-login/templates/aws-ecr-login-cronjob.yaml
@@ -54,11 +54,6 @@ spec:
                 configMapKeyRef:
                   key: PULL_SECRET_NAME
                   name: {{ .Values.awsEcr.configName }}
-            - name: DOCKER_EMAIL
-              valueFrom:
-                configMapKeyRef:
-                  key: DOCKER_EMAIL
-                  name: {{ .Values.awsEcr.configName }}
             resources:
               requests:
                 memory: 128Mi

--- a/deploy/helm/aws-login/templates/aws-ecr-login-oneshot.yaml
+++ b/deploy/helm/aws-login/templates/aws-ecr-login-oneshot.yaml
@@ -54,11 +54,6 @@ spec:
             configMapKeyRef:
               key: PULL_SECRET_NAME
               name: "{{ .Values.awsEcr.configName }}"
-        - name: DOCKER_EMAIL
-          valueFrom:
-            configMapKeyRef:
-              key: DOCKER_EMAIL
-              name: "{{ .Values.awsEcr.configName }}"
         resources:
           requests:
             memory: 128Mi

--- a/deploy/helm/aws-login/templates/aws-login-config.yaml
+++ b/deploy/helm/aws-login/templates/aws-login-config.yaml
@@ -7,4 +7,3 @@ metadata:
 data:
   NAMESPACES: "{{ .Release.Namespace }}"
   PULL_SECRET_NAME: "{{ .Values.global.pullSecretName }}"
-  DOCKER_EMAIL: "{{ .Values.awsEcr.dockerEmail }}"

--- a/deploy/helm/aws-login/values.yaml
+++ b/deploy/helm/aws-login/values.yaml
@@ -21,9 +21,8 @@ awsEcr:
   configName: aws-ecr-config
   cron: yes
   cronJobName: ecr-cred-helper-cron
-  dockerEmail: noreply@thecombine.app
   image: "public.ecr.aws/thecombine/aws-kubectl"
-  imageVersion: "0.4.1"
+  imageVersion: "0.4.2"
   jobName: ecr-cred-helper
   schedule: "0 */8 * * *"
   secretsName: aws-ecr-credentials

--- a/deploy/helm/thecombine/charts/maintenance/values.yaml
+++ b/deploy/helm/thecombine/charts/maintenance/values.yaml
@@ -37,7 +37,7 @@ serviceAccount:
 
 awsEcr:
   image: "public.ecr.aws/thecombine/aws-kubectl"
-  imageVersion: "0.4.1"
+  imageVersion: "0.4.2"
 
 #######################################
 # Variables controlling backups

--- a/maintenance/Dockerfile
+++ b/maintenance/Dockerfile
@@ -16,7 +16,7 @@
 #   - ARM 64-bit
 ############################################################
 
-FROM public.ecr.aws/thecombine/aws-kubectl:0.4.1-$TARGETARCH
+FROM public.ecr.aws/thecombine/aws-kubectl:0.4.2-$TARGETARCH
 
 USER root
 


### PR DESCRIPTION
Uses: https://github.com/sillsdev/aws-kubectl/pull/8

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4242)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Docker email configuration requirement from AWS ECR login setup, simplifying deployment configuration.
  * Updated AWS kubectl container image to version 0.4.2 across maintenance and automation configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->