### PR TITLE
Bump codecov-action from v6.0.0 to v7.0.0

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           name: coverage
       - name: Upload coverage report
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -117,7 +117,7 @@ jobs:
         with:
           name: coverage
       - name: Upload coverage report
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
v7.0.0 fixes GPG signature verification failures caused by Codecov rotating their signing key in CLI v11.x.

Example failure: https://github.com/sillsdev/TheCombine/actions/runs/27145564391/job/80122725710#step:6:243

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4298)
<!-- Reviewable:end -->
