### PR TITLE
Use crypto.randomUUID instead of uuid.v4

### DIFF
--- a/docs/user_guide/assets/licenses/frontend_licenses.txt
+++ b/docs/user_guide/assets/licenses/frontend_licenses.txt
@@ -1,4 +1,4 @@
-@babel/code-frame 7.27.1
+@babel/code-frame 7.29.0
 MIT
 MIT License
 
@@ -24,7 +24,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-@babel/generator 7.28.5
+@babel/generator 7.29.1
 MIT
 MIT License
 
@@ -76,7 +76,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-@babel/helper-module-imports 7.27.1
+@babel/helper-module-imports 7.28.6
 MIT
 MIT License
 
@@ -154,7 +154,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-@babel/parser 7.28.5
+@babel/parser 7.29.2
 MIT
 Copyright (C) 2012-2014 by various contributors (see AUTHORS)
 
@@ -203,7 +203,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-@babel/template 7.27.2
+@babel/template 7.28.6
 MIT
 MIT License
 
@@ -229,7 +229,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-@babel/traverse 7.28.5
+@babel/traverse 7.29.0
 MIT
 MIT License
 
@@ -255,7 +255,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-@babel/types 7.28.5
+@babel/types 7.29.0
 MIT
 MIT License
 
@@ -4877,19 +4877,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-
-uuid 11.1.0
-MIT
-The MIT License (MIT)
-
-Copyright (c) 2010-2020 Robert Kieffer and other contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 void-elements 3.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,8 +49,7 @@
         "redux": "~5.0.1",
         "redux-persist": "~6.0.0",
         "redux-thunk": "~3.1.0",
