### PR TITLE
Cap UserEdit edits to fix 16 MB limit (do NOT merge until after v3)

### DIFF
--- a/Backend.Tests/Controllers/UserEditControllerTests.cs
+++ b/Backend.Tests/Controllers/UserEditControllerTests.cs
@@ -166,6 +166,28 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
+        public async Task TestAddGoalToUserEditTrimsToMaxEdits()
+        {
+            var userEdit = new UserEdit { ProjectId = ProjId };
+            foreach (var _ in Range(0, UserEdit.MaxEdits))
+            {
+                userEdit.Edits.Add(new Edit());
+            }
+            userEdit = await _userEditRepo.Create(userEdit);
+            var oldestEditGuid = userEdit.Edits.First().Guid;
+
+            var newEdit = new Edit();
+            var result = await _userEditController.UpdateUserEditGoal(ProjId, userEdit.Id, newEdit);
+            Assert.That(result, Is.InstanceOf<OkResult>());
+
+            var repoUserEdit = await _userEditRepo.GetUserEdit(ProjId, userEdit.Id);
+            Assert.That(repoUserEdit, Is.Not.Null);
+            Assert.That(repoUserEdit.Edits, Has.Count.EqualTo(UserEdit.MaxEdits));
+            Assert.That(repoUserEdit.Edits.Last().Guid, Is.EqualTo(newEdit.Guid));
+            Assert.That(repoUserEdit.Edits.Select(e => e.Guid), Does.Not.Contain(oldestEditGuid));
+        }
+
+        [Test]
         public async Task TestAddStepToGoal()
         {
             // Generate db entry to test.

--- a/Backend.Tests/Mocks/UserEditRepositoryMock.cs
+++ b/Backend.Tests/Mocks/UserEditRepositoryMock.cs
@@ -54,11 +54,59 @@ namespace Backend.Tests.Mocks
             return Task.FromResult(rmCount > 0);
         }
 
