### PR TITLE
Bump backend deps

### DIFF
--- a/Backend.Tests/Backend.Tests.csproj
+++ b/Backend.Tests/Backend.Tests.csproj
@@ -16,13 +16,13 @@
     <PackageReference Include="EphemeralMongo7.runtime.linux-x64" Version="2.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
     <PackageReference Include="EphemeralMongo7.runtime.osx-arm64" Version="2.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
     <PackageReference Include="EphemeralMongo7.runtime.win-x64" Version="2.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq.Contrib.HttpClient" Version="1.4.0" />
     <PackageReference Include="NUnit" Version="4.5.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.12.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.13.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageReference Include="coverlet.collector" Version="8.0.1"/>
-    <PackageReference Include="coverlet.msbuild" Version="8.0.1"/>
+    <PackageReference Include="coverlet.collector" Version="10.0.0"/>
+    <PackageReference Include="coverlet.msbuild" Version="10.0.0"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Backend\BackendFramework.csproj" />

--- a/Backend/BackendFramework.csproj
+++ b/Backend/BackendFramework.csproj
@@ -29,10 +29,9 @@
     <!-- SIL Maintained Dependencies. -->
     <PackageReference Include="icu.net" Version="3.0.1" />
     <PackageReference Include="Icu4c.Win.Full.Lib" Version="62.2.3-beta" />
-    <PackageReference Include="SIL.Core" Version="16.0.0" />
-    <PackageReference Include="SIL.Core.Desktop" Version="16.0.0"/>
-    <PackageReference Include="SIL.DictionaryServices" Version="16.0.0"/>
-    <PackageReference Include="SIL.Lift" Version="16.0.0"/>
-    <PackageReference Include="SIL.WritingSystems" Version="16.0.0" />
+    <PackageReference Include="SIL.Core" Version="17.0.0" />
+    <PackageReference Include="SIL.DictionaryServices" Version="17.0.0"/>
+    <PackageReference Include="SIL.Lift" Version="17.0.0"/>
+    <PackageReference Include="SIL.WritingSystems" Version="17.0.0" />
   </ItemGroup>
 </Project>

--- a/Backend/BackendFramework.csproj
+++ b/Backend/BackendFramework.csproj
@@ -10,28 +10,28 @@
     <NoWarn>$(NoWarn);CA1305;CA1848;CS1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageReference Include="RelaxNG" Version="3.2.3">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.17" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.12.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.12.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.26" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
     <PackageReference Include="MailKit" Version="4.16.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.4.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />
-    <PackageReference Include="Xabe.FFmpeg" Version="6.0.1"/>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+    <PackageReference Include="Xabe.FFmpeg" Version="6.0.2"/>
 
     <!-- SIL Maintained Dependencies. -->
     <PackageReference Include="icu.net" Version="3.0.1" />
     <PackageReference Include="Icu4c.Win.Full.Lib" Version="62.2.3-beta" />
-    <PackageReference Include="SIL.Core" Version="17.0.0" />
-    <PackageReference Include="SIL.DictionaryServices" Version="17.0.0"/>
-    <PackageReference Include="SIL.Lift" Version="17.0.0"/>
-    <PackageReference Include="SIL.WritingSystems" Version="17.0.0" />
+    <PackageReference Include="SIL.Core" Version="18.0.0-beta0012" />
+    <PackageReference Include="SIL.DictionaryServices" Version="18.0.0-beta0012"/>
+    <PackageReference Include="SIL.Lift" Version="18.0.0-beta0012"/>
+    <PackageReference Include="SIL.WritingSystems" Version="18.0.0-beta0012" />
   </ItemGroup>
 </Project>

--- a/docs/user_guide/assets/licenses/backend_licenses.txt
+++ b/docs/user_guide/assets/licenses/backend_licenses.txt
@@ -33,6 +33,13 @@ Authors: JetBrains
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
+PackageId: L10NSharp
+PackageVersion: 10.0.0-beta0002
+PackageProjectUrl: https://github.com/sillsdev/l10nsharp
+Authors: SIL Global
+License: MIT
+LicenseUrl: https://licenses.nuget.org/MIT
+###############################################################
 PackageId: MailKit
 PackageVersion: 4.16.0
 PackageProjectUrl: http://www.mimekit.net/
@@ -48,7 +55,7 @@ License: BSD-2-Clause
 LicenseUrl: https://licenses.nuget.org/BSD-2-Clause
 ###############################################################
 PackageId: Microsoft.AspNetCore.Authentication.JwtBearer