-        "ts-key-enum": "~2.0.13",
-        "uuid": "~11.1.0"
+        "ts-key-enum": "~2.0.13"
       },
       "devDependencies": {
         "@babel/core": "~7.29.0",
@@ -15663,19 +15662,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -79,8 +79,7 @@
     "redux": "~5.0.1",
     "redux-persist": "~6.0.0",
     "redux-thunk": "~3.1.0",
-    "ts-key-enum": "~2.0.13",
-    "uuid": "~11.1.0"
+    "ts-key-enum": "~2.0.13"
   },
   "devDependencies": {
     "@babel/core": "~7.29.0",

--- a/src/backend/sessionStorage.ts
+++ b/src/backend/sessionStorage.ts
@@ -1,5 +1,3 @@
-import { v4 } from "uuid";
-
 export enum SessionStorageKey {
   SessionId = "sessionId",
 }
@@ -8,7 +6,7 @@ export enum SessionStorageKey {
 export function getSessionId(): string {
   let id = sessionStorage.getItem(SessionStorageKey.SessionId);
   if (!id) {
-    id = v4();
+    id = crypto.randomUUID();
     sessionStorage.setItem(SessionStorageKey.SessionId, id);
   }
   return id;

--- a/src/components/DataEntry/DataEntryTable/index.tsx
+++ b/src/components/DataEntry/DataEntryTable/index.tsx
@@ -12,7 +12,6 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "react-toastify";
-import { v4 } from "uuid";
 
 import {
   Note,
@@ -188,7 +187,7 @@ export function updateEntryGloss(
     senses.push(newSense);
   } else {
     // Otherwise, the other semantic domains should be retained with the old sense.
-    newSense.guid = v4();
+    newSense.guid = crypto.randomUUID();
     senses.push(oldSense, newSense);
   }
   return { ...entry.word, senses };

--- a/src/components/DataEntry/DataEntryTable/tests/index.test.tsx
+++ b/src/components/DataEntry/DataEntryTable/tests/index.test.tsx
@@ -10,7 +10,6 @@ import {
 import userEvent, { UserEvent } from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import configureMockStore from "redux-mock-store";
-import { v4 } from "uuid";
 
 import { Gloss, SemanticDomain, Sense, Word } from "api/models";
 import DataEntryTable, {
@@ -346,7 +345,7 @@ describe("DataEntryTable", () => {
   describe("with duplicate selected", () => {
     beforeEach(async () => {
       mockUpdateWord.mockImplementation((w: Word) =>
-        Promise.resolve({ ...w, id: v4() })
+        Promise.resolve({ ...w, id: crypto.randomUUID() })
       );
       await renderTable();
     });

--- a/src/goals/MergeDuplicates/MergeDupsStep/MergeDragDrop/index.tsx
+++ b/src/goals/MergeDuplicates/MergeDupsStep/MergeDragDrop/index.tsx
@@ -7,7 +7,7 @@ import {
   ImageListItem,
   Tooltip,
 } from "@mui/material";
-import { CSSProperties, ReactElement, useState } from "react";
+import { CSSProperties, ReactElement, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "react-toastify";
 
@@ -256,7 +256,8 @@ export default function MergeDragDrop(): ReactElement {
     );
   }
 
-  const newId = crypto.randomUUID();
+  // Create a stable id for the extra empty word each time words changes.
+  const newId = useMemo(() => crypto.randomUUID(), [words]);
   const colCount = Object.keys(words).length + 1; // +1 for extra empty word.
 
   // This prevents things from moving when a draggable is dragged over the trash.

--- a/src/goals/MergeDuplicates/MergeDupsStep/MergeDragDrop/index.tsx
+++ b/src/goals/MergeDuplicates/MergeDupsStep/MergeDragDrop/index.tsx
@@ -10,7 +10,6 @@ import {
 import { CSSProperties, ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "react-toastify";
-import { v4 } from "uuid";
 
 import { appBarHeight } from "components/AppBar/AppBarTypes";
 import CancelConfirmDialog from "components/Dialogs/CancelConfirmDialog";
@@ -257,7 +256,7 @@ export default function MergeDragDrop(): ReactElement {
     );
   }
 
-  const newId = v4();
+  const newId = crypto.randomUUID();
   const colCount = Object.keys(words).length + 1; // +1 for extra empty word.
 
   // This prevents things from moving when a draggable is dragged over the trash.

--- a/src/goals/MergeDuplicates/MergeDupsTreeTypes.ts
+++ b/src/goals/MergeDuplicates/MergeDupsTreeTypes.ts
@@ -1,5 +1,3 @@
-import { v4 } from "uuid";
-
 import {
   type Flag,
   type Note,
@@ -89,7 +87,7 @@ export function convertSenseToMergeTreeSense(
 export function convertWordToMergeTreeWord(word: Word): MergeTreeWord {
   const mergeTreeWord = newMergeTreeWord(word.vernacular);
   word.senses.forEach((sense) => {
-    mergeTreeWord.sensesGuids[v4()] = [sense.guid];
+    mergeTreeWord.sensesGuids[crypto.randomUUID()] = [sense.guid];
   });
   mergeTreeWord.flag = { ...word.flag };
   mergeTreeWord.note = { ...word.note };

--- a/src/goals/MergeDuplicates/Redux/MergeDupsReducer.ts
+++ b/src/goals/MergeDuplicates/Redux/MergeDupsReducer.ts
@@ -1,5 +1,4 @@
 import { createSlice } from "@reduxjs/toolkit";
-import { v4 } from "uuid";
 
 import { Status, type Word } from "api/models";
 import {
@@ -238,7 +237,10 @@ const mergeDuplicatesSlice = createSlice({
 
         // Update the destWord.
         const sensesPairs = Object.entries(words[destWordId].sensesGuids);
-        sensesPairs.splice(action.payload.destOrder, 0, [v4(), [guid]]);
+        sensesPairs.splice(action.payload.destOrder, 0, [
+          crypto.randomUUID(),
+          [guid],
+        ]);
         words[destWordId].sensesGuids = Object.fromEntries(sensesPairs);
       }
     },

--- a/src/goals/MergeDuplicates/Redux/tests/MergeDupsReducer.test.ts
+++ b/src/goals/MergeDuplicates/Redux/tests/MergeDupsReducer.test.ts
@@ -3,7 +3,6 @@ import {
   type PayloadAction,
   type UnknownAction,
 } from "@reduxjs/toolkit";
-import * as uuid from "uuid";
 
 import { Status } from "api/models";
 import {
@@ -42,23 +41,28 @@ import { setupStore } from "rootRedux/store";
 import { type Hash } from "types/hash";
 import { newFlag, testWordList } from "types/word";
 
-jest.mock("uuid");
-
-const mockUuidV4 = uuid.v4 as jest.MockedFunction<() => string>;
+let mockRandomUuid: jest.SpiedFunction<typeof crypto.randomUUID>;
 
 let uuidIndex = 0;
 /** When `increment` (default `true`) is set to `false`,
- * returns the next uuid to be assigned by our mocked `v4`. */
-function getMockUuid(increment = true): string {
-  const uuid = `mockUuid${uuidIndex}`;
+ * returns the next uuid to be assigned by our mocked `randomUUID`. */
+function getMockUuid(increment = true): ReturnType<typeof crypto.randomUUID> {
+  const suffix = `${uuidIndex}`.padStart(12, "0");
   if (increment) {
     uuidIndex++;
   }
-  return uuid;
+  return `00000000-0000-4000-8000-${suffix}`;
 }
 
 beforeEach(() => {
-  mockUuidV4.mockImplementation(getMockUuid);
+  uuidIndex = 0;
+  mockRandomUuid = jest
+    .spyOn(crypto, "randomUUID")
+    .mockImplementation(() => getMockUuid());
+});
+
+afterEach(() => {
+  mockRandomUuid.mockRestore();
 });
 
 describe("MergeDupsReducer", () => {

--- a/src/types/goals.ts
+++ b/src/types/goals.ts
@@ -1,5 +1,3 @@
-import { v4 } from "uuid";
-
 import {
   type CharInvChanges,
   type CharInvData,
@@ -73,7 +71,7 @@ export class Goal {
     steps: GoalStep[] = [{}],
     data?: GoalData
   ) {
-    this.guid = v4();
+    this.guid = crypto.randomUUID();
     this.goalType = type;
     this.name = name;
     this.steps = steps;

--- a/src/types/semanticDomain.ts
+++ b/src/types/semanticDomain.ts
@@ -1,5 +1,3 @@
-import { v4 } from "uuid";
-
 import {
   SemanticDomain,
   SemanticDomainFull,
@@ -18,7 +16,7 @@ export function newSemanticDomain(
   lang = Bcp47Code.Default as string
 ): SemanticDomainFull {
   return {
-    guid: v4(),
+    guid: crypto.randomUUID(),
     id,
     name,
     lang,
@@ -51,7 +49,7 @@ export function newSemanticDomainTreeNode(
     id,
     name,
     lang,
-    guid: v4(),
+    guid: crypto.randomUUID(),
   };
 }
 

--- a/src/types/word.ts
+++ b/src/types/word.ts
@@ -1,5 +1,3 @@
-import { v4 } from "uuid";
-
 import {
   Definition,
   Flag,
@@ -57,7 +55,7 @@ export function newSense(
   semDom?: SemanticDomain
 ): Sense {
   const sense: Sense = {
-    guid: v4(),
+    guid: crypto.randomUUID(),
     definitions: [],
     glosses: [],
     semanticDomains: [],
@@ -88,7 +86,7 @@ export function newGrammaticalInfo(): GrammaticalInfo {
 export function newWord(vernacular = "", lang?: string): Word {
   return {
     id: "",
-    guid: v4(),
+    guid: crypto.randomUUID(),
     vernacular,
     senses: [],
     audio: [],


### PR DESCRIPTION
Replacement for #4268

Devin review: https://app.devin.ai/review/sillsdev/TheCombine/pull/4271

Browsers block the crypto package on http:// (non-https) sites, but both our NUC and laptop installs host The Combine at an https:// page, so that's not a problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4271)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the `uuid` package dependency and updated the application to use platform-native UUID generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->