### PR TITLE
Add timeout and retry to combine_restore kubectl cp

### DIFF
--- a/maintenance/scripts/combine_app.py
+++ b/maintenance/scripts/combine_app.py
@@ -17,8 +17,9 @@ from maint_utils import run_cmd
 # A `kubectl cp` streams a tar over the exec channel and can stall intermittently,
 # which would otherwise hang forever.  Bound each copy with a timeout so a stalled
 # stream gets killed, and retry a few times so a transient stall is recovered.
-CP_ATTEMPTS = int(os.getenv("kubectl_cp_attempts", "3"))
-CP_TIMEOUT = float(os.getenv("kubectl_cp_timeout", "300"))
+# Clamp to a sane floor so a misconfigured env var can't skip the copy entirely.
+CP_ATTEMPTS = max(1, int(os.getenv("kubectl_cp_attempts", "3")))
+CP_TIMEOUT = max(10.0, float(os.getenv("kubectl_cp_timeout", "300")))
 # A fast-failing copy can exhaust all attempts within the same second, giving a
 # transient failure no time to clear; pause between attempts so the retries span time.
 CP_RETRY_DELAY = 3.0

--- a/maintenance/scripts/combine_app.py
+++ b/maintenance/scripts/combine_app.py
@@ -39,6 +39,7 @@ class CombineApp:
         *,
         exec_opts: Optional[List[str]] = None,
         check_results: bool = True,
+        timeout: Optional[float] = None,
     ) -> subprocess.CompletedProcess[str]:
         """
         Run a kubectl 'exec' command in a Combine Kubernetes cluster.
@@ -52,6 +53,8 @@ class CombineApp:
                      command, for example, to specify a working directory or a
                      specific user to run the command.
             check_results: Indicate if subprocess should not check for failure.
+            timeout: If set, kill the command and raise subprocess.TimeoutExpired
+                     when it runs longer than this many seconds.
         Returns a subprocess.CompletedProcess.
         """
         exec_opts = exec_opts or []
@@ -65,11 +68,25 @@ class CombineApp:
             + [pod_id, "--"]
             + cmd,
             check_results=check_results,
+            timeout=timeout,
         )
 
-    def kubectl(self, cmd: List[str]) -> subprocess.CompletedProcess[str]:
-        """Run kubectl command adding the configuration file and namespace."""
-        return run_cmd(["kubectl"] + self.kubectl_opts + cmd)
+    def kubectl(
+        self, cmd: List[str], *, check_results: bool = True, timeout: Optional[float] = None
+    ) -> subprocess.CompletedProcess[str]:
+        """Run kubectl command adding the configuration file and namespace.
+
+        Args:
+            cmd: The kubectl subcommand and its arguments.
+            check_results: Indicate if subprocess should not check for failure.
+            timeout: If set, kill the command and raise subprocess.TimeoutExpired
+                     when it runs longer than this many seconds.
+        """
+        return run_cmd(
+            ["kubectl"] + self.kubectl_opts + cmd,
+            check_results=check_results,
+            timeout=timeout,
+        )
 
     def get_pod_id(self, service: CombineApp.Component, *, instance: int = 0) -> str:
         """Look up the Kubernetes pod id for the specified service."""

--- a/maintenance/scripts/combine_app.py
+++ b/maintenance/scripts/combine_app.py
@@ -18,7 +18,7 @@ from maint_utils import run_cmd
 # so a stalled stream gets killed, and retry a few times so a transient stall is
 # recovered.  Both defaults are overridable via environment variables.
 CP_TIMEOUT = float(os.getenv("kubectl_cp_timeout", "300"))
-CP_RETRIES = int(os.getenv("kubectl_cp_retries", "3"))
+CP_ATTEMPTS = int(os.getenv("kubectl_cp_attempts", "3"))
 
 
 class CombineApp:
@@ -103,28 +103,29 @@ class CombineApp:
         *,
         label: str,
         timeout: float = CP_TIMEOUT,
