### PR TITLE
[ReviewEntries > Cells] Don't require function for non-editable cells

### DIFF
--- a/src/goals/ReviewEntries/ReviewEntriesTable/Cells/CellTypes.ts
+++ b/src/goals/ReviewEntries/ReviewEntriesTable/Cells/CellTypes.ts
@@ -1,7 +1,10 @@
 import { type Word } from "api/models";
 
-export interface CellProps {
+export interface ReadonlyCellProps {
+  word: Word;
+}
+
+export interface CellProps extends ReadonlyCellProps {
   delete: (wordId: string) => Promise<void>;
   replace: (oldId: string, newId: string) => Promise<void>;
-  word: Word;
 }

--- a/src/goals/ReviewEntries/ReviewEntriesTable/Cells/DefinitionsCell.tsx
+++ b/src/goals/ReviewEntries/ReviewEntriesTable/Cells/DefinitionsCell.tsx
@@ -1,9 +1,11 @@
 import { type ReactElement } from "react";
 
 import SensesTextSummary from "components/WordCard/SensesTextSummary";
-import { type CellProps } from "goals/ReviewEntries/ReviewEntriesTable/Cells/CellTypes";
+import { type ReadonlyCellProps } from "goals/ReviewEntries/ReviewEntriesTable/Cells/CellTypes";
 
-export default function DefinitionsCell(props: CellProps): ReactElement {
+export default function DefinitionsCell(
+  props: ReadonlyCellProps
+): ReactElement {
   return (
     <SensesTextSummary
       definitionsOrGlosses="definitions"

--- a/src/goals/ReviewEntries/ReviewEntriesTable/Cells/DomainsCell.tsx
+++ b/src/goals/ReviewEntries/ReviewEntriesTable/Cells/DomainsCell.tsx
@@ -2,7 +2,7 @@ import { Chip, Grid2 } from "@mui/material";
 import { type ReactElement } from "react";
 
 import { type SemanticDomain, type Sense } from "api/models";
-import { type CellProps } from "goals/ReviewEntries/ReviewEntriesTable/Cells/CellTypes";
+import { type ReadonlyCellProps } from "goals/ReviewEntries/ReviewEntriesTable/Cells/CellTypes";
 
 /** Collect all distinct sense.semanticDomains entries. */
 export function gatherDomains(senses: Sense[]): SemanticDomain[] {
@@ -17,7 +17,7 @@ export function gatherDomains(senses: Sense[]): SemanticDomain[] {
     .sort((a, b) => a.id.localeCompare(b.id));
 }
 
-export default function DomainsCell(props: CellProps): ReactElement {
+export default function DomainsCell(props: ReadonlyCellProps): ReactElement {
   return (
     <Grid2 container spacing={1}>
       {gatherDomains(props.word.senses).map((dom) => (

--- a/src/goals/ReviewEntries/ReviewEntriesTable/Cells/GlossesCell.tsx
+++ b/src/goals/ReviewEntries/ReviewEntriesTable/Cells/GlossesCell.tsx
@@ -1,9 +1,9 @@
 import { type ReactElement } from "react";
 
 import SensesTextSummary from "components/WordCard/SensesTextSummary";
-import { type CellProps } from "goals/ReviewEntries/ReviewEntriesTable/Cells/CellTypes";
+import { type ReadonlyCellProps } from "goals/ReviewEntries/ReviewEntriesTable/Cells/CellTypes";
 
-export default function GlossesCell(props: CellProps): ReactElement {
+export default function GlossesCell(props: ReadonlyCellProps): ReactElement {
   return (
     <SensesTextSummary
       definitionsOrGlosses="glosses"

--- a/src/goals/ReviewEntries/ReviewEntriesTable/Cells/NoteCell.tsx
+++ b/src/goals/ReviewEntries/ReviewEntriesTable/Cells/NoteCell.tsx
@@ -1,9 +1,9 @@
 import { type ReactElement } from "react";
 
-import { type CellProps } from "goals/ReviewEntries/ReviewEntriesTable/Cells/CellTypes";
+import { type ReadonlyCellProps } from "goals/ReviewEntries/ReviewEntriesTable/Cells/CellTypes";
 import { TypographyWithFont } from "utilities/fontComponents";
 
-export default function NoteCell(props: CellProps): ReactElement {
+export default function NoteCell(props: ReadonlyCellProps): ReactElement {
   const MAX_LENGTH = 100;
   let text = props.word.note.text;
   if (text.length > MAX_LENGTH) {

--- a/src/goals/ReviewEntries/ReviewEntriesTable/Cells/PartOfSpeechCell.tsx
+++ b/src/goals/ReviewEntries/ReviewEntriesTable/Cells/PartOfSpeechCell.tsx
@@ -3,7 +3,7 @@ import { type ReactElement } from "react";
 
 import { type GrammaticalInfo, type Sense } from "api/models";
 import PartOfSpeechButton from "components/Buttons/PartOfSpeechButton";
-import { type CellProps } from "goals/ReviewEntries/ReviewEntriesTable/Cells/CellTypes";
+import { type ReadonlyCellProps } from "goals/ReviewEntries/ReviewEntriesTable/Cells/CellTypes";
 
 /** Collect all distinct sense.grammaticalInfo values. */
 function gatherGramInfo(senses: Sense[]): GrammaticalInfo[] {
@@ -16,7 +16,9 @@ function gatherGramInfo(senses: Sense[]): GrammaticalInfo[] {
   }, []);
 }
 
-export default function PartOfSpeechCell(props: CellProps): ReactElement {
+export default function PartOfSpeechCell(
+  props: ReadonlyCellProps
+): ReactElement {
   return (
     <Grid2 container spacing={2}>
       {gatherGramInfo(props.word.senses).map((gi) => (

--- a/src/goals/ReviewEntries/ReviewEntriesTable/Cells/VernacularCell.tsx
+++ b/src/goals/ReviewEntries/ReviewEntriesTable/Cells/VernacularCell.tsx
@@ -1,9 +1,9 @@
 import { type ReactElement } from "react";
 
-import { type CellProps } from "goals/ReviewEntries/ReviewEntriesTable/Cells/CellTypes";
+import { type ReadonlyCellProps } from "goals/ReviewEntries/ReviewEntriesTable/Cells/CellTypes";
 import { TypographyWithFont } from "utilities/fontComponents";
 
-export default function VernacularCell(props: CellProps): ReactElement {
+export default function VernacularCell(props: ReadonlyCellProps): ReactElement {
   return (
     <TypographyWithFont id={`row-${props.word.id}-vernacular`} vernacular>
       {props.word.vernacular}


### PR DESCRIPTION
`src/components/DataEntry/DataEntryTable/NewEntry/VernDialog.tsx` uses both `DomainsCell` and `PartOfSpeechCell`, which was overlooked in #4217.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4259)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code structure improvements to review entry table components. No changes to end-user functionality or interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->