-        public Task<bool> Replace(string projectId, string userEditId, UserEdit userEdit)
+        public Task<bool> AddEdit(string projectId, string userEditId, Edit edit)
         {
-            var rmCount = _userEdits.RemoveAll(ue => ue.Id == userEditId);
-            _userEdits.Add(userEdit);
-            return Task.FromResult(rmCount > 0);
+            var userEdit = _userEdits.Find(ue => ue.ProjectId == projectId && ue.Id == userEditId);
+            if (userEdit is null)
+            {
+                return Task.FromResult(false);
+            }
+            userEdit.Edits.Add(edit.Clone());
+            // Mirror the real repository's negative $slice: keep only the most recent MaxEdits entries.
+            if (userEdit.Edits.Count > UserEdit.MaxEdits)
+            {
+                userEdit.Edits.RemoveRange(0, userEdit.Edits.Count - UserEdit.MaxEdits);
+            }
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> ReplaceEdit(string projectId, string userEditId, Edit edit)
+        {
+            var userEdit = _userEdits.Find(ue => ue.ProjectId == projectId && ue.Id == userEditId);
+            var editIndex = userEdit?.Edits.FindIndex(e => e.Guid == edit.Guid) ?? -1;
+            if (userEdit is null || editIndex == -1)
+            {
+                return Task.FromResult(false);
+            }
+            userEdit.Edits[editIndex] = edit.Clone();
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> AddStepToEdit(string projectId, string userEditId, Guid editGuid, string stepData)
+        {
+            var userEdit = _userEdits.Find(ue => ue.ProjectId == projectId && ue.Id == userEditId);
+            var edit = userEdit?.Edits.Find(e => e.Guid == editGuid);
+            if (edit is null)
+            {
+                return Task.FromResult(false);
+            }
+            edit.StepData.Add(stepData);
+            edit.Modified = DateTime.UtcNow;
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> UpdateStepInEdit(
+            string projectId, string userEditId, Guid editGuid, int stepIndex, string stepData)
+        {
+            var userEdit = _userEdits.Find(ue => ue.ProjectId == projectId && ue.Id == userEditId);
+            var edit = userEdit?.Edits.Find(e => e.Guid == editGuid);
+            if (edit is null)
+            {
+                return Task.FromResult(false);
+            }
+            edit.StepData[stepIndex] = stepData;
+            edit.Modified = DateTime.UtcNow;
+            return Task.FromResult(true);
         }
     }
 }

--- a/Backend.Tests/Repositories/UserEditRepositoryTests.cs
+++ b/Backend.Tests/Repositories/UserEditRepositoryTests.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using BackendFramework.Contexts;
+using BackendFramework.Models;
+using BackendFramework.Repositories;
+using Microsoft.Extensions.Options;
+using MongoDB.Bson;
+using NUnit.Framework;
+using static System.Linq.Enumerable;
+
+namespace Backend.Tests.Repositories
+{
+    /// <summary>
+    /// Integration tests for <see cref="UserEditRepository"/> that spin up an actual MongoDB instance.
+    /// </summary>
+    [TestFixture]
+    [Category("IntegrationTest")]
+    public sealed class UserEditRepositoryTests
+    {
+        private static MongoDbTestRunner _runner = null!;
+        private UserEditRepository _repo = null!;
+        private string _projectId = null!;
+
+        [OneTimeSetUp]
+        public static void StartMongo()
+        {
+            _runner?.Dispose();
+            _runner = MongoDbTestRunner.Start();
+        }
+
+        [OneTimeTearDown]
+        public static void StopMongo()
+        {
+            _runner?.Dispose();
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            _projectId = Guid.NewGuid().ToString();
+            var options = Options.Create(new BackendFramework.Startup.Settings
+            {
+                ConnectionString = _runner.ConnectionString,
+                CombineDatabase = "UserEditRepositoryTests",
+            });
+            _repo = new UserEditRepository(new MongoDbContext(options));
+        }
+
+        private Task<UserEdit> CreateUserEdit(params Edit[] edits)
+        {
+            return _repo.Create(new UserEdit { ProjectId = _projectId, Edits = [.. edits] });
+        }
+
+        /// <summary> Generates a valid MongoDB ObjectId string that does not exist in the database. </summary>
+        private static string NewObjectId() => ObjectId.GenerateNewId().ToString();
+
+        [Test]
+        public async Task TestAddEditAppendsToExistingUserEdit()
+        {
+            var userEdit = await CreateUserEdit(new Edit { StepData = ["step"] });
+            var newEdit = new Edit { GoalType = 2, Changes = "{\"a\":1}" };
+
+            var result = await _repo.AddEdit(_projectId, userEdit.Id, newEdit);
+
+            Assert.That(result, Is.True);
+            var retrieved = await _repo.GetUserEdit(_projectId, userEdit.Id);
+            Assert.That(retrieved, Is.Not.Null);
+            Assert.That(retrieved.Edits, Has.Count.EqualTo(2));
+            Assert.That(retrieved.Edits.Last().Guid, Is.EqualTo(newEdit.Guid));
+        }
+
+        [Test]
+        public async Task TestAddEditNonexistentUserEditReturnsFalse()
+        {
+            var result = await _repo.AddEdit(_projectId, NewObjectId(), new Edit());
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public async Task TestAddEditWrongProjectIdReturnsFalse()
+        {
+            var userEdit = await CreateUserEdit();
+            var result = await _repo.AddEdit(Guid.NewGuid().ToString(), userEdit.Id, new Edit());
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public async Task TestAddEditAtMaxEditsTrimsOldest()
+        {
+            var edits = Range(0, UserEdit.MaxEdits).Select(_ => new Edit()).ToArray();
+            var userEdit = await CreateUserEdit(edits);
+            var oldestEditGuid = edits.First().Guid;
+            var newEdit = new Edit();
+
+            var result = await _repo.AddEdit(_projectId, userEdit.Id, newEdit);
+
+            Assert.That(result, Is.True);
+            var retrieved = await _repo.GetUserEdit(_projectId, userEdit.Id);
+            Assert.That(retrieved, Is.Not.Null);
+            Assert.That(retrieved.Edits, Has.Count.EqualTo(UserEdit.MaxEdits));
+            Assert.That(retrieved.Edits.Last().Guid, Is.EqualTo(newEdit.Guid));
+            Assert.That(retrieved.Edits.Select(e => e.Guid), Does.Not.Contain(oldestEditGuid));
+        }
+
+        [Test]
+        public async Task TestReplaceEditReplacesMatchingElement()
+        {
+            var edit = new Edit { GoalType = 1, StepData = ["old"], Changes = "{}" };
+            var userEdit = await CreateUserEdit(new Edit(), edit);
+            var replacement = new Edit
+            {
+                Guid = edit.Guid,
+                GoalType = 3,
+                StepData = ["new"],
+                Changes = "{\"b\":2}",
+                Modified = DateTime.UtcNow,
+            };
+
+            var result = await _repo.ReplaceEdit(_projectId, userEdit.Id, replacement);
+
+            Assert.That(result, Is.True);
+            var retrieved = await _repo.GetUserEdit(_projectId, userEdit.Id);
+            Assert.That(retrieved, Is.Not.Null);
+            Assert.That(retrieved.Edits, Has.Count.EqualTo(2));
+            var retrievedEdit = retrieved.Edits.Find(e => e.Guid == edit.Guid);
+            Assert.That(retrievedEdit, Is.Not.Null);
+            Assert.That(retrievedEdit.GoalType, Is.EqualTo(replacement.GoalType));
+            Assert.That(retrievedEdit.StepData, Is.EqualTo(replacement.StepData));
+            Assert.That(retrievedEdit.Changes, Is.EqualTo(replacement.Changes));
+        }
+
+        [Test]
+        public async Task TestReplaceEditUnknownGuidReturnsFalse()
+        {
+            var userEdit = await CreateUserEdit(new Edit());
+            var result = await _repo.ReplaceEdit(_projectId, userEdit.Id, new Edit());
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public async Task TestAddStepToEditAppendsToRightEdit()
+        {
+            var targetEdit = new Edit { StepData = ["first"] };
+            var otherEdit = new Edit { StepData = ["other"] };
+            var userEdit = await CreateUserEdit(otherEdit, targetEdit);
+
+            var result = await _repo.AddStepToEdit(_projectId, userEdit.Id, targetEdit.Guid, "second");
+
+            Assert.That(result, Is.True);
+            var retrieved = await _repo.GetUserEdit(_projectId, userEdit.Id);
+            Assert.That(retrieved, Is.Not.Null);
+            var retrievedTarget = retrieved.Edits.Find(e => e.Guid == targetEdit.Guid);
+            Assert.That(retrievedTarget, Is.Not.Null);
+            Assert.That(retrievedTarget.StepData, Is.EqualTo(["first", "second"]));
+            var retrievedOther = retrieved.Edits.Find(e => e.Guid == otherEdit.Guid);
+            Assert.That(retrievedOther, Is.Not.Null);
+            Assert.That(retrievedOther.StepData, Is.EqualTo(["other"]));
+        }
+
+        [Test]
+        public async Task TestAddStepToEditUnknownGuidReturnsFalse()
+        {
+            var userEdit = await CreateUserEdit(new Edit());
+            var result = await _repo.AddStepToEdit(_projectId, userEdit.Id, Guid.NewGuid(), "step");
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public async Task TestUpdateStepInEditOverwritesRightIndex()
+        {
+            var edit = new Edit { StepData = ["a", "b", "c"] };
+            var userEdit = await CreateUserEdit(edit);
+
+            var result = await _repo.UpdateStepInEdit(_projectId, userEdit.Id, edit.Guid, 1, "B");
+
+            Assert.That(result, Is.True);
+            var retrieved = await _repo.GetUserEdit(_projectId, userEdit.Id);
+            Assert.That(retrieved, Is.Not.Null);
+            var retrievedEdit = retrieved.Edits.Find(e => e.Guid == edit.Guid);
+            Assert.That(retrievedEdit, Is.Not.Null);
+            Assert.That(retrievedEdit.StepData, Is.EqualTo(["a", "B", "c"]));
+        }
+
+        [Test]
+        public async Task TestUpdateStepInEditUnknownGuidReturnsFalse()
+        {
+            var userEdit = await CreateUserEdit(new Edit { StepData = ["a"] });
+            var result = await _repo.UpdateStepInEdit(_projectId, userEdit.Id, Guid.NewGuid(), 0, "A");
+            Assert.That(result, Is.False);
+        }
+    }
+}

--- a/Backend/Interfaces/IUserEditRepository.cs
+++ b/Backend/Interfaces/IUserEditRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using BackendFramework.Models;
 
@@ -11,6 +12,9 @@ namespace BackendFramework.Interfaces
         Task<UserEdit> Create(UserEdit userEdit);
         Task<bool> Delete(string projectId, string userEditId);
         Task<bool> DeleteAllUserEdits(string projectId);
-        Task<bool> Replace(string projectId, string userEditId, UserEdit userEdit);
+        Task<bool> AddEdit(string projectId, string userEditId, Edit edit);
+        Task<bool> ReplaceEdit(string projectId, string userEditId, Edit edit);
+        Task<bool> AddStepToEdit(string projectId, string userEditId, Guid editGuid, string stepData);
+        Task<bool> UpdateStepInEdit(string projectId, string userEditId, Guid editGuid, int stepIndex, string stepData);
     }
 }

--- a/Backend/Models/UserEdit.cs
+++ b/Backend/Models/UserEdit.cs
@@ -10,6 +10,13 @@ namespace BackendFramework.Models
     /// <summary> The changes a user has made on a particular project </summary>
     public class UserEdit
     {
+        /// <summary> Max length of <see cref="Edits"/>, capped to keep the document under MongoDB's 16 MB limit. </summary>
+        /// <remarks>
+        /// Production data showed edits averaging up to ~40 kB, so 250 keeps worst-case documents near 10 MB.
+        /// Keep in sync with the cap in database/trim-user-edits.js.
+        /// </remarks>
+        public const int MaxEdits = 250;
+
         [Required]
         [BsonId]
         [BsonRepresentation(BsonType.ObjectId)]

--- a/Backend/Repositories/UserEditRepository.cs
+++ b/Backend/Repositories/UserEditRepository.cs
@@ -6,6 +6,7 @@ using BackendFramework.Interfaces;
 using BackendFramework.Models;
 using BackendFramework.Otel;
 using MongoDB.Driver;
+using MongoDB.Driver.Linq;
 
 namespace BackendFramework.Repositories
 {
@@ -81,18 +82,91 @@ namespace BackendFramework.Repositories
             return deleted.DeletedCount > 0;
         }
 
-        /// <summary> Replaces <see cref="UserEdit"/> with specified userRoleId and projectId </summary>
+        /// <summary>
+        /// Appends an <see cref="Edit"/> to the <see cref="UserEdit"/> with specified userEditId and projectId,
+        /// dropping the oldest edits if the total exceeds <see cref="UserEdit.MaxEdits"/>.
+        /// </summary>
         /// <returns> A bool: success of operation </returns>
-        public async Task<bool> Replace(string projectId, string userEditId, UserEdit userEdit)
+        public async Task<bool> AddEdit(string projectId, string userEditId, Edit edit)
         {
-            using var activity = OtelService.StartActivityWithTag(otelTagName, "replacing a user edit");
+            using var activity = OtelService.StartActivityWithTag(otelTagName, "adding an edit to a user edit");
 
             var filterDef = new FilterDefinitionBuilder<UserEdit>();
             var filter = filterDef.And(filterDef.Eq(
                 x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, userEditId));
 
-            var result = await _userEdits.ReplaceOneAsync(filter, userEdit);
-            return result.ModifiedCount == 1;
+            // The negative slice atomically keeps only the most recent MaxEdits entries,
+            // preventing the document from growing towards MongoDB's 16 MB limit.
+            var update = Builders<UserEdit>.Update.PushEach(u => u.Edits, [edit], slice: -UserEdit.MaxEdits);
+            var result = await _userEdits.UpdateOneAsync(filter, update);
+            return result.IsAcknowledged && result.MatchedCount == 1;
+        }
+
+        /// <summary>
+        /// Replaces the <see cref="Edit"/> with matching guid in the <see cref="UserEdit"/>
+        /// with specified userEditId and projectId.
+        /// </summary>
+        /// <returns> A bool: success of operation </returns>
+        public async Task<bool> ReplaceEdit(string projectId, string userEditId, Edit edit)
+        {
+            using var activity = OtelService.StartActivityWithTag(otelTagName, "replacing an edit in a user edit");
+
+            var filterDef = new FilterDefinitionBuilder<UserEdit>();
+            var filter = filterDef.And(
+                filterDef.Eq(x => x.ProjectId, projectId),
+                filterDef.Eq(x => x.Id, userEditId),
+                filterDef.ElemMatch(x => x.Edits, e => e.Guid == edit.Guid));
+
+            var update = Builders<UserEdit>.Update.Set(u => u.Edits.FirstMatchingElement(), edit);
+            var result = await _userEdits.UpdateOneAsync(filter, update);
+            // MatchedCount, not ModifiedCount: replacing an edit with an identical one is still a success.
+            return result.IsAcknowledged && result.MatchedCount == 1;
+        }
+
+        /// <summary>
+        /// Appends a step to the <see cref="Edit"/> with matching guid in the <see cref="UserEdit"/>
+        /// with specified userEditId and projectId.
+        /// </summary>
+        /// <returns> A bool: success of operation </returns>
+        public async Task<bool> AddStepToEdit(string projectId, string userEditId, Guid editGuid, string stepData)
+        {
+            using var activity = OtelService.StartActivityWithTag(otelTagName, "adding a step to an edit");
+
+            var filterDef = new FilterDefinitionBuilder<UserEdit>();
+            var filter = filterDef.And(
+                filterDef.Eq(x => x.ProjectId, projectId),
+                filterDef.Eq(x => x.Id, userEditId),
+                filterDef.ElemMatch(x => x.Edits, e => e.Guid == editGuid));
+
+            var update = Builders<UserEdit>.Update
+                .Push(u => u.Edits.FirstMatchingElement().StepData, stepData)
+                .Set(u => u.Edits.FirstMatchingElement().Modified, DateTime.UtcNow);
+            var result = await _userEdits.UpdateOneAsync(filter, update);
+            return result.IsAcknowledged && result.MatchedCount == 1;
+        }
+
+        /// <summary>
+        /// Overwrites the step at the given index of the <see cref="Edit"/> with matching guid
+        /// in the <see cref="UserEdit"/> with specified userEditId and projectId.
+        /// </summary>
+        /// <remarks> The caller is responsible for ensuring that stepIndex is within bounds. </remarks>
+        /// <returns> A bool: success of operation </returns>
+        public async Task<bool> UpdateStepInEdit(
+            string projectId, string userEditId, Guid editGuid, int stepIndex, string stepData)
+        {
+            using var activity = OtelService.StartActivityWithTag(otelTagName, "updating a step in an edit");
+
+            var filterDef = new FilterDefinitionBuilder<UserEdit>();
+            var filter = filterDef.And(
+                filterDef.Eq(x => x.ProjectId, projectId),
+                filterDef.Eq(x => x.Id, userEditId),
+                filterDef.ElemMatch(x => x.Edits, e => e.Guid == editGuid));
+
+            var update = Builders<UserEdit>.Update
+                .Set($"edits.$.stepData.{stepIndex}", stepData)
+                .Set(u => u.Edits.FirstMatchingElement().Modified, DateTime.UtcNow);
+            var result = await _userEdits.UpdateOneAsync(filter, update);
+            return result.IsAcknowledged && result.MatchedCount == 1;
         }
     }
 }

--- a/Backend/Services/UserEditService.cs
+++ b/Backend/Services/UserEditService.cs
@@ -41,41 +41,20 @@ namespace BackendFramework.Services
             edit.Modified = DateTime.UtcNow;
 
             // Update existing Edit if guid exists, otherwise add new one at end of List.
-            var editIndex = userEdit.Edits.FindLastIndex(e => e.Guid == edit.Guid);
-            if (editIndex > -1)
-            {
-                userEdit.Edits[editIndex] = edit;
-            }
-            else
-            {
-                userEdit.Edits.Add(edit);
-            }
+            var isSuccess = userEdit.Edits.FindLastIndex(e => e.Guid == edit.Guid) > -1
+                ? await _userEditRepo.ReplaceEdit(projectId, userEditId, edit)
+                : await _userEditRepo.AddEdit(projectId, userEditId, edit);
 
-            // Replace the old UserEdit object with the new one that contains the new/updated edit
-            var editReplaced = await _userEditRepo.Replace(projectId, userEditId, userEdit);
-
-            return new Tuple<bool, Guid?>(editReplaced, edit.Guid);
+            return new Tuple<bool, Guid?>(isSuccess, edit.Guid);
         }
 
         /// <summary> Adds a string representation of a step to a specified <see cref="Edit"/> </summary>
-        /// <returns> A bool: success of operation </returns>
+        /// <returns> A bool: success of operation (false if userEdit or edit not found) </returns>
         public async Task<bool> AddStepToGoal(string projectId, string userEditId, Guid editGuid, string stepString)
         {
             using var activity = OtelService.StartActivityWithTag(otelTagName, "adding step to goal");
 
-            var userEdit = await _userEditRepo.GetUserEdit(projectId, userEditId);
-            if (userEdit is null)
-            {
-                return false;
-            }
-            var edit = userEdit.Edits.FindLast(e => e.Guid == editGuid);
-            if (edit is null)
-            {
-                return false;
-            }
-            edit.Modified = DateTime.UtcNow;
-            edit.StepData.Add(stepString);
-            return await _userEditRepo.Replace(projectId, userEditId, userEdit);
+            return await _userEditRepo.AddStepToEdit(projectId, userEditId, editGuid, stepString);
         }
 
         /// <summary> Updates a specified step in a specified <see cref="Edit"/> </summary>
@@ -89,6 +68,9 @@ namespace BackendFramework.Services
             {
                 return false;
             }
+
+            // Read first to bounds-check stepIndex: a $set beyond the array's end
+            // would pad the array with nulls instead of failing.
             var userEdit = await _userEditRepo.GetUserEdit(projectId, userEditId);
             if (userEdit is null)
             {
@@ -99,9 +81,7 @@ namespace BackendFramework.Services
             {
                 return false;
             }
-            edit.Modified = DateTime.UtcNow;
-            edit.StepData[stepIndex] = stepString;
-            return await _userEditRepo.Replace(projectId, userEditId, userEdit);
+            return await _userEditRepo.UpdateStepInEdit(projectId, userEditId, editGuid, stepIndex, stepString);
         }
     }
 }