-        retries: int = CP_RETRIES,
+        attempts: int = CP_ATTEMPTS,
     ) -> None:
         """Run a `kubectl cp`, bounding it with a timeout and retrying transient stalls.
 
         `kubectl cp` streams a tar over the exec channel and can stall intermittently
-        with no output.  Each attempt is killed after `timeout` seconds and retried up
-        to `retries` times.  If every attempt fails, the failing copy is logged and the
-        process exits non-zero so the failure surfaces instead of hanging silently.
+        with no output.  Each attempt is killed after `timeout` seconds and the copy is
+        tried up to `attempts` times.  If every attempt fails, the failing copy is
+        logged and the process exits non-zero so the failure surfaces instead of
+        hanging silently.
 
         Args:
             cp_args: Arguments to `kubectl cp` (source and destination, plus any flags).
             label: Human-readable description of what is being copied, for logging.
             timeout: Per-attempt timeout in seconds.
-            retries: Number of attempts before giving up.
+            attempts: Total number of attempts before giving up.
         """
-        for attempt in range(1, retries + 1):
+        for attempt in range(1, attempts + 1):
             try:
                 proc = self.kubectl(["cp"] + cp_args, check_results=False, timeout=timeout)
             except subprocess.TimeoutExpired:
                 logging.warning(
                     f"Copy of {label} timed out after {timeout:g}s "
-                    f"(attempt {attempt}/{retries})."
+                    f"(attempt {attempt}/{attempts})."
                 )
                 continue
             if proc.returncode == 0:
@@ -133,9 +134,9 @@ class CombineApp:
                 return
             logging.warning(
                 f"Copy of {label} failed with return code {proc.returncode} "
-                f"(attempt {attempt}/{retries}).\n{proc.stderr.strip()}"
+                f"(attempt {attempt}/{attempts}).\n{proc.stderr.strip()}"
             )
-        logging.error(f"Failed to copy {label} after {retries} attempts; aborting.")
+        logging.error(f"Failed to copy {label} after {attempts} attempts; aborting.")
         sys.exit(1)
 
     def get_pod_id(self, service: CombineApp.Component, *, instance: int = 0) -> str:

--- a/maintenance/scripts/combine_app.py
+++ b/maintenance/scripts/combine_app.py
@@ -15,14 +15,13 @@ from typing import Any, Dict, List, Optional
 from maint_utils import run_cmd
 
 # A `kubectl cp` streams a tar over the exec channel and can stall intermittently,
-# which would otherwise hang forever (issue #4322).  Bound each copy with a timeout
-# so a stalled stream gets killed, and retry a few times so a transient stall is
-# recovered.  Both defaults are overridable via environment variables.
-CP_TIMEOUT = float(os.getenv("kubectl_cp_timeout", "300"))
+# which would otherwise hang forever.  Bound each copy with a timeout so a stalled
+# stream gets killed, and retry a few times so a transient stall is recovered.
 CP_ATTEMPTS = int(os.getenv("kubectl_cp_attempts", "3"))
+CP_TIMEOUT = float(os.getenv("kubectl_cp_timeout", "300"))
 # A fast-failing copy can exhaust all attempts within the same second, giving a
 # transient failure no time to clear; pause between attempts so the retries span time.
-CP_RETRY_DELAY = 5.0
+CP_RETRY_DELAY = 3.0
 
 
 class CombineApp:

--- a/maintenance/scripts/combine_app.py
+++ b/maintenance/scripts/combine_app.py
@@ -19,7 +19,7 @@ from maint_utils import run_cmd
 # stream gets killed, and retry a few times so a transient stall is recovered.
 # Clamp to a sane floor so a misconfigured env var can't skip the copy entirely.
 CP_ATTEMPTS = max(1, int(os.getenv("kubectl_cp_attempts", "3")))
-CP_TIMEOUT = max(10.0, float(os.getenv("kubectl_cp_timeout", "300")))
+CP_TIMEOUT_S = max(10.0, float(os.getenv("kubectl_cp_timeout_s", "300")))
 # A fast-failing copy can exhaust all attempts within the same second, giving a
 # transient failure no time to clear; pause between attempts so the retries span time.
 CP_RETRY_DELAY = 3.0
@@ -106,7 +106,7 @@ class CombineApp:
         cp_args: List[str],
         *,
         label: str,
