### PR TITLE
Bump aws-kubectl to latest (based on Ubuntu 24.04)

### DIFF
--- a/deploy/helm/aws-login/values.yaml
+++ b/deploy/helm/aws-login/values.yaml
@@ -22,7 +22,7 @@ awsEcr:
   cron: yes
   cronJobName: ecr-cred-helper-cron
   image: "public.ecr.aws/thecombine/aws-kubectl"
-  imageVersion: "0.4.2"
+  imageVersion: "0.5.0"
   jobName: ecr-cred-helper
   schedule: "0 */8 * * *"
   secretsName: aws-ecr-credentials

--- a/deploy/helm/thecombine/charts/maintenance/values.yaml
+++ b/deploy/helm/thecombine/charts/maintenance/values.yaml
@@ -37,7 +37,7 @@ serviceAccount:
 
 awsEcr:
   image: "public.ecr.aws/thecombine/aws-kubectl"
-  imageVersion: "0.4.2"
+  imageVersion: "0.5.0"
 
 #######################################
 # Variables controlling backups

--- a/maintenance/Dockerfile
+++ b/maintenance/Dockerfile
@@ -32,7 +32,7 @@ ENV SCRIPT_DIR=${HOME}/.local/bin
 ENV FONT_DIR=/var/local/fonts
 
 RUN mkdir -p ${FONT_DIR}
-RUN chown user:user ${FONT_DIR}
+RUN chown user:group ${FONT_DIR}
 
 # switch to non-root user
 USER user
@@ -40,10 +40,10 @@ WORKDIR ${HOME}
 
 ENV PATH=${PATH}:${SCRIPT_DIR}
 
-COPY --chown=user:user requirements.txt .
+COPY --chown=user:group requirements.txt .
 
 RUN pip3 install --break-system-packages -r requirements.txt
 
-COPY --chown=user:user scripts/*.py ${SCRIPT_DIR}
-COPY --chown=user:user scripts/*.sh ${SCRIPT_DIR}
-COPY --chown=user:user scripts/mui_language_picker_fonts.txt ${SCRIPT_DIR}
+COPY --chown=user:group scripts/*.py ${SCRIPT_DIR}
+COPY --chown=user:group scripts/*.sh ${SCRIPT_DIR}
+COPY --chown=user:group scripts/mui_language_picker_fonts.txt ${SCRIPT_DIR}

--- a/maintenance/Dockerfile
+++ b/maintenance/Dockerfile
@@ -16,7 +16,7 @@
 #   - ARM 64-bit
 ############################################################
 
-FROM public.ecr.aws/thecombine/aws-kubectl:0.4.2-$TARGETARCH
+FROM public.ecr.aws/thecombine/aws-kubectl:0.5.0-$TARGETARCH
 
 USER root
 

--- a/maintenance/Dockerfile
+++ b/maintenance/Dockerfile
@@ -21,8 +21,7 @@ FROM public.ecr.aws/thecombine/aws-kubectl:0.5.0-$TARGETARCH
 USER root
 
 RUN apt-get update && \
-  apt-get install -y python3 python3-pip nano && \
-  apt-get autoremove && \
+  apt-get install -y --no-install-recommends nano python3 python3-pip && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
@@ -43,7 +42,7 @@ ENV PATH=${PATH}:${SCRIPT_DIR}
 
 COPY --chown=user:user requirements.txt .
 
-RUN pip3 install -r requirements.txt
+RUN pip3 install --break-system-packages -r requirements.txt
 
 COPY --chown=user:user scripts/*.py ${SCRIPT_DIR}
 COPY --chown=user:user scripts/*.sh ${SCRIPT_DIR}


### PR DESCRIPTION
Pairs with https://github.com/sillsdev/aws-kubectl/pull/9

Devin review: https://app.devin.ai/review/sillsdev/TheCombine/pull/4262

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4262)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated AWS credential helper container image version to 0.5.0.
  * Updated kubectl/tooling container image version to 0.5.0 across deployments.
  * Updated maintenance container base image and build steps, including streamlined package installation and adjusted file ownerships for container builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->