### PR TITLE
[gha] Have combine_deploy_image workflow also delete old images

### DIFF
--- a/.github/workflows/combine_deploy_image.yml
+++ b/.github/workflows/combine_deploy_image.yml
@@ -70,7 +70,7 @@ jobs:
             --query "imageDetails[?imagePushedAt<'${CUTOFF}'].imageDigest" \
             --output text)
           OLD_COUNT=$(printf '%s' "${OLD_DIGESTS}" | awk '{print NF}')
-          if [ "${OLD_COUNT}" -eq 0 ] || [ "${OLD_DIGESTS}" = "None" ]; then
+          if [ -z "${OLD_DIGESTS}" ] || [ "${OLD_DIGESTS}" = "None" ] || [ "${OLD_COUNT}" -eq 0 ]; then
             echo "No images older than 1 year found."
             exit 0
           fi


### PR DESCRIPTION
`public.ecr.aws/thecombine/combine_deploy` is a seldom used option for deploying from a local Linux machine (e.g., onto a connected NUC). The workflow `.github/workflows/combine_deploy_image.yml` updates this image whenever there's any change in `deploy/`. However, there's no cleanup of old images, so we have them going back to August 2023, and each is around 1/3 GB.

This pr adds a final step to the workflow to automatically deletes any image more than a year old.

Devin review: https://app.devin.ai/review/sillsdev/TheCombine/pull/4248

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4248)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated cleanup workflow to remove container images older than one year from the deployment repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->