### PR TITLE
Fix transform ignore

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -25,7 +25,7 @@
     "^.+\\.(js|jsx|ts|tsx)$": "<rootDir>/scripts/jestTransform/babelTransform.js",
     "^(?!.*\\.(cjs|css|js|json|jsx|mjs|ts|tsx)$)": "<rootDir>/scripts/jestTransform/fileTransform.js"
   },
-  "transformIgnorePatterns": ["/node_modules/(!(axios))"],
+  "transformIgnorePatterns": ["/node_modules/(?!axios/)"],
   "watchPlugins": [
     "jest-watch-typeahead/filename",
     "jest-watch-typeahead/testname"


### PR DESCRIPTION
The ignore pattern was wrong, so all `node_modules` packages were being transformed, when we only need to transform `axios`. This fix cuts minutes off the local frontend test time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4269)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing configuration to optimize how dependencies are processed during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->