-PackageVersion: 8.0.17
+PackageVersion: 8.0.26
 PackageProjectUrl: https://asp.net/
 Authors: Microsoft
 License: MIT
@@ -76,35 +83,35 @@ License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.Configuration
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.Configuration.Abstractions
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.Configuration.Binder
-PackageVersion: 9.0.0
+PackageVersion: 8.0.2
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.DependencyInjection
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.DependencyInjection.Abstractions
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
@@ -118,84 +125,91 @@ License: https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT
 LicenseUrl: https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT
 ###############################################################
 PackageId: Microsoft.Extensions.Diagnostics.Abstractions
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.FileProviders.Abstractions
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.Hosting.Abstractions
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.Logging
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.Logging.Abstractions
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.Logging.Configuration
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
+PackageId: Microsoft.Extensions.ObjectPool
+PackageVersion: 6.0.16
+PackageProjectUrl: https://asp.net/
+Authors: Microsoft
+License: MIT
+LicenseUrl: https://licenses.nuget.org/MIT
+###############################################################
 PackageId: Microsoft.Extensions.Options
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.Options.ConfigurationExtensions
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.Extensions.Primitives
-PackageVersion: 9.0.0
+PackageVersion: 8.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.IdentityModel.Abstractions
-PackageVersion: 8.12.1
+PackageVersion: 8.18.0
 PackageProjectUrl: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.IdentityModel.JsonWebTokens
-PackageVersion: 8.12.1
+PackageVersion: 8.18.0
 PackageProjectUrl: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.IdentityModel.Logging
-PackageVersion: 8.12.1
+PackageVersion: 8.18.0
 PackageProjectUrl: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet
 Authors: Microsoft
 License: MIT
@@ -216,7 +230,7 @@ License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Microsoft.IdentityModel.Tokens
-PackageVersion: 8.12.1
+PackageVersion: 8.18.0
 PackageProjectUrl: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet
 Authors: Microsoft
 License: MIT
@@ -237,7 +251,7 @@ License: http://go.microsoft.com/fwlink/?LinkId=329770
 LicenseUrl: http://go.microsoft.com/fwlink/?LinkId=329770
 ###############################################################
 PackageId: Microsoft.OpenApi
-PackageVersion: 1.6.23
+PackageVersion: 2.4.1
 PackageProjectUrl: https://github.com/Microsoft/OpenAPI.NET
 Authors: Microsoft
 License: MIT
@@ -286,63 +300,63 @@ License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Newtonsoft.Json
-PackageVersion: 13.0.3
+PackageVersion: 13.0.4
 PackageProjectUrl: https://www.newtonsoft.com/json
 Authors: James Newton-King
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: OpenTelemetry
-PackageVersion: 1.12.0
+PackageVersion: 1.15.3
 PackageProjectUrl: https://opentelemetry.io/
 Authors: OpenTelemetry Authors
 License: Apache-2.0
 LicenseUrl: https://licenses.nuget.org/Apache-2.0
 ###############################################################
 PackageId: OpenTelemetry.Api
-PackageVersion: 1.12.0
+PackageVersion: 1.15.3
 PackageProjectUrl: https://opentelemetry.io/
 Authors: OpenTelemetry Authors
 License: Apache-2.0
 LicenseUrl: https://licenses.nuget.org/Apache-2.0
 ###############################################################
 PackageId: OpenTelemetry.Api.ProviderBuilderExtensions
-PackageVersion: 1.12.0
+PackageVersion: 1.15.3
 PackageProjectUrl: https://opentelemetry.io/
 Authors: OpenTelemetry Authors
 License: Apache-2.0
 LicenseUrl: https://licenses.nuget.org/Apache-2.0
 ###############################################################
 PackageId: OpenTelemetry.Exporter.Console
-PackageVersion: 1.12.0
+PackageVersion: 1.15.3
 PackageProjectUrl: https://opentelemetry.io/
 Authors: OpenTelemetry Authors
 License: Apache-2.0
 LicenseUrl: https://licenses.nuget.org/Apache-2.0
 ###############################################################
 PackageId: OpenTelemetry.Exporter.OpenTelemetryProtocol
-PackageVersion: 1.12.0
+PackageVersion: 1.15.3
 PackageProjectUrl: https://opentelemetry.io/
 Authors: OpenTelemetry Authors
 License: Apache-2.0
 LicenseUrl: https://licenses.nuget.org/Apache-2.0
 ###############################################################
 PackageId: OpenTelemetry.Extensions.Hosting