-        timeout: float = CP_TIMEOUT,
+        timeout: float = CP_TIMEOUT_S,
         attempts: int = CP_ATTEMPTS,
     ) -> None:
         """Run a `kubectl cp`, bounding it with a timeout and retrying transient stalls.

--- a/maintenance/scripts/combine_app.py
+++ b/maintenance/scripts/combine_app.py
@@ -9,6 +9,7 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+import time
 from typing import Any, Dict, List, Optional
 
 from maint_utils import run_cmd
@@ -19,6 +20,9 @@ from maint_utils import run_cmd
 # recovered.  Both defaults are overridable via environment variables.
 CP_TIMEOUT = float(os.getenv("kubectl_cp_timeout", "300"))
 CP_ATTEMPTS = int(os.getenv("kubectl_cp_attempts", "3"))
+# A fast-failing copy can exhaust all attempts within the same second, giving a
+# transient failure no time to clear; pause between attempts so the retries span time.
+CP_RETRY_DELAY = 5.0
 
 
 class CombineApp:
@@ -109,9 +113,9 @@ class CombineApp:
 
         `kubectl cp` streams a tar over the exec channel and can stall intermittently
         with no output.  Each attempt is killed after `timeout` seconds and the copy is
-        tried up to `attempts` times.  If every attempt fails, the failing copy is
-        logged and the process exits non-zero so the failure surfaces instead of
-        hanging silently.
+        tried up to `attempts` times, pausing briefly between attempts.  If every
+        attempt fails, the failing copy is logged and the process exits non-zero so
+        the failure surfaces instead of hanging silently.
 
         Args:
             cp_args: Arguments to `kubectl cp` (source and destination, plus any flags).
@@ -127,15 +131,17 @@ class CombineApp:
                     f"Copy of {label} timed out after {timeout:g}s "
                     f"(attempt {attempt}/{attempts})."
                 )
-                continue
-            if proc.returncode == 0:
-                logging.debug(f"stderr:\n{proc.stderr.strip()}")
-                logging.debug(f"stdout:\n{proc.stdout.strip()}")
-                return
-            logging.warning(
-                f"Copy of {label} failed with return code {proc.returncode} "
-                f"(attempt {attempt}/{attempts}).\n{proc.stderr.strip()}"
-            )
+            else:
+                if proc.returncode == 0:
+                    logging.debug(f"stderr:\n{proc.stderr.strip()}")
+                    logging.debug(f"stdout:\n{proc.stdout.strip()}")
+                    return
+                logging.warning(
+                    f"Copy of {label} failed with return code {proc.returncode} "
+                    f"(attempt {attempt}/{attempts}).\n{proc.stderr.strip()}"
+                )
+            if attempt < attempts:
+                time.sleep(CP_RETRY_DELAY)
         logging.error(f"Failed to copy {label} after {attempts} attempts; aborting.")
         sys.exit(1)
 

--- a/maintenance/scripts/combine_app.py
+++ b/maintenance/scripts/combine_app.py
@@ -4,12 +4,21 @@ from __future__ import annotations
 
 from enum import Enum, unique
 import json
+import logging
+import os
 from pathlib import Path
 import subprocess
 import sys
 from typing import Any, Dict, List, Optional
 
 from maint_utils import run_cmd
+
+# A `kubectl cp` streams a tar over the exec channel and can stall intermittently,
+# which would otherwise hang forever (issue #4322).  Bound each copy with a timeout
+# so a stalled stream gets killed, and retry a few times so a transient stall is
+# recovered.  Both defaults are overridable via environment variables.
+CP_TIMEOUT = float(os.getenv("kubectl_cp_timeout", "300"))
+CP_RETRIES = int(os.getenv("kubectl_cp_retries", "3"))
 
 
 class CombineApp:
@@ -87,6 +96,47 @@ class CombineApp:
             check_results=check_results,
             timeout=timeout,
         )
+
+    def cp_with_retry(
+        self,
+        cp_args: List[str],
+        *,
+        label: str,
+        timeout: float = CP_TIMEOUT,
+        retries: int = CP_RETRIES,
+    ) -> None:
+        """Run a `kubectl cp`, bounding it with a timeout and retrying transient stalls.
+
+        `kubectl cp` streams a tar over the exec channel and can stall intermittently
+        with no output.  Each attempt is killed after `timeout` seconds and retried up
+        to `retries` times.  If every attempt fails, the failing copy is logged and the
+        process exits non-zero so the failure surfaces instead of hanging silently.
+
+        Args:
+            cp_args: Arguments to `kubectl cp` (source and destination, plus any flags).
+            label: Human-readable description of what is being copied, for logging.
+            timeout: Per-attempt timeout in seconds.
+            retries: Number of attempts before giving up.
+        """
+        for attempt in range(1, retries + 1):
+            try:
+                proc = self.kubectl(["cp"] + cp_args, check_results=False, timeout=timeout)
+            except subprocess.TimeoutExpired:
+                logging.warning(
+                    f"Copy of {label} timed out after {timeout:g}s "
+                    f"(attempt {attempt}/{retries})."
+                )
+                continue
+            if proc.returncode == 0:
+                logging.debug(f"stderr:\n{proc.stderr.strip()}")
+                logging.debug(f"stdout:\n{proc.stdout.strip()}")
+                return
+            logging.warning(
+                f"Copy of {label} failed with return code {proc.returncode} "
+                f"(attempt {attempt}/{retries}).\n{proc.stderr.strip()}"
+            )
+        logging.error(f"Failed to copy {label} after {retries} attempts; aborting.")
+        sys.exit(1)
 
     def get_pod_id(self, service: CombineApp.Component, *, instance: int = 0) -> str:
         """Look up the Kubernetes pod id for the specified service."""

--- a/maintenance/scripts/combine_backup.py
+++ b/maintenance/scripts/combine_backup.py
@@ -96,23 +96,23 @@ def main() -> None:
 
         with tarfile.open(backup_file, "x:gz") as tar:
             # cp, tar, and rm the db subdir
-            combine.kubectl(
+            combine.cp_with_retry(
                 [
-                    "cp",
                     f"{db_pod}:/{db_files_subdir}",
                     str(Path(backup_dir) / db_files_subdir),
-                ]
+                ],
+                label=f"database dump ({db_files_subdir})",
             )
             tar.add(db_files_subdir)
             rmtree(db_files_subdir)
 
             # cp, tar, and rm the backend subdir
-            combine.kubectl(
+            combine.cp_with_retry(
                 [
-                    "cp",
                     f"{backend_pod}:/home/app/{backend_files_subdir}/",
                     str(Path(backup_dir) / backend_files_subdir),
-                ]
+                ],
+                label=f"backend files ({backend_files_subdir})",
             )
             tar.add(backend_files_subdir)
             rmtree(backend_files_subdir)

--- a/maintenance/scripts/combine_restore.py
+++ b/maintenance/scripts/combine_restore.py
@@ -23,7 +23,6 @@ import logging
 import os
 from pathlib import Path
 import re
-import subprocess
 import sys
 import tarfile
 import tempfile
@@ -34,13 +33,6 @@ from combine_app import CombineApp
 import humanfriendly
 from maint_utils import check_env_vars
 from script_step import ScriptStep
-
-# A stalled `kubectl cp` stream would otherwise hang forever (issue #4322).  Bound
-# each copy with a timeout so a stalled stream gets killed, and retry a few times
-# so a transient stall is recovered instead of aborting the whole restore.  Both
-# values are overridable via environment variables.
-CP_TIMEOUT = float(os.getenv("kubectl_cp_timeout", "300"))
-CP_RETRIES = int(os.getenv("kubectl_cp_retries", "3"))
 
 
 def parse_args() -> argparse.Namespace:
@@ -65,35 +57,6 @@ def aws_strip_bucket(obj_name: str) -> str:
     if match is not None:
         return match.group(1)
     return obj_name
-
-
-def kubectl_cp(combine: CombineApp, cp_args: List[str], *, label: str) -> None:
-    """Run a `kubectl cp`, bounding it with a timeout and retrying transient stalls.
-
-    `kubectl cp` streams a tar over the exec channel and can stall intermittently
-    with no output.  Each attempt is killed after CP_TIMEOUT seconds and retried up
-    to CP_RETRIES times.  If every attempt fails, the failing copy is logged and the
-    restore exits non-zero so the failure surfaces instead of hanging silently.
-    """
-    for attempt in range(1, CP_RETRIES + 1):
-        try:
-            proc = combine.kubectl(["cp"] + cp_args, check_results=False, timeout=CP_TIMEOUT)
-        except subprocess.TimeoutExpired:
-            logging.warning(
-                f"Copy of {label} timed out after {CP_TIMEOUT:g}s "
-                f"(attempt {attempt}/{CP_RETRIES})."
-            )
-            continue
-        if proc.returncode == 0:
-            logging.debug(f"stderr:\n{proc.stderr.strip()}")
-            logging.debug(f"stdout:\n{proc.stdout.strip()}")
-            return
-        logging.warning(
-            f"Copy of {label} failed with return code {proc.returncode} "
-            f"(attempt {attempt}/{CP_RETRIES}).\n{proc.stderr.strip()}"
-        )
-    logging.error(f"Failed to copy {label} after {CP_RETRIES} attempts; aborting restore.")
-    sys.exit(1)
 
 
 def main() -> None:
@@ -197,8 +160,8 @@ def main() -> None:
             sys.exit(1)
 
         logging.debug(f"Copying {db_files_subdir} to {db_pod} ...")
-        kubectl_cp(
-            combine, [db_files_subdir, f"{db_pod}:/"], label=f"database dump ({db_files_subdir})"
+        combine.cp_with_retry(
+            [db_files_subdir, f"{db_pod}:/"], label=f"database dump ({db_files_subdir})"
         )
 
         logging.debug(f"Running mongorestore on {db_pod} ...")
@@ -240,8 +203,7 @@ def main() -> None:
                 continue
             logging.debug(f"Copying {item} ...")
             local_item = os.path.join(backend_files_subdir, item)
-            kubectl_cp(
-                combine,
+            combine.cp_with_retry(
                 [local_item, remote_subdir, "--no-preserve"],
                 label=f"backend files for {item}",
             )

--- a/maintenance/scripts/combine_restore.py
+++ b/maintenance/scripts/combine_restore.py
@@ -23,6 +23,7 @@ import logging
 import os
 from pathlib import Path
 import re
+import subprocess
 import sys
 import tarfile
 import tempfile
@@ -33,6 +34,13 @@ from combine_app import CombineApp
 import humanfriendly
 from maint_utils import check_env_vars
 from script_step import ScriptStep
+
+# A stalled `kubectl cp` stream would otherwise hang forever (issue #4322).  Bound
+# each copy with a timeout so a stalled stream gets killed, and retry a few times
+# so a transient stall is recovered instead of aborting the whole restore.  Both
+# values are overridable via environment variables.
+CP_TIMEOUT = float(os.getenv("kubectl_cp_timeout", "300"))
+CP_RETRIES = int(os.getenv("kubectl_cp_retries", "3"))
 
 
 def parse_args() -> argparse.Namespace:
@@ -57,6 +65,35 @@ def aws_strip_bucket(obj_name: str) -> str:
     if match is not None:
         return match.group(1)
     return obj_name
+
+
+def kubectl_cp(combine: CombineApp, cp_args: List[str], *, label: str) -> None:
+    """Run a `kubectl cp`, bounding it with a timeout and retrying transient stalls.
+
+    `kubectl cp` streams a tar over the exec channel and can stall intermittently
+    with no output.  Each attempt is killed after CP_TIMEOUT seconds and retried up
+    to CP_RETRIES times.  If every attempt fails, the failing copy is logged and the
+    restore exits non-zero so the failure surfaces instead of hanging silently.
+    """
+    for attempt in range(1, CP_RETRIES + 1):
+        try:
+            proc = combine.kubectl(["cp"] + cp_args, check_results=False, timeout=CP_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            logging.warning(
+                f"Copy of {label} timed out after {CP_TIMEOUT:g}s "
+                f"(attempt {attempt}/{CP_RETRIES})."
+            )
+            continue
+        if proc.returncode == 0:
+            logging.debug(f"stderr:\n{proc.stderr.strip()}")
+            logging.debug(f"stdout:\n{proc.stdout.strip()}")
+            return
+        logging.warning(
+            f"Copy of {label} failed with return code {proc.returncode} "
+            f"(attempt {attempt}/{CP_RETRIES}).\n{proc.stderr.strip()}"
+        )
+    logging.error(f"Failed to copy {label} after {CP_RETRIES} attempts; aborting restore.")
+    sys.exit(1)
 
 
 def main() -> None:
@@ -160,9 +197,9 @@ def main() -> None:
             sys.exit(1)
 
         logging.debug(f"Copying {db_files_subdir} to {db_pod} ...")
-        cp_proc = combine.kubectl(["cp", db_files_subdir, f"{db_pod}:/"])
-        logging.debug(f"stderr:\n{cp_proc.stderr.strip()}")
-        logging.debug(f"stdout:\n{cp_proc.stdout.strip()}")
+        kubectl_cp(
+            combine, [db_files_subdir, f"{db_pod}:/"], label=f"database dump ({db_files_subdir})"
+        )
 
         logging.debug(f"Running mongorestore on {db_pod} ...")
         mongorestore_proc = combine.exec(
@@ -203,7 +240,11 @@ def main() -> None:
                 continue
             logging.debug(f"Copying {item} ...")
             local_item = os.path.join(backend_files_subdir, item)
-            combine.kubectl(["cp", local_item, remote_subdir, "--no-preserve"])
+            kubectl_cp(
+                combine,
+                [local_item, remote_subdir, "--no-preserve"],
+                label=f"backend files for {item}",
+            )
 
 
 if __name__ == "__main__":

--- a/maintenance/scripts/maint_utils.py
+++ b/maintenance/scripts/maint_utils.py
@@ -6,7 +6,7 @@ import logging
 import os
 import subprocess
 import sys
-from typing import List
+from typing import List, Optional
 
 
 def check_env_vars(var_names: List[str]) -> tuple[str, ...]:
@@ -26,8 +26,18 @@ def check_env_vars(var_names: List[str]) -> tuple[str, ...]:
     return tuple(value_list)
 
 
-def run_cmd(cmd: List[str], *, check_results: bool = True) -> subprocess.CompletedProcess[str]:
-    """Run a command with subprocess and catch any CalledProcessErrors."""
+def run_cmd(
+    cmd: List[str], *, check_results: bool = True, timeout: Optional[float] = None
+) -> subprocess.CompletedProcess[str]:
+    """Run a command with subprocess and catch any CalledProcessErrors.
+
+    Args:
+        cmd: the command, as an argument list, to run.
+        check_results: if true, exit when the command returns a non-zero code.
+        timeout: if set, the command is killed and subprocess.TimeoutExpired is
+                 raised when it runs longer than this many seconds.  Callers that
+                 pass a timeout are responsible for handling TimeoutExpired.
+    """
     try:
         return subprocess.run(
             cmd,
@@ -35,6 +45,7 @@ def run_cmd(cmd: List[str], *, check_results: bool = True) -> subprocess.Complet
             stderr=subprocess.PIPE,
             universal_newlines=True,
             check=check_results,
+            timeout=timeout,
         )
     except subprocess.CalledProcessError as err:
         print("CalledProcessError")


### PR DESCRIPTION
## Fixes

Fixes #4322

## Problem

`maintenance/scripts/combine_restore.py` copies backend files into the backend pod with a per-project `kubectl cp` loop (and copies the DB dump the same way). `kubectl cp` streams a tar over the exec channel and can stall intermittently. Because `maint_utils.run_cmd()` called `subprocess.run(...)` with **no `timeout`**, a stalled copy hung **forever** with no error and no output. Since this is The Combine's disaster-recovery restore, a silent infinite hang is a serious reliability problem.

## Changes

- **`maint_utils.py`**: add an optional `timeout` parameter to `run_cmd()`, passed through to `subprocess.run(...)`. When set, a stalled command is killed and `subprocess.TimeoutExpired` is raised for the caller to handle. Default `None` preserves existing behavior.
- **`combine_app.py`**: thread `timeout` through `CombineApp.exec()` and `CombineApp.kubectl()` (also adding `check_results` to `kubectl()`).
- **`combine_restore.py`**: wrap each `kubectl cp` (the database dump and every backend-file item) in a new `kubectl_cp()` helper that:
  - bounds each attempt with a timeout so a stalled stream is killed;
  - retries a few times so a transient stall is recovered instead of aborting the whole restore;
  - on repeated failure, logs the failing item (project) and exits non-zero so it surfaces as an error rather than a silent hang.
- The timeout and retry count are configurable via the `kubectl_cp_timeout` (default 300s) and `kubectl_cp_retries` (default 3) environment variables.

I kept the existing per-item `kubectl cp` loop rather than switching to a single `tar`-pipe (listed as optional in the issue) to keep the change focused; the timeout/retry guard applies either way.

## Testing

- `tox` equivalents pass locally on the changed files: `isort --check`, `black --check`, `flake8`, and `mypy --platform linux maintenance/scripts` (strict) — all clean.
- Exercised the new logic directly:
  - `run_cmd(..., timeout=1)` on a 30s sleep raises `TimeoutExpired` (no longer hangs) and still returns output for fast commands.
  - `kubectl_cp()` succeeds without retry on a clean copy (and passes `check_results=False` + `timeout`), recovers from transient stalls (timeout → timeout → success), and exits non-zero after exhausting retries on repeated failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Devin review: https://app.devin.ai/review/sillsdev/TheCombine/pull/4323

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4323)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup and restore reliability by retrying file copy operations that can stall or fail temporarily.
  * Added timeouts to long-running copy and command operations so they fail more predictably instead of hanging indefinitely.
  * Backup and restore flows now use clearer copy-step labeling for better troubleshooting.

* **Chores**
  * Added configurable environment-based settings for copy timeouts and retry attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->