--- a/database/trim-user-edits.js
+++ b/database/trim-user-edits.js
@@ -1,0 +1,60 @@
+// Migration script: trim oversized `edits` arrays in UserEditsCollection.
+//
+// Usage (local):
+//   mongosh CombineDatabase database/trim-user-edits.js
+//
+// Usage (Kubernetes, e.g. production):
+//   kubectl -n thecombine cp database/trim-user-edits.js <database-pod>:/tmp/trim-user-edits.js
+//   kubectl -n thecombine exec <database-pod> -- mongosh CombineDatabase /tmp/trim-user-edits.js
+//
+// IMPORTANT: Back up the database first (e.g., maintenance/scripts/combine_backup.py,
+// or at minimum `mongodump --db=CombineDatabase --collection=UserEditsCollection`).
+// Trimming discards the oldest entries of each oversized `edits` array; they are
+// unrecoverable without a backup.
+//
+// Background (https://github.com/sillsdev/TheCombine/issues/4320):
+//   UserEdit documents grow with every goal a user works on. Documents that
+//   approach MongoDB's 16 MB limit reject all further writes (WriteError 17419),
+//   permanently blocking the user's goal/step progress in that project.
+//   The backend now caps `edits` at the most recent MAX_EDITS entries on every
+//   append; this script applies the same cap to existing documents. Documents are
+//   trimmed in place — never deleted, since each user's `workedProjects` map
+//   references the document `_id`.
+
+// Keep in sync with UserEdit.MaxEdits in Backend/Models/UserEdit.cs.
+var MAX_EDITS = 250;
+
+var coll = db.getCollection("UserEditsCollection");
+var overCap = {
+  edits: { $exists: true, $type: "array" },
+  $expr: { $gt: [{ $size: "$edits" }, MAX_EDITS] },
+};
+
+print("UserEdit documents with more than " + MAX_EDITS + " edits:");
+var affected = 0;
+coll.find(overCap).forEach(function (doc) {
+  affected++;
+  print(
+    "  _id: " + doc._id.toString() + ", projectId: " + doc.projectId +
+    ", edits: " + doc.edits.length + ", size: " +
+    (Object.bsonsize(doc) / (1024 * 1024)).toFixed(2) + " MB"
+  );
+});
+print("Total: " + affected);
+
+if (affected > 0) {
+  // $push with an empty $each and negative $slice atomically keeps the last
+  // MAX_EDITS entries without rewriting the rest of the document.
+  var result = coll.updateMany(overCap, {
+    $push: { edits: { $each: [], $slice: -MAX_EDITS } },
+  });
+  print("Trimmed " + result.modifiedCount + " document(s) to the most recent " + MAX_EDITS + " edits.");
+}
+
+// Verify.
+var remaining = coll.countDocuments(overCap);
+if (remaining === 0) {
+  print("Verification passed: no documents exceed " + MAX_EDITS + " edits.");
+} else {
+  print("WARNING: " + remaining + " document(s) still exceed " + MAX_EDITS + " edits.");
+}