-PackageVersion: 1.12.0
+PackageVersion: 1.15.3
 PackageProjectUrl: https://opentelemetry.io/
 Authors: OpenTelemetry Authors
 License: Apache-2.0
 LicenseUrl: https://licenses.nuget.org/Apache-2.0
 ###############################################################
 PackageId: OpenTelemetry.Instrumentation.AspNetCore
-PackageVersion: 1.12.0
+PackageVersion: 1.15.2
 PackageProjectUrl: https://opentelemetry.io/
 Authors: OpenTelemetry Authors
 License: Apache-2.0
 LicenseUrl: https://licenses.nuget.org/Apache-2.0
 ###############################################################
 PackageId: OpenTelemetry.Instrumentation.Http
-PackageVersion: 1.12.0
+PackageVersion: 1.15.1
 PackageProjectUrl: https://opentelemetry.io/
 Authors: OpenTelemetry Authors
 License: Apache-2.0
@@ -471,35 +485,35 @@ PackageProjectUrl: https://github.com/adamhathcock/sharpcompress
 Authors: Adam Hathcock
 ###############################################################
 PackageId: SIL.Core
-PackageVersion: 16.0.0
+PackageVersion: 18.0.0-beta0012
 PackageProjectUrl: https://github.com/sillsdev/libpalaso
 Authors: SIL Global
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: SIL.Core.Desktop
-PackageVersion: 16.0.0
+PackageVersion: 18.0.0-beta0012
 PackageProjectUrl: https://github.com/sillsdev/libpalaso
 Authors: SIL Global
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: SIL.DictionaryServices
-PackageVersion: 16.0.0
+PackageVersion: 18.0.0-beta0012
 PackageProjectUrl: https://github.com/sillsdev/libpalaso
 Authors: SIL Global
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: SIL.Lift
-PackageVersion: 16.0.0
+PackageVersion: 18.0.0-beta0012
 PackageProjectUrl: https://github.com/sillsdev/libpalaso
 Authors: SIL Global
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: SIL.WritingSystems
-PackageVersion: 16.0.0
+PackageVersion: 18.0.0-beta0012
 PackageProjectUrl: https://github.com/sillsdev/libpalaso
 Authors: SIL Global
 License: MIT
@@ -518,28 +532,28 @@ License: https://opensource.org/licenses/Zlib
 LicenseUrl: https://opensource.org/licenses/Zlib
 ###############################################################
 PackageId: Swashbuckle.AspNetCore
-PackageVersion: 9.0.1
+PackageVersion: 10.1.7
 PackageProjectUrl: https://github.com/domaindrivendev/Swashbuckle.AspNetCore
 Authors: domaindrivendev
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Swashbuckle.AspNetCore.Swagger
-PackageVersion: 9.0.1
+PackageVersion: 10.1.7
 PackageProjectUrl: https://github.com/domaindrivendev/Swashbuckle.AspNetCore
 Authors: domaindrivendev
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Swashbuckle.AspNetCore.SwaggerGen
-PackageVersion: 9.0.1
+PackageVersion: 10.1.7
 PackageProjectUrl: https://github.com/domaindrivendev/Swashbuckle.AspNetCore
 Authors: domaindrivendev
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
 PackageId: Swashbuckle.AspNetCore.SwaggerUI
-PackageVersion: 9.0.1
+PackageVersion: 10.1.7
 PackageProjectUrl: https://github.com/domaindrivendev/Swashbuckle.AspNetCore
 Authors: domaindrivendev
 License: MIT
@@ -588,7 +602,7 @@ License: http://go.microsoft.com/fwlink/?LinkId=329770
 LicenseUrl: http://go.microsoft.com/fwlink/?LinkId=329770
 ###############################################################
 PackageId: System.Diagnostics.DiagnosticSource
-PackageVersion: 9.0.0
+PackageVersion: 10.0.0
 PackageProjectUrl: https://dot.net/
 Authors: Microsoft
 License: MIT
@@ -644,7 +658,7 @@ License: http://go.microsoft.com/fwlink/?LinkId=329770
 LicenseUrl: http://go.microsoft.com/fwlink/?LinkId=329770
 ###############################################################
 PackageId: System.IdentityModel.Tokens.Jwt
