### PR TITLE
[ansible] Enable NUC user kubectl access

### DIFF
--- a/deploy/ansible/roles/k8s_install/tasks/main.yml
+++ b/deploy/ansible/roles/k8s_install/tasks/main.yml
@@ -75,7 +75,6 @@
     path: "{{ k8s_user_home.stdout }}/.profile"
     line: "export KUBECONFIG=${HOME}/.kube/config"
     mode: 0600
-  when: ansible_connection == "local"
 
 - name: Setup remote access to cluster
   include_tasks:


### PR DESCRIPTION
After installing The Combine on a NUC, attempts to run `kubectl get pods` on the NUC user's cli result in:
```
WARN[0000] Unable to read /etc/rancher/k3s/k3s.yaml, please start server with --write-kubeconfig-mod to modify kube config permissions
error: error loading config file "/etc/rancher/k3s/k3s.yaml": open /etc/rancher/k3s/k3s.yaml: permission denied
```

The temporary fix is `export KUBECONFIG=$HOME/.kube/config`. This pr is the permanent fix.

It seams older k3s installers weren't so strict and would silently fall back to this path.

Devin: https://app.devin.ai/review/sillsdev/TheCombine/pull/4273

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4273)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where profile configuration updates were not consistently applied across all deployment connection types during Kubernetes installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->