### PR TITLE
Bump backend otel deps to resolve a CVE

### DIFF
--- a/Backend/BackendFramework.csproj
+++ b/Backend/BackendFramework.csproj
@@ -10,11 +10,11 @@
     <NoWarn>$(NoWarn);CA1305;CA1848;CS1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageReference Include="RelaxNG" Version="3.2.3">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>

--- a/docs/user_guide/assets/licenses/backend_licenses.txt
+++ b/docs/user_guide/assets/licenses/backend_licenses.txt
@@ -76,35 +76,35 @@ License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.Configuration
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.Configuration.Abstractions
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.Configuration.Binder
-PackageVersion: 9.0.0
+PackageVersion: 8.0.2
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.DependencyInjection
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.DependencyInjection.Abstractions
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
@@ -118,63 +118,63 @@ License: https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT
 LicenseUrl: https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT
 ###############################################################
 PackageId: Microsoft.Extensions.Diagnostics.Abstractions
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.FileProviders.Abstractions
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.Hosting.Abstractions
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.Logging
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.Logging.Abstractions
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.Logging.Configuration
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.Options
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.Options.ConfigurationExtensions
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.Primitives
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
@@ -293,56 +293,56 @@ License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: OpenTelemetry
-PackageVersion: 1.12.0
+PackageVersion: 1.15.3
 PackageProjectUrl: https://opentelemetry.io/
 Authors: OpenTelemetry Authors
 License: Apache-2.0
 LicenseUrl: https://licenses.nuget.org/Apache-2.0
 ###############################################################
 PackageId: OpenTelemetry.Api
-PackageVersion: 1.12.0
+PackageVersion: 1.15.3
 PackageProjectUrl: https://opentelemetry.io/
 Authors: OpenTelemetry Authors
 License: Apache-2.0
 LicenseUrl: https://licenses.nuget.org/Apache-2.0
 ###############################################################
 PackageId: OpenTelemetry.Api.ProviderBuilderExtensions
-PackageVersion: 1.12.0
+PackageVersion: 1.15.3
 PackageProjectUrl: https://opentelemetry.io/
 Authors: OpenTelemetry Authors
 License: Apache-2.0
 LicenseUrl: https://licenses.nuget.org/Apache-2.0
 ###############################################################
 PackageId: OpenTelemetry.Exporter.Console
-PackageVersion: 1.12.0
+PackageVersion: 1.15.3
 PackageProjectUrl: https://opentelemetry.io/
 Authors: OpenTelemetry Authors
 License: Apache-2.0
 LicenseUrl: https://licenses.nuget.org/Apache-2.0
 ###############################################################
 PackageId: OpenTelemetry.Exporter.OpenTelemetryProtocol
-PackageVersion: 1.12.0
+PackageVersion: 1.15.3
 PackageProjectUrl: https://opentelemetry.io/
 Authors: OpenTelemetry Authors
 License: Apache-2.0
 LicenseUrl: https://licenses.nuget.org/Apache-2.0
 ###############################################################
 PackageId: OpenTelemetry.Extensions.Hosting
-PackageVersion: 1.12.0
+PackageVersion: 1.15.3
 PackageProjectUrl: https://opentelemetry.io/
 Authors: OpenTelemetry Authors
 License: Apache-2.0
 LicenseUrl: https://licenses.nuget.org/Apache-2.0
 ###############################################################
 PackageId: OpenTelemetry.Instrumentation.AspNetCore
-PackageVersion: 1.12.0
+PackageVersion: 1.15.2
 PackageProjectUrl: https://opentelemetry.io/
 Authors: OpenTelemetry Authors
 License: Apache-2.0
 LicenseUrl: https://licenses.nuget.org/Apache-2.0
 ###############################################################
 PackageId: OpenTelemetry.Instrumentation.Http
-PackageVersion: 1.12.0
+PackageVersion: 1.15.1
 PackageProjectUrl: https://opentelemetry.io/
 Authors: OpenTelemetry Authors
 License: Apache-2.0
@@ -588,7 +588,7 @@ License: http://go.microsoft.com/fwlink/?LinkId=329770
 LicenseUrl: http://go.microsoft.com/fwlink/?LinkId=329770
 ###############################################################
 PackageId: System.Diagnostics.DiagnosticSource
-PackageVersion: 9.0.0
+PackageVersion: 10.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
@@ -915,13 +915,6 @@ PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: http://go.microsoft.com/fwlink/?LinkId=329770
 LicenseUrl: http://go.microsoft.com/fwlink/?LinkId=329770
-###############################################################
-PackageId: System.Text.Json
-PackageVersion: 8.0.5
-PackageProjectUrl: https://dot.net/
-Authors: Microsoft
-License: MIT
-LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: System.Threading
 PackageVersion: 4.3.0


### PR DESCRIPTION
This resolves 
```
  /home/runner/work/TheCombine/TheCombine/Backend/BackendFramework.csproj : error NU1902: Warning As Error: Package 'OpenTelemetry.Exporter.OpenTelemetryProtocol' 1.12.0 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-4625-4j76-fww9 [/home/runner/work/TheCombine/TheCombine/BackendFramework.sln]
  ```

Also, when I updated the license file, some MS versions dropped from 9 to 8, because I had previously been accidentally using .NET 9 with this project even though it is currently at .NET 8.

Devin: https://app.devin.ai/review/sillsdev/TheCombine/pull/4276

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4276)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenTelemetry packages to versions 1.15.x for enhanced observability and telemetry capabilities.
  * Updated core framework dependencies and diagnostic packages to latest stable versions for improved functionality and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->