### PR TITLE
Update Linkedin link

### DIFF
--- a/docs/user_guide/mkdocs.yml
+++ b/docs/user_guide/mkdocs.yml
@@ -87,7 +87,7 @@ extra:
     - icon: fontawesome/brands/youtube
       link: https://www.youtube.com/channel/UC6ojqR9jOPHuPN7XP92Zj9Q
     - icon: fontawesome/brands/linkedin
-      link: https://www.linkedin.com/company/silglobal
+      link: https://www.linkedin.com/showcase/sil-language-technology/
 nav:
   - Overview: index.md
   - Account: account.md


### PR DESCRIPTION
Rather than linking to SIL Global, link to Language Tech (which does have an affiliate link to SIL Global).

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4270)
<!-- Reviewable:end -->