-PackageVersion: 8.12.1
+PackageVersion: 8.18.0
 PackageProjectUrl: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet
 Authors: Microsoft
 License: MIT
@@ -769,6 +783,13 @@ Authors: Microsoft
 License: http://go.microsoft.com/fwlink/?LinkId=329770
 LicenseUrl: http://go.microsoft.com/fwlink/?LinkId=329770
 ###############################################################
+PackageId: System.Resources.Extensions
+PackageVersion: 6.0.0
+PackageProjectUrl: https://dot.net/
+Authors: Microsoft
+License: MIT
+LicenseUrl: https://licenses.nuget.org/MIT
+###############################################################
 PackageId: System.Resources.ResourceManager
 PackageVersion: 4.3.0
 PackageProjectUrl: https://dot.net/
@@ -784,8 +805,8 @@ License: http://go.microsoft.com/fwlink/?LinkId=329770
 LicenseUrl: http://go.microsoft.com/fwlink/?LinkId=329770
 ###############################################################
 PackageId: System.Runtime.CompilerServices.Unsafe
-PackageVersion: 6.0.0
-PackageProjectUrl: https://dot.net/
+PackageVersion: 6.1.2
+PackageProjectUrl: https://github.com/dotnet/maintenance-packages
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
@@ -895,6 +916,13 @@ Authors: Microsoft
 License: http://go.microsoft.com/fwlink/?LinkId=329770
 LicenseUrl: http://go.microsoft.com/fwlink/?LinkId=329770
 ###############################################################
+PackageId: System.Security.Cryptography.Xml
+PackageVersion: 6.0.1
+PackageProjectUrl: https://dot.net/
+Authors: Microsoft
+License: MIT
+LicenseUrl: https://licenses.nuget.org/MIT
+###############################################################
 PackageId: System.Security.Permissions
 PackageVersion: 6.0.0
 PackageProjectUrl: https://dot.net/
@@ -905,6 +933,20 @@ LicenseUrl: https://licenses.nuget.org/MIT
 PackageId: System.Security.Principal.Windows
 PackageVersion: 5.0.0
 PackageProjectUrl: https://github.com/dotnet/runtime
+Authors: Microsoft
+License: MIT
+LicenseUrl: https://licenses.nuget.org/MIT
+###############################################################
+PackageId: System.ServiceModel.Http
+PackageVersion: 6.2.0
+PackageProjectUrl: https://github.com/dotnet/wcf
+Authors: Microsoft
+License: MIT
+LicenseUrl: https://licenses.nuget.org/MIT
+###############################################################
+PackageId: System.ServiceModel.Primitives
+PackageVersion: 6.2.0
+PackageProjectUrl: https://github.com/dotnet/wcf
 Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
@@ -951,13 +993,20 @@ Authors: Microsoft
 License: MIT
 LicenseUrl: https://licenses.nuget.org/MIT
 ###############################################################
+PackageId: TagLibSharp
+PackageVersion: 2.3.0
+PackageProjectUrl: https://github.com/mono/taglib-sharp
+Authors: Brian Nickel, Gabriel Burt, Stephen Shaw, etc
+License: LGPL-2.1-only
+LicenseUrl: https://licenses.nuget.org/LGPL-2.1-only
+###############################################################
 PackageId: Tenuto
 PackageVersion: 1.0.0.39
 PackageProjectUrl: https://github.com/josephmyers/relaxng-tenuto
 Authors: Tenuto
 ###############################################################
 PackageId: Xabe.FFmpeg
-PackageVersion: 6.0.1
+PackageVersion: 6.0.2
 PackageProjectUrl: https://ffmpeg.xabe.net/index.html
 Authors: Xabe
 License: https://ffmpeg.xabe.net/license.html


### PR DESCRIPTION
Resolves a CVE with OpenTelemetry.
Updates SIL libpalaso deps, which should resolve #880. The fix was in v17, though we're moving to the latest v18 beta to also get updated `net8.0` coverage.
Updates license report.
Keeps `NUnit` at 4.5.1 rather than updating to 4.6.0, which breaks some tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security and authentication framework packages to the latest stable versions.
  * Upgraded observability and telemetry infrastructure for enhanced monitoring capabilities.
  * Enhanced API documentation generation and management tools.
  * Improved testing and code quality analysis frameworks.
  * Refreshed license documentation to reflect all dependency updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sillsdev/TheCombine/pull/4283)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4283)
<!-- Reviewable:end -->