### PR DESCRIPTION
> [!CAUTION]
> **DO NOT MERGE until after the v3 release.** This PR changes the `UserEdit` write path and includes a data migration that trims production data. It is intentionally held back so it doesn't land in the v3 release; merge only once v3 has shipped and the migration plan below has been agreed on.

Resolves #4320

## Problem

A `UserEdit` document's `edits` array is unbounded, and every goal/step write loaded the full document and rewrote it with `ReplaceOneAsync`. Once a document neared MongoDB's 16 MB limit, every write failed with `WriteError 17419` and the user was permanently blocked from recording goal/step progress in that project (observed in production; see #4320).

## Fix

- **Targeted atomic updates instead of full-document replaces.** `UserEditRepository.Replace` is removed; goal and step writes now use `$push`/`$set` on just the affected `edits` element.
- **Server-side cap on `edits`.** Appending a new edit uses `$push` + `$slice: -UserEdit.MaxEdits`, so the array is atomically trimmed to the most recent `MaxEdits` entries on every append. Growth is bounded going forward.
- `MaxEdits = 250`: production documents that hit the limit held 387–976 edits at 14–16 MB (up to ~40 kB per edit), so 250 keeps worst-case documents around 10 MB. Value is easy to tune if we want to keep more history.

Because the capped `$push` produces a *smaller* resulting document, deploying this backend also unblocks already-affected users on their next goal write — the migration below is still needed to shrink oversized documents proactively (they slow down reads such as `GetProjectUserEdits`).

Frontend requires no changes: edits are addressed by GUID everywhere; nothing persists an index into the `edits` array.

## Mongo migration instructions

`database/trim-user-edits.js` trims every `UserEdit` document with more than 250 edits down to its most recent 250, in place (documents are never deleted — each user's `workedProjects` references the document `_id`). Run it once against production (and qa) after this PR is deployed:

1. **Back up first** — trimmed entries are unrecoverable without a backup:

   ```bash
   # full backup via the maintenance pod, or at minimum:
   mongodump --db=CombineDatabase --collection=UserEditsCollection
   ```

2. **Run the script** on the database pod:

   ```bash
   kubectl -n thecombine cp database/trim-user-edits.js <database-pod>:/tmp/trim-user-edits.js
   kubectl -n thecombine exec <database-pod> -- mongosh CombineDatabase /tmp/trim-user-edits.js
   ```

   The script prints each affected document (`_id`, project, edit count, size) before trimming and verifies afterward that no document exceeds the cap.

3. Per the precedent of the GUID-subtype migration (#4179 / #4209), the script can be removed from the repo in a follow-up once it has been run everywhere.

## Testing

- `dotnet build BackendFramework.sln`: 0 warnings, 0 errors.
- `dotnet test Backend.Tests`: 1186/1186 passed, including 12 new `UserEditRepositoryTests` integration tests that run the new atomic updates against a real (ephemeral) mongod — append, cap-trim (oldest dropped, newest last), replace-by-guid, step append/overwrite, and false-on-missing cases — plus a controller-level trim test via the mock.
- `npm run fmt-backend`: clean.
- Step writes previously stamped `Edit.Modified`; the new `$push`/`$set` updates preserve that (the goal history UI displays it).

## Notes for reviewers

- `Replace` had no callers outside `UserEditService`, so it was removed from `IUserEditRepository`, the repository, and the mock rather than left as dead code that reintroduces the full-document-rewrite pattern.
- Each `Edit.changes` blob is still unbounded (a single huge edit could in theory exceed limits on its own); trimming what's stored per edit and/or moving edits to their own collection remain the longer-term options discussed in #4320.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4327)
<!-- Reviewable:end -->
