### PR TITLE
Satisfy security scanning rule

### DIFF
--- a/src/backend/localStorage.ts
+++ b/src/backend/localStorage.ts
@@ -34,7 +34,7 @@ export function getCurrentUser(): User | undefined {
   return userString ? JSON.parse(userString) : undefined;
 }
 export function setCurrentUser(user: User): void {
-  const userString = JSON.stringify(user);
+  const userString = JSON.stringify({ ...user, password: "" });
   localStorage.setItem(LocalStorageKey.User, userString);
 }
 

--- a/src/backend/tests/localStorage.test.ts
+++ b/src/backend/tests/localStorage.test.ts
@@ -51,7 +51,10 @@ describe("LocalStorage", () => {
     LocalStorage.setClosedBanner(mockClosedBanner);
     expect(LocalStorage.getClosedBanner()).toEqual(mockClosedBanner);
     LocalStorage.setCurrentUser(mockUser);
-    expect(LocalStorage.getCurrentUser()).toEqual(mockUser);
+    expect(LocalStorage.getCurrentUser()).toEqual({
+      ...mockUser,
+      password: "",
+    });
     expect(LocalStorage.getUserId()).toEqual(mockUser.id);
     LocalStorage.setProjectId(mockProjectId);
     expect(LocalStorage.getProjectId()).toEqual(mockProjectId);


### PR DESCRIPTION
Resolve https://github.com/sillsdev/TheCombine/security/code-scanning/805

Just a safeguard, since the backend clears the pw before sending to the frontend.

Devin: https://app.devin.ai/review/sillsdev/TheCombine/pull/4310

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4310)
<!-- Reviewable:end -->
