### PR TITLE
[ansible] Ensure k8s install variable is bool

### DIFF
--- a/deploy/ansible/roles/k8s_install/tasks/k8s_remote_access.yml
+++ b/deploy/ansible/roles/k8s_install/tasks/k8s_remote_access.yml
@@ -50,4 +50,4 @@
         src: "{{ kubecfg }}"
         dest: "{{ lookup('env', 'HOME') }}/.kube/config"
         mode: 0600
-      when: link_kubeconfig | default(false)
+      when: (link_kubeconfig | default(false)) | bool


### PR DESCRIPTION
#4126 only mostly fixed #4125. Once instruction in `docs/deploy/README.md` reveals a missing bug:

```
ansible-playbook -i hosts.yml playbook_nuc_setup.yml --limit <target> -u <target_user> -K -e link_kubeconfig=true
```

Installing The Combine on a NUC resulted in the following error:
```
TASK [k8s_install : Link ~/.kube/config to /root/.kube/nuc1/config] ************
[ERROR]: Task failed: Conditional result (True) was derived from value of type 'str' at "<CLI option '-e'>". Conditionals must have a boolean result.

Task failed.
Origin: /root/ansible/roles/k8s_install/tasks/k8s_remote_access.yml:47:7

45         replace: '\1{{ kubecfgdir }}\2'
46
47     - name: Link ~/.kube/config to {{ kubecfg }}
         ^ column 7

<<< caused by >>>

Conditional result (True) was derived from value of type 'str' at "<CLI option '-e'>". Conditionals must have a boolean result.
Origin: /root/ansible/roles/k8s_install/tasks/k8s_remote_access.yml:53:13

51         dest: "{{ lookup('env', 'HOME') }}/.kube/config"
52         mode: 0600
53       when: link_kubeconfig | default(false)
               ^ column 13

Broken conditionals can be temporarily allowed with the `ALLOW_BROKEN_CONDITIONALS` configuration option.

fatal: [nuc1 -> localhost]: FAILED! => {"changed": false, "msg": "Task failed: Conditional result (True) was derived from value of type 'str' at \"<CLI option '-e'>\". Conditionals must have a boolean result."}
```

This pr fixes it.

Devin review: https://app.devin.ai/review/sillsdev/TheCombine/pull/4272

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4272)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed kubeconfig configuration handling during Kubernetes deployment to properly evaluate configuration values, ensuring consistent behavior regardless of value format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->