### PR TITLE
Move edits to their own collection

### DIFF
--- a/Backend.Tests/Controllers/UserEditControllerTests.cs
+++ b/Backend.Tests/Controllers/UserEditControllerTests.cs
@@ -148,6 +148,25 @@ namespace Backend.Tests.Controllers
         }
 
         [Test]
+        public async Task TestUpdateGoalInUserEdit()
+        {
+            var userEdit = RandomUserEdit();
+            await _userEditRepo.Create(userEdit);
+            var existingEdit = userEdit.Edits.First();
+
+            var updatedEdit = existingEdit.Clone();
+            updatedEdit.GoalType = existingEdit.GoalType + 1;
+            updatedEdit.StepData = ["A revised step"];
+            await _userEditController.UpdateUserEditGoal(ProjId, userEdit.Id, updatedEdit);
+
+            var repoUserEdit = await _userEditRepo.GetUserEdit(ProjId, userEdit.Id);
+            Assert.That(repoUserEdit, Is.Not.Null);
+            Assert.That(repoUserEdit.Edits, Has.Count.EqualTo(1));
+            Assert.That(repoUserEdit.Edits.First().GoalType, Is.EqualTo(updatedEdit.GoalType));
+            Assert.That(repoUserEdit.Edits.First().StepData, Is.EqualTo(updatedEdit.StepData));
+        }
+
+        [Test]
         public async Task TestAddGoalToUserEditNoPermissions()
         {
             _userEditController.ControllerContext.HttpContext = PermissionServiceMock.UnauthorizedHttpContext();

--- a/Backend.Tests/Mocks/UserEditRepositoryMock.cs
+++ b/Backend.Tests/Mocks/UserEditRepositoryMock.cs
@@ -69,7 +69,7 @@ namespace Backend.Tests.Mocks
         public Task<bool> ReplaceEdit(string projectId, string userEditId, Edit edit)
         {
             var userEdit = _userEdits.Find(ue => ue.ProjectId == projectId && ue.Id == userEditId);
-            var editIndex = userEdit?.Edits.FindIndex(e => e.Guid == edit.Guid) ?? -1;
+            var editIndex = userEdit?.Edits.FindLastIndex(e => e.Guid == edit.Guid) ?? -1;
             if (userEdit is null || editIndex == -1)
             {
                 return Task.FromResult(false);

--- a/Backend.Tests/Mocks/UserEditRepositoryMock.cs
+++ b/Backend.Tests/Mocks/UserEditRepositoryMock.cs
@@ -26,7 +26,7 @@ namespace Backend.Tests.Mocks
         {
             try
             {
-                var foundUserEdit = _userEdits.Single(ue => ue.Id == userEditId);
+                var foundUserEdit = _userEdits.Single(ue => ue.ProjectId == projectId && ue.Id == userEditId);
                 return Task.FromResult<UserEdit?>(foundUserEdit.Clone());
             }
             catch (InvalidOperationException)
@@ -44,13 +44,14 @@ namespace Backend.Tests.Mocks
 
         public Task<bool> DeleteAllUserEdits(string projectId)
         {
-            _userEdits.Clear();
-            return Task.FromResult(true);
+            var rmCount = _userEdits.RemoveAll(userEdit => userEdit.ProjectId == projectId);
+            return Task.FromResult(rmCount > 0);
         }
 
         public Task<bool> Delete(string projectId, string userEditId)
         {
-            var rmCount = _userEdits.RemoveAll(userEdit => userEdit.Id == userEditId);
+            var rmCount = _userEdits.RemoveAll(
+                userEdit => userEdit.ProjectId == projectId && userEdit.Id == userEditId);
             return Task.FromResult(rmCount > 0);
         }
 
@@ -95,7 +96,7 @@ namespace Backend.Tests.Mocks
         {
             var userEdit = _userEdits.Find(ue => ue.ProjectId == projectId && ue.Id == userEditId);
             var edit = userEdit?.Edits.Find(e => e.Guid == editGuid);
-            if (edit is null)
+            if (edit is null || stepIndex < 0 || stepIndex >= edit.StepData.Count)
             {
                 return Task.FromResult(false);
             }

--- a/Backend.Tests/Mocks/UserEditRepositoryMock.cs
+++ b/Backend.Tests/Mocks/UserEditRepositoryMock.cs
@@ -69,7 +69,8 @@ namespace Backend.Tests.Mocks
         public Task<bool> ReplaceEdit(string projectId, string userEditId, Edit edit)
         {
             var userEdit = _userEdits.Find(ue => ue.ProjectId == projectId && ue.Id == userEditId);
-            var editIndex = userEdit?.Edits.FindLastIndex(e => e.Guid == edit.Guid) ?? -1;
+            // Match the first entry by guid, as MongoDB's UpdateOne does in the real repository.
+            var editIndex = userEdit?.Edits.FindIndex(e => e.Guid == edit.Guid) ?? -1;
             if (userEdit is null || editIndex == -1)
             {
                 return Task.FromResult(false);

--- a/Backend.Tests/Mocks/UserEditRepositoryMock.cs
+++ b/Backend.Tests/Mocks/UserEditRepositoryMock.cs
@@ -54,11 +54,54 @@ namespace Backend.Tests.Mocks
             return Task.FromResult(rmCount > 0);
         }
 
-        public Task<bool> Replace(string projectId, string userEditId, UserEdit userEdit)
+        public Task<bool> AddEdit(string projectId, string userEditId, Edit edit)
         {
-            var rmCount = _userEdits.RemoveAll(ue => ue.Id == userEditId);
-            _userEdits.Add(userEdit);
-            return Task.FromResult(rmCount > 0);
+            var userEdit = _userEdits.Find(ue => ue.ProjectId == projectId && ue.Id == userEditId);
+            if (userEdit is null)
+            {
+                return Task.FromResult(false);
+            }
+            userEdit.Edits.Add(edit.Clone());
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> ReplaceEdit(string projectId, string userEditId, Edit edit)
+        {
+            var userEdit = _userEdits.Find(ue => ue.ProjectId == projectId && ue.Id == userEditId);
+            var editIndex = userEdit?.Edits.FindIndex(e => e.Guid == edit.Guid) ?? -1;
+            if (userEdit is null || editIndex == -1)
+            {
+                return Task.FromResult(false);
+            }
+            userEdit.Edits[editIndex] = edit.Clone();
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> AddStepToEdit(string projectId, string userEditId, Guid editGuid, string stepData)
+        {
+            var userEdit = _userEdits.Find(ue => ue.ProjectId == projectId && ue.Id == userEditId);
+            var edit = userEdit?.Edits.Find(e => e.Guid == editGuid);
+            if (edit is null)
+            {
+                return Task.FromResult(false);
+            }
+            edit.StepData.Add(stepData);
+            edit.Modified = DateTime.UtcNow;
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> UpdateStepInEdit(
+            string projectId, string userEditId, Guid editGuid, int stepIndex, string stepData)
+        {
+            var userEdit = _userEdits.Find(ue => ue.ProjectId == projectId && ue.Id == userEditId);
+            var edit = userEdit?.Edits.Find(e => e.Guid == editGuid);
+            if (edit is null)
+            {
+                return Task.FromResult(false);
+            }
+            edit.StepData[stepIndex] = stepData;
+            edit.Modified = DateTime.UtcNow;
+            return Task.FromResult(true);
         }
     }
 }

--- a/Backend.Tests/Repositories/MongoDbSetUpFixture.cs
+++ b/Backend.Tests/Repositories/MongoDbSetUpFixture.cs
@@ -1,0 +1,26 @@
+using NUnit.Framework;
+
+namespace Backend.Tests.Repositories
+{
+    /// <summary>
+    /// Starts a single shared MongoDB instance for all repository integration tests.
+    /// Fixtures isolate themselves by using distinct database names.
+    /// </summary>
+    [SetUpFixture]
+    public sealed class MongoDbSetUpFixture
+    {
+        internal static MongoDbTestRunner Runner { get; private set; } = null!;
+
+        [OneTimeSetUp]
+        public void StartMongo()
+        {
+            Runner = MongoDbTestRunner.Start();
+        }
+
+        [OneTimeTearDown]
+        public void StopMongo()
+        {
+            Runner?.Dispose();
+        }
+    }
+}

--- a/Backend.Tests/Repositories/UserEditRepositoryTests.cs
+++ b/Backend.Tests/Repositories/UserEditRepositoryTests.cs
@@ -1,0 +1,353 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BackendFramework.Contexts;
+using BackendFramework.Models;
+using BackendFramework.Repositories;
+using Microsoft.Extensions.Options;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using NUnit.Framework;
+
+namespace Backend.Tests.Repositories
+{
+    /// <summary>
+    /// Integration tests for <see cref="UserEditRepository"/> that spin up an actual MongoDB instance.
+    /// </summary>
+    [TestFixture]
+    [Category("IntegrationTest")]
+    public sealed class UserEditRepositoryTests
+    {
+        private static MongoDbTestRunner _runner = null!;
+        private MongoDbContext _dbContext = null!;
+        private UserEditRepository _repo = null!;
+        private IMongoCollection<StoredEdit> _editsCollection = null!;
+        private string _projectId = null!;
+
+        [OneTimeSetUp]
+        public static void StartMongo()
+        {
+            _runner?.Dispose();
+            _runner = MongoDbTestRunner.Start();
+        }
+
+        [OneTimeTearDown]
+        public static void StopMongo()
+        {
+            _runner?.Dispose();
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            _projectId = Guid.NewGuid().ToString();
+            var options = Options.Create(new BackendFramework.Startup.Settings
+            {
+                ConnectionString = _runner.ConnectionString,
+                CombineDatabase = "UserEditRepositoryTests",
+            });
+            _dbContext = new MongoDbContext(options);
+            _repo = new UserEditRepository(_dbContext);
+            _editsCollection = _dbContext.Db.GetCollection<StoredEdit>("EditsCollection");
+        }
+
+        private Task<UserEdit> CreateUserEdit(params Edit[] edits)
+        {
+            return _repo.Create(new UserEdit { ProjectId = _projectId, Edits = [.. edits] });
+        }
+
+        /// <summary> Generates a valid MongoDB ObjectId string that does not exist in the database. </summary>
+        private static string NewObjectId() => ObjectId.GenerateNewId().ToString();
+
+        /// <summary> Gets all EditsCollection documents for a user edit in the test project. </summary>
+        private Task<List<StoredEdit>> GetStoredEdits(string userEditId)
+        {
+            return _editsCollection
+                .Find(e => e.ProjectId == _projectId && e.UserEditId == userEditId).ToListAsync();
+        }
+
+        /// <summary> Counts EditsCollection documents (in any project) for an edit guid. </summary>
+        private async Task<long> CountStoredEditsWithGuid(Guid editGuid)
+        {
+            return await _editsCollection.CountDocumentsAsync(e => e.Guid == editGuid);
+        }
+
+        [Test]
+        public async Task TestCreateEmptyUserEditSetsId()
+        {
+            var userEdit = await CreateUserEdit();
+
+            Assert.That(userEdit.Id, Is.Not.Empty);
+            var retrieved = await _repo.GetUserEdit(_projectId, userEdit.Id);
+            Assert.That(retrieved, Is.Not.Null);
+            Assert.That(retrieved.Edits, Is.Empty);
+        }
+
+        [Test]
+        public async Task TestCreateWithEditsPersistsStoredEditDocuments()
+        {
+            var modified = new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+            var editA = new Edit { GoalType = 1, StepData = ["a1", "a2"], Changes = "{\"a\":1}", Modified = modified };
+            var editB = new Edit { GoalType = 2, StepData = ["b"], Changes = "{\"b\":2}" };
+
+            var userEdit = await CreateUserEdit(editA, editB);
+
+            // The returned wire object keeps its edits and gains an id.
+            Assert.That(userEdit.Id, Is.Not.Empty);
+            Assert.That(userEdit.Edits, Has.Count.EqualTo(2));
+
+            // One StoredEdit document per edit, each with the correct projectId and userEditId.
+            var storedEdits = await GetStoredEdits(userEdit.Id);
+            Assert.That(storedEdits, Has.Count.EqualTo(2));
+            var storedIdsByGuid = storedEdits.ToDictionary(e => e.Guid, e => e.Id);
+
+            // The UserEdit document's edits array holds ObjectId refs to those documents, in order.
+            var rawUserEdits = _dbContext.Db.GetCollection<BsonDocument>("UserEditsCollection");
+            var rawDoc = await rawUserEdits.Find(new BsonDocument("_id", ObjectId.Parse(userEdit.Id))).FirstAsync();
+            var refs = rawDoc["edits"].AsBsonArray;
+            Assert.That(refs.Select(r => r.BsonType), Is.All.EqualTo(BsonType.ObjectId));
+            Assert.That(refs.Select(r => r.AsObjectId.ToString()),
+                Is.EqualTo(new[] { storedIdsByGuid[editA.Guid], storedIdsByGuid[editB.Guid] }));
+
+            // GetUserEdit round-trips all edit fields.
+            var retrieved = await _repo.GetUserEdit(_projectId, userEdit.Id);
+            Assert.That(retrieved, Is.Not.Null);
+            Assert.That(retrieved.ProjectId, Is.EqualTo(_projectId));
+            Assert.That(retrieved.Edits, Is.EqualTo(new[] { editA, editB }).UsingPropertiesComparer());
+        }
+
+        [Test]
+        public async Task TestGetUserEditNonexistentReturnsNull()
+        {
+            var retrieved = await _repo.GetUserEdit(_projectId, NewObjectId());
+            Assert.That(retrieved, Is.Null);
+        }
+
+        [Test]
+        public async Task TestGetUserEditAssemblesEditsInInsertionOrder()
+        {
+            var userEdit = await CreateUserEdit();
+            var edits = new List<Edit> { new(), new(), new() };
+            foreach (var edit in edits)
+            {
+                Assert.That(await _repo.AddEdit(_projectId, userEdit.Id, edit), Is.True);
+            }
+
+            var retrieved = await _repo.GetUserEdit(_projectId, userEdit.Id);
+            Assert.That(retrieved, Is.Not.Null);
+            Assert.That(retrieved.Edits.Select(e => e.Guid), Is.EqualTo(edits.Select(e => e.Guid)));
+        }
+
+        [Test]
+        public async Task TestGetAllUserEditsExcludesOtherProjects()
+        {
+            var userEditA = await CreateUserEdit(new Edit { StepData = ["a"] });
+            var userEditB = await CreateUserEdit(new Edit { StepData = ["b1"] }, new Edit { StepData = ["b2"] });
+            var otherUserEdit = await _repo.Create(
+                new UserEdit { ProjectId = Guid.NewGuid().ToString(), Edits = [new Edit()] });
+
+            var userEdits = await _repo.GetAllUserEdits(_projectId);
+
+            Assert.That(userEdits, Has.Count.EqualTo(2));
+            Assert.That(userEdits.Select(u => u.Id), Does.Not.Contain(otherUserEdit.Id));
+            var retrievedA = userEdits.Find(u => u.Id == userEditA.Id);
+            Assert.That(retrievedA, Is.Not.Null);
+            Assert.That(retrievedA.Edits, Is.EqualTo(userEditA.Edits).UsingPropertiesComparer());
+            var retrievedB = userEdits.Find(u => u.Id == userEditB.Id);
+            Assert.That(retrievedB, Is.Not.Null);
+            Assert.That(retrievedB.Edits, Is.EqualTo(userEditB.Edits).UsingPropertiesComparer());
+        }
+
+        [Test]
+        public async Task TestAddEditAppendsToExistingUserEdit()
+        {
+            var userEdit = await CreateUserEdit(new Edit { StepData = ["step"] });
+            var newEdit = new Edit { GoalType = 2, Changes = "{\"a\":1}" };
+
+            var result = await _repo.AddEdit(_projectId, userEdit.Id, newEdit);
+
+            Assert.That(result, Is.True);
+            var retrieved = await _repo.GetUserEdit(_projectId, userEdit.Id);
+            Assert.That(retrieved, Is.Not.Null);
+            Assert.That(retrieved.Edits, Has.Count.EqualTo(2));
+            Assert.That(retrieved.Edits.Last().Guid, Is.EqualTo(newEdit.Guid));
+
+            // The EditsCollection gained a document with the correct projectId and userEditId.
+            var storedEdits = await GetStoredEdits(userEdit.Id);
+            Assert.That(storedEdits, Has.Count.EqualTo(2));
+            Assert.That(storedEdits.Select(e => e.Guid), Does.Contain(newEdit.Guid));
+        }
+
+        [Test]
+        public async Task TestAddEditNonexistentUserEditReturnsFalse()
+        {
+            var edit = new Edit();
+            var result = await _repo.AddEdit(_projectId, NewObjectId(), edit);
+
+            Assert.That(result, Is.False);
+            // The transaction must abort without leaving an orphaned EditsCollection document.
+            Assert.That(await CountStoredEditsWithGuid(edit.Guid), Is.Zero);
+        }
+
+        [Test]
+        public async Task TestAddEditWrongProjectIdReturnsFalse()
+        {
+            var userEdit = await CreateUserEdit();
+            var edit = new Edit();
+            var result = await _repo.AddEdit(Guid.NewGuid().ToString(), userEdit.Id, edit);
+
+            Assert.That(result, Is.False);
+            // The transaction must abort without leaving an orphaned EditsCollection document.
+            Assert.That(await CountStoredEditsWithGuid(edit.Guid), Is.Zero);
+        }
+
+        [Test]
+        public async Task TestReplaceEditReplacesMatchingEdit()
+        {
+            var edit = new Edit { GoalType = 1, StepData = ["old"], Changes = "{}" };
+            var userEdit = await CreateUserEdit(new Edit(), edit);
+            var replacement = new Edit
+            {
+                Guid = edit.Guid,
+                GoalType = 3,
+                StepData = ["new"],
+                Changes = "{\"b\":2}",
+                Modified = new DateTime(2024, 5, 6, 7, 8, 9, DateTimeKind.Utc),
+            };
+
+            var result = await _repo.ReplaceEdit(_projectId, userEdit.Id, replacement);
+
+            Assert.That(result, Is.True);
+            var retrieved = await _repo.GetUserEdit(_projectId, userEdit.Id);
+            Assert.That(retrieved, Is.Not.Null);
+            Assert.That(retrieved.Edits, Has.Count.EqualTo(2));
+            var retrievedEdit = retrieved.Edits.Find(e => e.Guid == edit.Guid);
+            Assert.That(retrievedEdit, Is.EqualTo(replacement).UsingPropertiesComparer());
+        }
+
+        [Test]
+        public async Task TestReplaceEditIdenticalEditReturnsTrue()
+        {
+            var edit = new Edit { GoalType = 1, StepData = ["step"] };
+            var userEdit = await CreateUserEdit(edit);
+            var result = await _repo.ReplaceEdit(_projectId, userEdit.Id, edit);
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public async Task TestReplaceEditUnknownGuidReturnsFalse()
+        {
+            var userEdit = await CreateUserEdit(new Edit());
+            var result = await _repo.ReplaceEdit(_projectId, userEdit.Id, new Edit());
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public async Task TestAddStepToEditAppendsToRightEdit()
+        {
+            var targetEdit = new Edit { StepData = ["first"] };
+            var otherEdit = new Edit { StepData = ["other"] };
+            var userEdit = await CreateUserEdit(otherEdit, targetEdit);
+
+            var result = await _repo.AddStepToEdit(_projectId, userEdit.Id, targetEdit.Guid, "second");
+
+            Assert.That(result, Is.True);
+            var retrieved = await _repo.GetUserEdit(_projectId, userEdit.Id);
+            Assert.That(retrieved, Is.Not.Null);
+            var retrievedTarget = retrieved.Edits.Find(e => e.Guid == targetEdit.Guid);
+            Assert.That(retrievedTarget, Is.Not.Null);
+            Assert.That(retrievedTarget.StepData, Is.EqualTo(["first", "second"]));
+            Assert.That(retrievedTarget.Modified, Is.Not.Null);
+            var retrievedOther = retrieved.Edits.Find(e => e.Guid == otherEdit.Guid);
+            Assert.That(retrievedOther, Is.Not.Null);
+            Assert.That(retrievedOther.StepData, Is.EqualTo(["other"]));
+        }
+
+        [Test]
+        public async Task TestAddStepToEditUnknownGuidReturnsFalse()
+        {
+            var userEdit = await CreateUserEdit(new Edit());
+            var result = await _repo.AddStepToEdit(_projectId, userEdit.Id, Guid.NewGuid(), "step");
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public async Task TestUpdateStepInEditOverwritesRightIndex()
+        {
+            var edit = new Edit { StepData = ["a", "b", "c"] };
+            var userEdit = await CreateUserEdit(edit);
+
+            var result = await _repo.UpdateStepInEdit(_projectId, userEdit.Id, edit.Guid, 1, "B");
+
+            Assert.That(result, Is.True);
+            var retrieved = await _repo.GetUserEdit(_projectId, userEdit.Id);
+            Assert.That(retrieved, Is.Not.Null);
+            var retrievedEdit = retrieved.Edits.Find(e => e.Guid == edit.Guid);
+            Assert.That(retrievedEdit, Is.Not.Null);
+            Assert.That(retrievedEdit.StepData, Is.EqualTo(["a", "B", "c"]));
+            Assert.That(retrievedEdit.Modified, Is.Not.Null);
+        }
+
+        [Test]
+        public async Task TestUpdateStepInEditUnknownGuidReturnsFalse()
+        {
+            var userEdit = await CreateUserEdit(new Edit { StepData = ["a"] });
+            var result = await _repo.UpdateStepInEdit(_projectId, userEdit.Id, Guid.NewGuid(), 0, "A");
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public async Task TestDeleteRemovesUserEditAndItsEdits()
+        {
+            var userEdit = await CreateUserEdit(new Edit(), new Edit());
+            var otherUserEdit = await CreateUserEdit(new Edit());
+
+            var result = await _repo.Delete(_projectId, userEdit.Id);
+
+            Assert.That(result, Is.True);
+            Assert.That(await _repo.GetUserEdit(_projectId, userEdit.Id), Is.Null);
+            Assert.That(await GetStoredEdits(userEdit.Id), Is.Empty);
+
+            // Another user edit in the same project is untouched.
+            Assert.That(await GetStoredEdits(otherUserEdit.Id), Has.Count.EqualTo(1));
+            var retrievedOther = await _repo.GetUserEdit(_projectId, otherUserEdit.Id);
+            Assert.That(retrievedOther, Is.Not.Null);
+            Assert.That(retrievedOther.Edits, Has.Count.EqualTo(1));
+        }
+
+        [Test]
+        public async Task TestDeleteNonexistentUserEditReturnsFalse()
+        {
+            var result = await _repo.Delete(_projectId, NewObjectId());
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public async Task TestDeleteAllUserEditsRemovesProjectDocuments()
+        {
+            await CreateUserEdit(new Edit());
+            await CreateUserEdit(new Edit(), new Edit());
+            var otherProjectId = Guid.NewGuid().ToString();
+            var otherUserEdit = await _repo.Create(new UserEdit { ProjectId = otherProjectId, Edits = [new Edit()] });
+
+            var result = await _repo.DeleteAllUserEdits(_projectId);
+
+            Assert.That(result, Is.True);
+            Assert.That(await _repo.GetAllUserEdits(_projectId), Is.Empty);
+            Assert.That(await _editsCollection.CountDocumentsAsync(e => e.ProjectId == _projectId), Is.Zero);
+
+            // Another project's documents are untouched.
+            var retrievedOther = await _repo.GetUserEdit(otherProjectId, otherUserEdit.Id);
+            Assert.That(retrievedOther, Is.Not.Null);
+            Assert.That(retrievedOther.Edits, Has.Count.EqualTo(1));
+        }
+
+        [Test]
+        public async Task TestDeleteAllUserEditsEmptyProjectReturnsFalse()
+        {
+            var result = await _repo.DeleteAllUserEdits(_projectId);
+            Assert.That(result, Is.False);
+        }
+    }
+}

--- a/Backend.Tests/Repositories/UserEditRepositoryTests.cs
+++ b/Backend.Tests/Repositories/UserEditRepositoryTests.cs
@@ -19,24 +19,10 @@ namespace Backend.Tests.Repositories
     [Category("IntegrationTest")]
     public sealed class UserEditRepositoryTests
     {
-        private static MongoDbTestRunner _runner = null!;
         private MongoDbContext _dbContext = null!;
         private UserEditRepository _repo = null!;
         private IMongoCollection<StoredEdit> _editsCollection = null!;
         private string _projectId = null!;
-
-        [OneTimeSetUp]
-        public static void StartMongo()
-        {
-            _runner?.Dispose();
-            _runner = MongoDbTestRunner.Start();
-        }
-
-        [OneTimeTearDown]
-        public static void StopMongo()
-        {
-            _runner?.Dispose();
-        }
 
         [SetUp]
         public void SetUp()
@@ -44,7 +30,7 @@ namespace Backend.Tests.Repositories
             _projectId = Guid.NewGuid().ToString();
             var options = Options.Create(new BackendFramework.Startup.Settings
             {
-                ConnectionString = _runner.ConnectionString,
+                ConnectionString = MongoDbSetUpFixture.Runner.ConnectionString,
                 CombineDatabase = "UserEditRepositoryTests",
             });
             _dbContext = new MongoDbContext(options);
@@ -295,6 +281,22 @@ namespace Backend.Tests.Repositories
             var userEdit = await CreateUserEdit(new Edit { StepData = ["a"] });
             var result = await _repo.UpdateStepInEdit(_projectId, userEdit.Id, Guid.NewGuid(), 0, "A");
             Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public async Task TestUpdateStepInEditOutOfBoundsReturnsFalseWithoutPadding()
+        {
+            var edit = new Edit { StepData = ["a"] };
+            var userEdit = await CreateUserEdit(edit);
+
+            var result = await _repo.UpdateStepInEdit(_projectId, userEdit.Id, edit.Guid, 2, "C");
+
+            Assert.That(result, Is.False);
+            var retrieved = await _repo.GetUserEdit(_projectId, userEdit.Id);
+            Assert.That(retrieved, Is.Not.Null);
+            var retrievedEdit = retrieved.Edits.Find(e => e.Guid == edit.Guid);
+            Assert.That(retrievedEdit, Is.Not.Null);
+            Assert.That(retrievedEdit.StepData, Is.EqualTo(["a"]));
         }
 
         [Test]

--- a/Backend.Tests/Repositories/WordRepositoryTests.cs
+++ b/Backend.Tests/Repositories/WordRepositoryTests.cs
@@ -17,22 +17,8 @@ namespace Backend.Tests.Repositories
     [Category("IntegrationTest")]
     public sealed class WordRepositoryTests
     {
-        private static MongoDbTestRunner _runner = null!;
         private WordRepository _repo = null!;
         private string _projectId = null!;
-
-        [OneTimeSetUp]
-        public static void StartMongo()
-        {
-            _runner?.Dispose();
-            _runner = MongoDbTestRunner.Start();
-        }
-
-        [OneTimeTearDown]
-        public static void StopMongo()
-        {
-            _runner?.Dispose();
-        }
 
         [SetUp]
         public void SetUp()
@@ -40,7 +26,7 @@ namespace Backend.Tests.Repositories
             _projectId = Guid.NewGuid().ToString();
             var options = Options.Create(new BackendFramework.Startup.Settings
             {
-                ConnectionString = _runner.ConnectionString,
+                ConnectionString = MongoDbSetUpFixture.Runner.ConnectionString,
                 CombineDatabase = "WordRepositoryTests",
             });
             _repo = new WordRepository(new MongoDbContext(options));

--- a/Backend/Controllers/UserEditController.cs
+++ b/Backend/Controllers/UserEditController.cs
@@ -174,8 +174,9 @@ namespace BackendFramework.Controllers
                 return NotFound($"userEditId: {userEditId}");
             }
 
-            // Ensure Edit exist.
-            var edit = document.Edits.FindLast(e => e.Guid == stepWrapper.EditGuid);
+            // Ensure Edit exist. First match, since the repo's step writes are UpdateOne
+            // calls that target the first edit with this guid.
+            var edit = document.Edits.Find(e => e.Guid == stepWrapper.EditGuid);
             if (edit is null)
             {
                 return NotFound($"editGuid: {stepWrapper.EditGuid}");

--- a/Backend/Interfaces/IUserEditRepository.cs
+++ b/Backend/Interfaces/IUserEditRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using BackendFramework.Models;
 
@@ -11,6 +12,9 @@ namespace BackendFramework.Interfaces
         Task<UserEdit> Create(UserEdit userEdit);
         Task<bool> Delete(string projectId, string userEditId);
         Task<bool> DeleteAllUserEdits(string projectId);
-        Task<bool> Replace(string projectId, string userEditId, UserEdit userEdit);
+        Task<bool> AddEdit(string projectId, string userEditId, Edit edit);
+        Task<bool> ReplaceEdit(string projectId, string userEditId, Edit edit);
+        Task<bool> AddStepToEdit(string projectId, string userEditId, Guid editGuid, string stepData);
+        Task<bool> UpdateStepInEdit(string projectId, string userEditId, Guid editGuid, int stepIndex, string stepData);
     }
 }

--- a/Backend/Models/UserEdit.cs
+++ b/Backend/Models/UserEdit.cs
@@ -90,7 +90,7 @@ namespace BackendFramework.Models
 
     /// <summary>
     /// The persisted form of a <see cref="UserEdit"/> in the UserEditsCollection, with each edit stored as a
-    /// reference to a <see cref="StoredEdit"/> document so the document cannot grow toward MongoDB's 16 MB limit.
+    /// reference to a <see cref="StoredEdit"/> document.
     /// </summary>
     public class StoredUserEdit
     {

--- a/Backend/Models/UserEdit.cs
+++ b/Backend/Models/UserEdit.cs
@@ -87,4 +87,79 @@ namespace BackendFramework.Models
             return clone;
         }
     }
+
+    /// <summary>
+    /// The persisted form of a <see cref="UserEdit"/> in the UserEditsCollection, with each edit stored as a
+    /// reference to a <see cref="StoredEdit"/> document so the document cannot grow toward MongoDB's 16 MB limit.
+    /// </summary>
+    public class StoredUserEdit
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.ObjectId)]
+        public string Id { get; set; } = "";
+
+        /// <summary> Ids of this user edit's <see cref="StoredEdit"/> documents, in order. </summary>
+        [BsonElement("edits")]
+        [BsonRepresentation(BsonType.ObjectId)]
+        public List<string> EditIds { get; set; } = [];
+
+        [BsonElement("projectId")]
+        public string ProjectId { get; set; } = "";
+    }
+
+    /// <summary> The persisted form of an <see cref="Edit"/>: one document in the EditsCollection. </summary>
+    public class StoredEdit
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.ObjectId)]
+        public string Id { get; set; } = "";
+
+        [BsonElement("projectId")]
+        public string ProjectId { get; set; } = "";
+
+        /// <summary> Id of the <see cref="StoredUserEdit"/> document this edit belongs to. </summary>
+        [BsonElement("userEditId")]
+        public string UserEditId { get; set; } = "";
+
+        [BsonElement("guid")]
+        [BsonGuidRepresentation(GuidRepresentation.Standard)]
+#pragma warning disable CA1720
+        public Guid Guid { get; set; } = Guid.NewGuid();
+#pragma warning restore CA1720
+
+        [BsonElement("goalType")]
+        public int GoalType { get; set; }
+
+        [BsonElement("stepData")]
+        public List<string> StepData { get; set; } = [];
+
+        [BsonElement("changes")]
+        public string Changes { get; set; } = "{}";
+
+        [BsonElement("modified")]
+        public DateTime? Modified { get; set; }
+
+        public StoredEdit() { }
+
+        public StoredEdit(string projectId, string userEditId, Edit edit)
+        {
+            ProjectId = projectId;
+            UserEditId = userEditId;
+            Guid = edit.Guid;
+            GoalType = edit.GoalType;
+            StepData = [.. edit.StepData];
+            Changes = edit.Changes;
+            Modified = edit.Modified;
+        }
+
+        /// <summary> Convert to the API-facing <see cref="Edit"/> shape. </summary>
+        public Edit ToEdit() => new()
+        {
+            Guid = Guid,
+            GoalType = GoalType,
+            StepData = [.. StepData],
+            Changes = Changes,
+            Modified = Modified,
+        };
+    }
 }

--- a/Backend/Repositories/UserEditRepository.cs
+++ b/Backend/Repositories/UserEditRepository.cs
@@ -220,17 +220,22 @@ namespace BackendFramework.Repositories
         /// Overwrites the step at the given index of the <see cref="Edit"/> with matching guid
         /// in the <see cref="UserEdit"/> with specified userEditId and projectId.
         /// </summary>
-        /// <remarks> The caller is responsible for ensuring that stepIndex is within bounds. </remarks>
-        /// <returns> A bool: success of operation </returns>
+        /// <returns> A bool: success of operation (false if the step doesn't exist) </returns>
         public async Task<bool> UpdateStepInEdit(
             string projectId, string userEditId, Guid editGuid, int stepIndex, string stepData)
         {
             using var activity = OtelService.StartActivityWithTag(otelTagName, "updating a step in an edit");
 
+            // Requiring the step to exist makes the bounds check atomic with the write;
+            // a $set beyond the array's end would pad the array with nulls instead of failing.
+            var filterDef = new FilterDefinitionBuilder<StoredEdit>();
+            var filter = filterDef.And(
+                GetEditFilter(projectId, userEditId, editGuid), filterDef.Exists($"stepData.{stepIndex}"));
+
             var update = Builders<StoredEdit>.Update
                 .Set($"stepData.{stepIndex}", stepData)
                 .Set(e => e.Modified, DateTime.UtcNow);
-            var result = await _edits.UpdateOneAsync(GetEditFilter(projectId, userEditId, editGuid), update);
+            var result = await _edits.UpdateOneAsync(filter, update);
             return result.IsAcknowledged && result.MatchedCount == 1;
         }
     }

--- a/Backend/Repositories/UserEditRepository.cs
+++ b/Backend/Repositories/UserEditRepository.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading.Tasks;
 using BackendFramework.Interfaces;
 using BackendFramework.Models;
 using BackendFramework.Otel;
+using MongoDB.Bson;
 using MongoDB.Driver;
 
 namespace BackendFramework.Repositories
@@ -13,17 +15,71 @@ namespace BackendFramework.Repositories
     [ExcludeFromCodeCoverage]
     public class UserEditRepository(IMongoDbContext dbContext) : IUserEditRepository
     {
-        private readonly IMongoCollection<UserEdit> _userEdits =
-            dbContext.Db.GetCollection<UserEdit>("UserEditsCollection");
+        private readonly IMongoDbContext _dbContext = dbContext;
+        private readonly IMongoCollection<StoredUserEdit> _userEdits =
+            dbContext.Db.GetCollection<StoredUserEdit>("UserEditsCollection");
+        private readonly IMongoCollection<StoredEdit> _edits =
+            dbContext.Db.GetCollection<StoredEdit>("EditsCollection");
 
         private const string otelTagName = "otel.UserEditRepository";
+
+        #region Private helper methods
+
+        /// <summary> Creates a mongo filter for the <see cref="StoredUserEdit"/> in a specified project. </summary>
+        private static FilterDefinition<StoredUserEdit> GetUserEditFilter(string projectId, string userEditId)
+        {
+            var filterDef = new FilterDefinitionBuilder<StoredUserEdit>();
+            return filterDef.And(filterDef.Eq(u => u.ProjectId, projectId), filterDef.Eq(u => u.Id, userEditId));
+        }
+
+        /// <summary> Creates a mongo filter for all of a user edit's <see cref="StoredEdit"/>s. </summary>
+        private static FilterDefinition<StoredEdit> GetEditsFilter(string projectId, string userEditId)
+        {
+            var filterDef = new FilterDefinitionBuilder<StoredEdit>();
+            return filterDef.And(
+                filterDef.Eq(e => e.ProjectId, projectId), filterDef.Eq(e => e.UserEditId, userEditId));
+        }
+
+        /// <summary> Creates a mongo filter for a user edit's <see cref="StoredEdit"/> with specified guid. </summary>
+        private static FilterDefinition<StoredEdit> GetEditFilter(string projectId, string userEditId, Guid editGuid)
+        {
+            var filterDef = new FilterDefinitionBuilder<StoredEdit>();
+            return filterDef.And(
+                filterDef.Eq(e => e.ProjectId, projectId),
+                filterDef.Eq(e => e.UserEditId, userEditId),
+                filterDef.Eq(e => e.Guid, editGuid));
+        }
+
+        /// <summary>
+        /// Assembles a <see cref="UserEdit"/> with edits in the order of the stored references,
+        /// skipping any dangling references.
+        /// </summary>
+        private static UserEdit AssembleUserEdit(StoredUserEdit storedUserEdit, List<StoredEdit> storedEdits)
+        {
+            var editsById = storedEdits.ToDictionary(e => e.Id);
+            var edits = new List<Edit>();
+            foreach (var editId in storedUserEdit.EditIds)
+            {
+                if (editsById.TryGetValue(editId, out var storedEdit))
+                {
+                    edits.Add(storedEdit.ToEdit());
+                }
+            }
+            return new UserEdit { Id = storedUserEdit.Id, ProjectId = storedUserEdit.ProjectId, Edits = edits };
+        }
+
+        #endregion
 
         /// <summary> Finds all <see cref="UserEdit"/>s with specified projectId </summary>
         public async Task<List<UserEdit>> GetAllUserEdits(string projectId)
         {
             using var activity = OtelService.StartActivityWithTag(otelTagName, "getting all user edits");
 
-            return await _userEdits.Find(u => u.ProjectId == projectId).ToListAsync();
+            var storedUserEdits = await _userEdits.Find(u => u.ProjectId == projectId).ToListAsync();
+            var storedEdits = await _edits.Find(e => e.ProjectId == projectId).ToListAsync();
+            var editsByUserEditId = storedEdits.GroupBy(e => e.UserEditId).ToDictionary(g => g.Key, g => g.ToList());
+            return storedUserEdits.ConvertAll(
+                u => AssembleUserEdit(u, editsByUserEditId.GetValueOrDefault(u.Id, [])));
         }
 
         /// <summary> Removes all <see cref="UserEdit"/>s for specified <see cref="Project"/> </summary>
@@ -32,29 +88,33 @@ namespace BackendFramework.Repositories
         {
             using var activity = OtelService.StartActivityWithTag(otelTagName, "deleting all user edits");
 
-            var deleted = await _userEdits.DeleteManyAsync(u => u.ProjectId == projectId);
-            return deleted.DeletedCount != 0;
+            return await _dbContext.ExecuteInTransaction(async s =>
+            {
+                await _edits.DeleteManyAsync(s, e => e.ProjectId == projectId);
+                var deleted = await _userEdits.DeleteManyAsync(s, u => u.ProjectId == projectId);
+                return deleted.DeletedCount != 0;
+            });
         }
 
-        /// <summary> Finds <see cref="UserEdit"/> with specified userRoleId and projectId </summary>
+        /// <summary> Finds <see cref="UserEdit"/> with specified userEditId and projectId </summary>
         public async Task<UserEdit?> GetUserEdit(string projectId, string userEditId)
         {
             using var activity = OtelService.StartActivityWithTag(otelTagName, "getting a user edit");
 
-            var filterDef = new FilterDefinitionBuilder<UserEdit>();
-            var filter = filterDef.And(filterDef.Eq(
-                x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, userEditId));
+            var userEditList = await _userEdits.FindAsync(GetUserEditFilter(projectId, userEditId));
 
-            var userEditList = await _userEdits.FindAsync(filter);
-
+            StoredUserEdit storedUserEdit;
             try
             {
-                return await userEditList.FirstAsync();
+                storedUserEdit = await userEditList.FirstAsync();
             }
             catch (InvalidOperationException)
             {
                 return null;
             }
+
+            var storedEdits = await _edits.Find(GetEditsFilter(projectId, userEditId)).ToListAsync();
+            return AssembleUserEdit(storedUserEdit, storedEdits);
         }
 
         /// <summary> Adds a <see cref="UserEdit"/> </summary>
@@ -63,36 +123,115 @@ namespace BackendFramework.Repositories
         {
             using var activity = OtelService.StartActivityWithTag(otelTagName, "creating a user edit");
 
-            await _userEdits.InsertOneAsync(userEdit);
+            var storedUserEdit = new StoredUserEdit { ProjectId = userEdit.ProjectId };
+            if (userEdit.Edits.Count == 0)
+            {
+                await _userEdits.InsertOneAsync(storedUserEdit);
+            }
+            else
+            {
+                // Pre-generate the id so the StoredEdit documents can reference their parent.
+                storedUserEdit.Id = ObjectId.GenerateNewId().ToString();
+                var storedEdits = userEdit.Edits.ConvertAll(
+                    e => new StoredEdit(userEdit.ProjectId, storedUserEdit.Id, e));
+                await _dbContext.ExecuteInTransaction(async s =>
+                {
+                    await _edits.InsertManyAsync(s, storedEdits);
+                    storedUserEdit.EditIds = storedEdits.ConvertAll(e => e.Id);
+                    await _userEdits.InsertOneAsync(s, storedUserEdit);
+                    return true;
+                });
+            }
+
+            userEdit.Id = storedUserEdit.Id;
             return userEdit;
         }
 
-        /// <summary> Removes <see cref="UserEdit"/> with specified userRoleId and projectId </summary>
+        /// <summary> Removes <see cref="UserEdit"/> with specified userEditId and projectId </summary>
         /// <returns> A bool: success of operation </returns>
         public async Task<bool> Delete(string projectId, string userEditId)
         {
             using var activity = OtelService.StartActivityWithTag(otelTagName, "deleting a user edit");
 
-            var filterDef = new FilterDefinitionBuilder<UserEdit>();
-            var filter = filterDef.And(filterDef.Eq(
-                x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, userEditId));
-
-            var deleted = await _userEdits.DeleteOneAsync(filter);
-            return deleted.DeletedCount > 0;
+            return await _dbContext.ExecuteInTransaction(async s =>
+            {
+                await _edits.DeleteManyAsync(s, GetEditsFilter(projectId, userEditId));
+                var deleted = await _userEdits.DeleteOneAsync(s, GetUserEditFilter(projectId, userEditId));
+                return deleted.DeletedCount > 0;
+            });
         }
 
-        /// <summary> Replaces <see cref="UserEdit"/> with specified userRoleId and projectId </summary>
+        /// <summary>
+        /// Appends an <see cref="Edit"/> to the <see cref="UserEdit"/> with specified userEditId and projectId.
+        /// </summary>
         /// <returns> A bool: success of operation </returns>
-        public async Task<bool> Replace(string projectId, string userEditId, UserEdit userEdit)
+        public async Task<bool> AddEdit(string projectId, string userEditId, Edit edit)
         {
-            using var activity = OtelService.StartActivityWithTag(otelTagName, "replacing a user edit");
+            using var activity = OtelService.StartActivityWithTag(otelTagName, "adding an edit to a user edit");
 
-            var filterDef = new FilterDefinitionBuilder<UserEdit>();
-            var filter = filterDef.And(filterDef.Eq(
-                x => x.ProjectId, projectId), filterDef.Eq(x => x.Id, userEditId));
+            var storedEdit = new StoredEdit(projectId, userEditId, edit);
+            // A null result aborts the transaction, so no orphaned edit document is left behind
+            // when the user edit doesn't exist.
+            return await _dbContext.ExecuteInTransactionAllowNull<bool?>(async s =>
+            {
+                await _edits.InsertOneAsync(s, storedEdit);
+                var update = Builders<StoredUserEdit>.Update.Push(u => u.EditIds, storedEdit.Id);
+                var result = await _userEdits.UpdateOneAsync(s, GetUserEditFilter(projectId, userEditId), update);
+                return result.IsAcknowledged && result.MatchedCount == 1 ? true : null;
+            }) ?? false;
+        }
 
-            var result = await _userEdits.ReplaceOneAsync(filter, userEdit);
-            return result.ModifiedCount == 1;
+        /// <summary>
+        /// Replaces the contents of the <see cref="Edit"/> with matching guid in the <see cref="UserEdit"/>
+        /// with specified userEditId and projectId.
+        /// </summary>
+        /// <returns> A bool: success of operation </returns>
+        public async Task<bool> ReplaceEdit(string projectId, string userEditId, Edit edit)
+        {
+            using var activity = OtelService.StartActivityWithTag(otelTagName, "replacing an edit in a user edit");
+
+            var update = Builders<StoredEdit>.Update
+                .Set(e => e.GoalType, edit.GoalType)
+                .Set(e => e.StepData, edit.StepData)
+                .Set(e => e.Changes, edit.Changes)
+                .Set(e => e.Modified, edit.Modified);
+            var result = await _edits.UpdateOneAsync(GetEditFilter(projectId, userEditId, edit.Guid), update);
+            // MatchedCount, not ModifiedCount: replacing an edit with an identical one is still a success.
+            return result.IsAcknowledged && result.MatchedCount == 1;
+        }
+
+        /// <summary>
+        /// Appends a step to the <see cref="Edit"/> with matching guid in the <see cref="UserEdit"/>
+        /// with specified userEditId and projectId.
+        /// </summary>
+        /// <returns> A bool: success of operation </returns>
+        public async Task<bool> AddStepToEdit(string projectId, string userEditId, Guid editGuid, string stepData)
+        {
+            using var activity = OtelService.StartActivityWithTag(otelTagName, "adding a step to an edit");
+
+            var update = Builders<StoredEdit>.Update
+                .Push(e => e.StepData, stepData)
+                .Set(e => e.Modified, DateTime.UtcNow);
+            var result = await _edits.UpdateOneAsync(GetEditFilter(projectId, userEditId, editGuid), update);
+            return result.IsAcknowledged && result.MatchedCount == 1;
+        }
+
+        /// <summary>
+        /// Overwrites the step at the given index of the <see cref="Edit"/> with matching guid
+        /// in the <see cref="UserEdit"/> with specified userEditId and projectId.
+        /// </summary>
+        /// <remarks> The caller is responsible for ensuring that stepIndex is within bounds. </remarks>
+        /// <returns> A bool: success of operation </returns>
+        public async Task<bool> UpdateStepInEdit(
+            string projectId, string userEditId, Guid editGuid, int stepIndex, string stepData)
+        {
+            using var activity = OtelService.StartActivityWithTag(otelTagName, "updating a step in an edit");
+
+            var update = Builders<StoredEdit>.Update
+                .Set($"stepData.{stepIndex}", stepData)
+                .Set(e => e.Modified, DateTime.UtcNow);
+            var result = await _edits.UpdateOneAsync(GetEditFilter(projectId, userEditId, editGuid), update);
+            return result.IsAcknowledged && result.MatchedCount == 1;
         }
     }
 }

--- a/Backend/Repositories/UserEditRepository.cs
+++ b/Backend/Repositories/UserEditRepository.cs
@@ -16,10 +16,10 @@ namespace BackendFramework.Repositories
     public class UserEditRepository(IMongoDbContext dbContext) : IUserEditRepository
     {
         private readonly IMongoDbContext _dbContext = dbContext;
-        private readonly IMongoCollection<StoredUserEdit> _userEdits =
-            dbContext.Db.GetCollection<StoredUserEdit>("UserEditsCollection");
         private readonly IMongoCollection<StoredEdit> _edits =
             dbContext.Db.GetCollection<StoredEdit>("EditsCollection");
+        private readonly IMongoCollection<StoredUserEdit> _userEdits =
+            dbContext.Db.GetCollection<StoredUserEdit>("UserEditsCollection");
 
         private const string otelTagName = "otel.UserEditRepository";
 

--- a/Backend/Services/UserEditService.cs
+++ b/Backend/Services/UserEditService.cs
@@ -34,8 +34,7 @@ namespace BackendFramework.Services
             edit.Modified = DateTime.UtcNow;
 
             // Replace the Edit with this guid if present, otherwise add it. Each repo call is atomic on its
-            // own; taking the branch from ReplaceEdit's result rather than a prior read closes the stale-read
-            // race. Two concurrent first-time writes of the same new guid could still both add it, but guids
+            // own. Two concurrent first-time writes of the same new guid could still both add it, but guids
             // are client-generated and unique per goal, so that window is tolerated rather than locked.
             var isSuccess = await _userEditRepo.ReplaceEdit(projectId, userEditId, edit)
                 || await _userEditRepo.AddEdit(projectId, userEditId, edit);
@@ -64,7 +63,6 @@ namespace BackendFramework.Services
                 return false;
             }
 
-            // The repository bounds-checks stepIndex atomically with the write.
             return await _userEditRepo.UpdateStepInEdit(projectId, userEditId, editGuid, stepIndex, stepString);
         }
     }

--- a/Backend/Services/UserEditService.cs
+++ b/Backend/Services/UserEditService.cs
@@ -41,41 +41,20 @@ namespace BackendFramework.Services
             edit.Modified = DateTime.UtcNow;
 
             // Update existing Edit if guid exists, otherwise add new one at end of List.
-            var editIndex = userEdit.Edits.FindLastIndex(e => e.Guid == edit.Guid);
-            if (editIndex > -1)
-            {
-                userEdit.Edits[editIndex] = edit;
-            }
-            else
-            {
-                userEdit.Edits.Add(edit);
-            }
+            var isSuccess = userEdit.Edits.FindLastIndex(e => e.Guid == edit.Guid) > -1
+                ? await _userEditRepo.ReplaceEdit(projectId, userEditId, edit)
+                : await _userEditRepo.AddEdit(projectId, userEditId, edit);
 
-            // Replace the old UserEdit object with the new one that contains the new/updated edit
-            var editReplaced = await _userEditRepo.Replace(projectId, userEditId, userEdit);
-
-            return new Tuple<bool, Guid?>(editReplaced, edit.Guid);
+            return new Tuple<bool, Guid?>(isSuccess, edit.Guid);
         }
 
         /// <summary> Adds a string representation of a step to a specified <see cref="Edit"/> </summary>
-        /// <returns> A bool: success of operation </returns>
+        /// <returns> A bool: success of operation (false if userEdit or edit not found) </returns>
         public async Task<bool> AddStepToGoal(string projectId, string userEditId, Guid editGuid, string stepString)
         {
             using var activity = OtelService.StartActivityWithTag(otelTagName, "adding step to goal");
 
-            var userEdit = await _userEditRepo.GetUserEdit(projectId, userEditId);
-            if (userEdit is null)
-            {
-                return false;
-            }
-            var edit = userEdit.Edits.FindLast(e => e.Guid == editGuid);
-            if (edit is null)
-            {
-                return false;
-            }
-            edit.Modified = DateTime.UtcNow;
-            edit.StepData.Add(stepString);
-            return await _userEditRepo.Replace(projectId, userEditId, userEdit);
+            return await _userEditRepo.AddStepToEdit(projectId, userEditId, editGuid, stepString);
         }
 
         /// <summary> Updates a specified step in a specified <see cref="Edit"/> </summary>
@@ -89,6 +68,9 @@ namespace BackendFramework.Services
             {
                 return false;
             }
+
+            // Read first to bounds-check stepIndex: a $set beyond the array's end
+            // would pad the array with nulls instead of failing.
             var userEdit = await _userEditRepo.GetUserEdit(projectId, userEditId);
             if (userEdit is null)
             {
@@ -99,9 +81,7 @@ namespace BackendFramework.Services
             {
                 return false;
             }
-            edit.Modified = DateTime.UtcNow;
-            edit.StepData[stepIndex] = stepString;
-            return await _userEditRepo.Replace(projectId, userEditId, userEdit);
+            return await _userEditRepo.UpdateStepInEdit(projectId, userEditId, editGuid, stepIndex, stepString);
         }
     }
 }

--- a/Backend/Services/UserEditService.cs
+++ b/Backend/Services/UserEditService.cs
@@ -24,28 +24,21 @@ namespace BackendFramework.Services
         /// </summary>
         /// <returns>
         /// Tuple of
-        ///     bool: true if Edit added/updated, false if nothing modified
-        ///     Guid?: guid of added/updated Edit, or null if UserEdit not found
+        ///     bool: true if the Edit was added or updated, false if the UserEdit was not found
+        ///     Guid?: guid of the added/updated Edit, or null if the UserEdit was not found
         /// </returns>
         public async Task<Tuple<bool, Guid?>> AddGoalToUserEdit(string projectId, string userEditId, Edit edit)
         {
             using var activity = OtelService.StartActivityWithTag(otelTagName, "adding goal to user edit");
 
-            // Get userEdit to change
-            var userEdit = await _userEditRepo.GetUserEdit(projectId, userEditId);
-            if (userEdit is null)
-            {
-                return new Tuple<bool, Guid?>(false, null);
-            }
-
             edit.Modified = DateTime.UtcNow;
 
-            // Update existing Edit if guid exists, otherwise add new one at end of List.
-            var isSuccess = userEdit.Edits.FindLastIndex(e => e.Guid == edit.Guid) > -1
-                ? await _userEditRepo.ReplaceEdit(projectId, userEditId, edit)
-                : await _userEditRepo.AddEdit(projectId, userEditId, edit);
+            // Replace an existing Edit with the same guid if present, otherwise add a new one. Letting the
+            // atomic ReplaceEdit report whether the guid existed avoids deciding from a separate stale read.
+            var isSuccess = await _userEditRepo.ReplaceEdit(projectId, userEditId, edit)
+                || await _userEditRepo.AddEdit(projectId, userEditId, edit);
 
-            return new Tuple<bool, Guid?>(isSuccess, edit.Guid);
+            return new Tuple<bool, Guid?>(isSuccess, isSuccess ? edit.Guid : null);
         }
 
         /// <summary> Adds a string representation of a step to a specified <see cref="Edit"/> </summary>

--- a/Backend/Services/UserEditService.cs
+++ b/Backend/Services/UserEditService.cs
@@ -69,18 +69,7 @@ namespace BackendFramework.Services
                 return false;
             }
 
-            // Read first to bounds-check stepIndex: a $set beyond the array's end
-            // would pad the array with nulls instead of failing.
-            var userEdit = await _userEditRepo.GetUserEdit(projectId, userEditId);
-            if (userEdit is null)
-            {
-                return false;
-            }
-            var edit = userEdit.Edits.FindLast(e => e.Guid == editGuid);
-            if (edit is null || stepIndex >= edit.StepData.Count)
-            {
-                return false;
-            }
+            // The repository bounds-checks stepIndex atomically with the write.
             return await _userEditRepo.UpdateStepInEdit(projectId, userEditId, editGuid, stepIndex, stepString);
         }
     }

--- a/Backend/Services/UserEditService.cs
+++ b/Backend/Services/UserEditService.cs
@@ -33,8 +33,10 @@ namespace BackendFramework.Services
 
             edit.Modified = DateTime.UtcNow;
 
-            // Replace an existing Edit with the same guid if present, otherwise add a new one. Letting the
-            // atomic ReplaceEdit report whether the guid existed avoids deciding from a separate stale read.
+            // Replace the Edit with this guid if present, otherwise add it. Each repo call is atomic on its
+            // own; taking the branch from ReplaceEdit's result rather than a prior read closes the stale-read
+            // race. Two concurrent first-time writes of the same new guid could still both add it, but guids
+            // are client-generated and unique per goal, so that window is tolerated rather than locked.
             var isSuccess = await _userEditRepo.ReplaceEdit(projectId, userEditId, edit)
                 || await _userEditRepo.AddEdit(projectId, userEditId, edit);
 

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -20,6 +20,7 @@ COPY semantic_domains/* /data/semantic-domains/
 # them from Kubernetes postStart to avoid first-boot race conditions.
 COPY init/update-semantic-domains.sh /opt/thecombine/update-semantic-domains.sh
 
-# Replica set readiness/alignment runs from Kubernetes postStart hook on every
-# container start, so this script is intentionally kept out of initdb.d.
+# Replica set readiness/alignment and index creation run from Kubernetes postStart
+# hook on every container start, so these scripts are intentionally kept out of initdb.d.
 COPY init/00-replica-set.js /opt/thecombine/00-replica-set.js
+COPY init/01-indexes.js /opt/thecombine/01-indexes.js

--- a/database/init/01-indexes.js
+++ b/database/init/01-indexes.js
@@ -1,0 +1,14 @@
+// The backend doesn't manage indexes itself, so this script is the only place a
+// fresh install gets them; when a migration script creates an index, add it here
+// too, so the index outlives that script's eventual removal.
+//
+// Runs from the Kubernetes postStart hook on every container start (see
+// deploy/helm/thecombine/charts/database/templates/database.yaml), so keep every
+// operation here idempotent.
+
+const combineDb = db.getSiblingDB("CombineDatabase");
+
+// The backend queries EditsCollection by projectId + userEditId (list a user edit's
+// edits) and by projectId + userEditId + guid (replace/update a single edit).
+combineDb.EditsCollection.createIndex({ projectId: 1, userEditId: 1, guid: 1 });
+print("Ensured index { projectId: 1, userEditId: 1, guid: 1 } on EditsCollection.");

--- a/database/migrate-useredits-to-edits-collection.js
+++ b/database/migrate-useredits-to-edits-collection.js
@@ -89,9 +89,11 @@ idsToMigrate.forEach(function (id) {
 });
 print("Moved " + totalEditsMoved + " edit(s) from " + idsToMigrate.length + " document(s).");
 
-// All backend queries on EditsCollection filter by projectId (+ userEditId).
-edits.createIndex({ projectId: 1, userEditId: 1 });
-print("Ensured index { projectId: 1, userEditId: 1 } on EditsCollection.");
+// Backend queries filter by projectId + userEditId (list a user edit's edits) and by
+// projectId + userEditId + guid (replace/update a single edit). One compound index serves
+// both: the leading fields cover the former, the full key covers the latter.
+edits.createIndex({ projectId: 1, userEditId: 1, guid: 1 });
+print("Ensured index { projectId: 1, userEditId: 1, guid: 1 } on EditsCollection.");
 
 // Verify: no old-format documents remain, and every ref resolves.
 var failures = 0;

--- a/database/migrate-useredits-to-edits-collection.js
+++ b/database/migrate-useredits-to-edits-collection.js
@@ -45,13 +45,13 @@ var oldFormat = { "edits.0.guid": { $exists: true } };
 // multi-MB documents are held in memory only one at a time. Sizes come from $bsonSize
 // because mongosh has no Object.bsonsize and its bsonsize() global isn't in every version.
 var idsToMigrate = [];
-var sizeMbById = {};
+var sizeMbById = new Map();
 userEdits.aggregate([
   { $match: oldFormat },
   { $project: { size: { $bsonSize: "$$ROOT" } } },
 ]).forEach(function (d) {
   idsToMigrate.push(d._id);
-  sizeMbById[d._id.toHexString()] = (d.size / (1024 * 1024)).toFixed(2);
+  sizeMbById.set(d._id.toHexString(), (d.size / (1024 * 1024)).toFixed(2));
 });
 print("UserEdit documents to migrate: " + idsToMigrate.length);
 
@@ -90,7 +90,7 @@ idsToMigrate.forEach(function (id) {
   totalEditsMoved += newDocs.length;
   print(
     "  migrated " + userEditId + " (projectId: " + doc.projectId + "): " +
-    newDocs.length + " edit(s), was " + sizeMbById[userEditId] + " MB"
+    newDocs.length + " edit(s), was " + sizeMbById.get(userEditId) + " MB"
   );
 });
 print("Moved " + totalEditsMoved + " edit(s) from " + idsToMigrate.length + " document(s).");
@@ -111,10 +111,12 @@ if (userEdits.countDocuments(oldFormat) > 0) {
   fail("old-format UserEdit documents remain.");
 }
 
-var knownUserEditIds = {};
+// Sets and Maps, not object literals: a userEditId of "constructor" (or any other
+// Object.prototype key) would otherwise look like an id that had been seen.
+var knownUserEditIds = new Set();
 userEdits.find().forEach(function (doc) {
   var userEditId = doc._id.toHexString();
-  knownUserEditIds[userEditId] = true;
+  knownUserEditIds.add(userEditId);
 
   if (!Array.isArray(doc.edits)) {
     fail("UserEdit " + userEditId + " has no `edits` array.");
@@ -123,21 +125,21 @@ userEdits.find().forEach(function (doc) {
 
   // Exact ids, not counts: a dangling ref alongside an unreferenced edit, or a ref listed
   // twice, balances out in a count. AssembleUserEdit silently skips a dangling ref.
-  var editsById = {};
+  var editsById = new Map();
   edits.find({ userEditId: userEditId }, { _id: 1, projectId: 1 }).forEach(function (e) {
-    editsById[e._id.toHexString()] = e;
+    editsById.set(e._id.toHexString(), e);
   });
 
-  var seen = {};
+  var seen = new Set();
   doc.edits.forEach(function (ref, index) {
     var refId = String(ref);
-    if (seen[refId]) {
+    if (seen.has(refId)) {
       fail("UserEdit " + userEditId + " references " + refId + " more than once.");
       return;
     }
-    seen[refId] = true;
+    seen.add(refId);
 
-    var edit = editsById[refId];
+    var edit = editsById.get(refId);
     if (!edit) {
       fail(
         "UserEdit " + userEditId + " ref " + index + " (" + refId +
@@ -154,8 +156,8 @@ userEdits.find().forEach(function (doc) {
     }
   });
 
-  Object.keys(editsById).forEach(function (editId) {
-    if (!seen[editId]) {
+  editsById.forEach(function (edit, editId) {
+    if (!seen.has(editId)) {
       fail("EditsCollection " + editId + " is unreferenced by UserEdit " + userEditId + ".");
     }
   });
@@ -164,7 +166,7 @@ userEdits.find().forEach(function (doc) {
 // A second pass, since the loop above only sees edits that have a parent. Keyed on parent
 // id so unreferenced edits under a parent aren't reported twice.
 edits.find({}, { _id: 1, userEditId: 1 }).forEach(function (e) {
-  if (!knownUserEditIds[e.userEditId]) {
+  if (!knownUserEditIds.has(e.userEditId)) {
     fail(
       "EditsCollection " + e._id.toHexString() + " is orphaned: userEditId " +
       e.userEditId + " matches no UserEdit."

--- a/database/migrate-useredits-to-edits-collection.js
+++ b/database/migrate-useredits-to-edits-collection.js
@@ -41,10 +41,17 @@ var edits = db.getCollection("EditsCollection");
 // migrated documents hold plain ObjectIds, which have no subfields.
 var oldFormat = { "edits.0.guid": { $exists: true } };
 
-// Gather ids up front so the update inside the loop can't disturb the cursor,
-// and so multi-MB documents are held in memory only one at a time.
-var idsToMigrate = userEdits.find(oldFormat, { _id: 1 }).toArray().map(function (d) {
-  return d._id;
+// Gather ids up front so the update inside the loop can't disturb the cursor, and so
+// multi-MB documents are held in memory only one at a time. Sizes come from $bsonSize
+// because mongosh has no Object.bsonsize and its bsonsize() global isn't in every version.
+var idsToMigrate = [];
+var sizeMbById = {};
+userEdits.aggregate([
+  { $match: oldFormat },
+  { $project: { size: { $bsonSize: "$$ROOT" } } },
+]).forEach(function (d) {
+  idsToMigrate.push(d._id);
+  sizeMbById[d._id.toHexString()] = (d.size / (1024 * 1024)).toFixed(2);
 });
 print("UserEdit documents to migrate: " + idsToMigrate.length);
 
@@ -83,38 +90,93 @@ idsToMigrate.forEach(function (id) {
   totalEditsMoved += newDocs.length;
   print(
     "  migrated " + userEditId + " (projectId: " + doc.projectId + "): " +
-    newDocs.length + " edit(s), was " +
-    (Object.bsonsize(doc) / (1024 * 1024)).toFixed(2) + " MB"
+    newDocs.length + " edit(s), was " + sizeMbById[userEditId] + " MB"
   );
 });
 print("Moved " + totalEditsMoved + " edit(s) from " + idsToMigrate.length + " document(s).");
 
-// Backend queries filter by projectId + userEditId (list a user edit's edits) and by
-// projectId + userEditId + guid (replace/update a single edit). One compound index serves
-// both: the leading fields cover the former, the full key covers the latter.
+// database/init/01-indexes.js creates this on every container start and documents the key;
+// repeated here so a just-migrated database is indexed before its next restart.
 edits.createIndex({ projectId: 1, userEditId: 1, guid: 1 });
 print("Ensured index { projectId: 1, userEditId: 1, guid: 1 } on EditsCollection.");
 
-// Verify: no old-format documents remain, and every ref resolves.
+// Verify: no old-format documents remain, and refs and edit documents correspond exactly.
 var failures = 0;
-if (userEdits.countDocuments(oldFormat) > 0) {
+function fail(message) {
   failures++;
-  print("WARNING: old-format UserEdit documents remain.");
+  print("WARNING: " + message);
 }
+
+if (userEdits.countDocuments(oldFormat) > 0) {
+  fail("old-format UserEdit documents remain.");
+}
+
+var knownUserEditIds = {};
 userEdits.find().forEach(function (doc) {
-  var refCount = doc.edits.length;
-  var docCount = edits.countDocuments({ userEditId: doc._id.toHexString() });
-  if (refCount !== docCount) {
-    failures++;
-    print(
-      "WARNING: UserEdit " + doc._id.toHexString() + " has " + refCount +
-      " ref(s) but " + docCount + " EditsCollection document(s)."
+  var userEditId = doc._id.toHexString();
+  knownUserEditIds[userEditId] = true;
+
+  if (!Array.isArray(doc.edits)) {
+    fail("UserEdit " + userEditId + " has no `edits` array.");
+    return;
+  }
+
+  // Exact ids, not counts: a dangling ref alongside an unreferenced edit, or a ref listed
+  // twice, balances out in a count. AssembleUserEdit silently skips a dangling ref.
+  var editsById = {};
+  edits.find({ userEditId: userEditId }, { _id: 1, projectId: 1 }).forEach(function (e) {
+    editsById[e._id.toHexString()] = e;
+  });
+
+  var seen = {};
+  doc.edits.forEach(function (ref, index) {
+    var refId = String(ref);
+    if (seen[refId]) {
+      fail("UserEdit " + userEditId + " references " + refId + " more than once.");
+      return;
+    }
+    seen[refId] = true;
+
+    var edit = editsById[refId];
+    if (!edit) {
+      fail(
+        "UserEdit " + userEditId + " ref " + index + " (" + refId +
+        ") has no EditsCollection document."
+      );
+      return;
+    }
+    // The backend filters on projectId too, so a mismatched child is invisible to it.
+    if (edit.projectId !== doc.projectId) {
+      fail(
+        "EditsCollection " + refId + " has projectId " + edit.projectId +
+        " but UserEdit " + userEditId + " has " + doc.projectId + "."
+      );
+    }
+  });
+
+  Object.keys(editsById).forEach(function (editId) {
+    if (!seen[editId]) {
+      fail("EditsCollection " + editId + " is unreferenced by UserEdit " + userEditId + ".");
+    }
+  });
+});
+
+// A second pass, since the loop above only sees edits that have a parent. Keyed on parent
+// id so unreferenced edits under a parent aren't reported twice.
+edits.find({}, { _id: 1, userEditId: 1 }).forEach(function (e) {
+  if (!knownUserEditIds[e.userEditId]) {
+    fail(
+      "EditsCollection " + e._id.toHexString() + " is orphaned: userEditId " +
+      e.userEditId + " matches no UserEdit."
     );
   }
 });
-if (failures === 0) {
-  print(
-    "Verification passed: " + userEdits.countDocuments({}) + " UserEdit document(s), " +
-    edits.countDocuments({}) + " EditsCollection document(s), all refs resolve."
-  );
+
+if (failures > 0) {
+  // Throw, don't just print: mongosh otherwise exits 0 and a failed run looks like a pass.
+  throw new Error("Verification FAILED with " + failures + " problem(s); see warnings.");
 }
+print(
+  "Verification passed: " + userEdits.countDocuments({}) + " UserEdit document(s), " +
+  edits.countDocuments({}) + " EditsCollection document(s), all refs resolve."
+);

--- a/database/migrate-useredits-to-edits-collection.js
+++ b/database/migrate-useredits-to-edits-collection.js
@@ -1,0 +1,118 @@
+// Migration script: move each embedded edit of UserEditsCollection into its own
+// document in EditsCollection, leaving the UserEdit's `edits` array holding only
+// ObjectId refs (in the original order).
+//
+// Usage (local):
+//   mongosh CombineDatabase database/migrate-useredits-to-edits-collection.js
+//
+// Usage (Kubernetes, e.g. production):
+//   kubectl -n thecombine cp database/migrate-useredits-to-edits-collection.js \
+//     <database-pod>:/tmp/migrate-useredits-to-edits-collection.js
+//   kubectl -n thecombine exec <database-pod> -- \
+//     mongosh CombineDatabase /tmp/migrate-useredits-to-edits-collection.js
+//
+// IMPORTANT:
+// - Back up the database first (e.g., maintenance/scripts/combine_backup.py, or at
+//   minimum `mongodump --db=CombineDatabase --collection=UserEditsCollection`).
+// - This is a BREAKING schema change: run it while the backend is stopped/scaled
+//   down, then deploy the backend version that reads the new schema. Old backends
+//   cannot read migrated documents, and the new backend cannot read unmigrated ones.
+// - The script is idempotent: it only touches documents still in the old format,
+//   and clears partial output from any interrupted previous run before redoing it.
+// - If an old (pre-migration) backup is ever restored, rerun this script.
+//
+// Background (https://github.com/sillsdev/TheCombine/issues/4320):
+//   UserEdit documents grow with every goal a user works on; documents approaching
+//   MongoDB's 16 MB limit reject all further writes (WriteError 17419), permanently
+//   blocking the user's goal/step progress in that project. With one document per
+//   edit, no document grows meaningfully with use. UserEdit documents are modified
+//   in place — never deleted or recreated, since each user's `workedProjects` map
+//   references the document `_id`.
+
+// New-format EditsCollection document (must match StoredEdit in Backend/Models/UserEdit.cs):
+//   { _id: ObjectId, projectId: string, userEditId: string,
+//     guid: UUID, goalType: int, stepData: [string], changes: string, modified: Date? }
+// Migrated UserEditsCollection `edits` field (must match StoredUserEdit): [ObjectId, ...]
+
+var userEdits = db.getCollection("UserEditsCollection");
+var edits = db.getCollection("EditsCollection");
+
+// Old-format documents have embedded edit objects (each with a `guid` field);
+// migrated documents hold plain ObjectIds, which have no subfields.
+var oldFormat = { "edits.0.guid": { $exists: true } };
+
+// Gather ids up front so the update inside the loop can't disturb the cursor,
+// and so multi-MB documents are held in memory only one at a time.
+var idsToMigrate = userEdits.find(oldFormat, { _id: 1 }).toArray().map(function (d) {
+  return d._id;
+});
+print("UserEdit documents to migrate: " + idsToMigrate.length);
+
+var totalEditsMoved = 0;
+idsToMigrate.forEach(function (id) {
+  var doc = userEdits.findOne({ _id: id });
+  var userEditId = id.toHexString();
+
+  // Clear any partial output from a previous interrupted run: while the document
+  // is still old-format, every EditsCollection row for it is a leftover.
+  edits.deleteMany({ userEditId: userEditId });
+
+  var refs = [];
+  var newDocs = doc.edits.map(function (e) {
+    var newDoc = {
+      _id: new ObjectId(),
+      projectId: doc.projectId,
+      userEditId: userEditId,
+      guid: e.guid,
+      goalType: e.goalType,
+      stepData: e.stepData,
+      changes: e.changes,
+    };
+    if ("modified" in e) {
+      newDoc.modified = e.modified;
+    }
+    refs.push(newDoc._id);
+    return newDoc;
+  });
+
+  if (newDocs.length > 0) {
+    edits.insertMany(newDocs, { ordered: true });
+  }
+  userEdits.updateOne({ _id: id }, { $set: { edits: refs } });
+
+  totalEditsMoved += newDocs.length;
+  print(
+    "  migrated " + userEditId + " (projectId: " + doc.projectId + "): " +
+    newDocs.length + " edit(s), was " +
+    (Object.bsonsize(doc) / (1024 * 1024)).toFixed(2) + " MB"
+  );
+});
+print("Moved " + totalEditsMoved + " edit(s) from " + idsToMigrate.length + " document(s).");
+
+// All backend queries on EditsCollection filter by projectId (+ userEditId).
+edits.createIndex({ projectId: 1, userEditId: 1 });
+print("Ensured index { projectId: 1, userEditId: 1 } on EditsCollection.");
+
+// Verify: no old-format documents remain, and every ref resolves.
+var failures = 0;
+if (userEdits.countDocuments(oldFormat) > 0) {
+  failures++;
+  print("WARNING: old-format UserEdit documents remain.");
+}
+userEdits.find().forEach(function (doc) {
+  var refCount = doc.edits.length;
+  var docCount = edits.countDocuments({ userEditId: doc._id.toHexString() });
+  if (refCount !== docCount) {
+    failures++;
+    print(
+      "WARNING: UserEdit " + doc._id.toHexString() + " has " + refCount +
+      " ref(s) but " + docCount + " EditsCollection document(s)."
+    );
+  }
+});
+if (failures === 0) {
+  print(
+    "Verification passed: " + userEdits.countDocuments({}) + " UserEdit document(s), " +
+    edits.countDocuments({}) + " EditsCollection document(s), all refs resolve."
+  );
+}

--- a/deploy/helm/thecombine/charts/database/templates/database.yaml
+++ b/deploy/helm/thecombine/charts/database/templates/database.yaml
@@ -70,6 +70,8 @@ spec:
                     done
                     echo "[postStart] Ensuring replica set host"
                     mongosh --quiet --host 127.0.0.1 /opt/thecombine/00-replica-set.js || exit $?
+                    echo "[postStart] Ensuring indexes"
+                    mongosh --quiet --host 127.0.0.1 /opt/thecombine/01-indexes.js || exit $?
                     needs_semantic_import="$(mongosh --quiet --host 127.0.0.1 --eval "const combineDb = db.getSiblingDB('CombineDatabase'); const treeCount = combineDb.SemanticDomainTree.countDocuments({}); const domainCount = combineDb.SemanticDomains.countDocuments({}); print(treeCount === 0 || domainCount === 0 ? 'yes' : 'no');")"
                     if [ "${needs_semantic_import}" = "yes" ]; then
                       /bin/bash /opt/thecombine/update-semantic-domains.sh

--- a/maintenance/scripts/rm_project.py
+++ b/maintenance/scripts/rm_project.py
@@ -20,6 +20,7 @@ import sys
 from combine_app import CombineApp
 
 collections_with_project_id = (
+    "EditsCollection",
     "FrontierCollection",
     "MergeBlacklistCollection",
     "MergeGraylistCollection",


### PR DESCRIPTION
Resolves #4320 (the "longer term" fix proposed there). Supersedes #4327.

## Problem

A `UserEdit` document embeds its entire `edits` array, which grows without bound, and every goal/step write loaded the full document and rewrote it with `ReplaceOneAsync`. Once a document neared MongoDB's 16 MB limit, every write failed with `WriteError 17419` and the user was permanently blocked from recording goal/step progress in that project (observed in production).

## Fix

Each `Edit` now lives in its own document in a new `EditsCollection` (`StoredEdit`: `projectId`, `userEditId`, plus the edit fields), and the `UserEdit` document's `edits` array holds only ObjectId refs, preserving order (`StoredUserEdit`). No document now grows meaningfully with use, so there is no cap on edit history.

- Goal/step writes are targeted atomic updates on the small per-edit documents;
  - `UserEditRepository.Replace` (full-document rewrite) is removed.
- Appending a new edit inserts the `StoredEdit` and pushes its ref inside a multi-document transaction (the DB always runs as a replica set), so a failed append can't leave orphans.
- Reads assemble the wire `UserEdit` from both collections, so **the API contract is unchanged**;
  - no frontend or OpenAPI changes.
- `rm_project.py` now also purges `EditsCollection`.

## Mongo migration instructions (required)

`database/migrate-useredits-to-edits-collection.js`:
- moves every embedded edit into `EditsCollection`;
- replaces each `edits` array with ordered refs;
  - documents are modified in place, not deleted, since each user's `workedProjects` references the document `_id`;
- creates the `{ projectId, userEditId, guid }` index;
- verifies that no old-format documents remain, that every ref resolves to exactly one edit document (comparing ids, not counts), that each edit's `projectId` matches its parent's, and that no edit is orphaned or unreferenced — throwing, so a failed verification exits non-zero.

It is idempotent and safe to rerun.

This is a breaking schema change — old backends can't read migrated documents and the new backend can't read unmigrated ones — so it must be coordinated with the deploy:

1. **Back up** (run `combine_backup.py` in the maintenance pod)
2. **Stop the backend** (`kubectl -n thecombine scale deployment backend --replicas=0`)
3. **Deploy the update**
4. **Stop the backend again** (the deploy scales it back to 1)
5. **Run the migration** on the database pod:

   ```bash
   kubectl -n thecombine cp database/migrate-useredits-to-edits-collection.js <database-pod>:/tmp/migrate-useredits-to-edits-collection.js
   kubectl -n thecombine exec <database-pod> -- mongosh CombineDatabase /tmp/migrate-useredits-to-edits-collection.js
   ```

6. **Start the backend** (`kubectl -n thecombine scale deployment backend --replicas=1`)

Per the precedent of the GUID-subtype migration (#4179 / #4209), the script can be removed from the repo in a follow-up once it has been run everywhere.

## Testing

- 20 new `UserEditRepositoryTests` integration tests against a real (ephemeral) mongod replica set
- The repository integration fixtures now share one ephemeral mongod via a `SetUpFixture`; two runner instances in one test process caused intermittent `MongoNotPrimaryException` flakiness.
- Existing `UserEditControllerTests` pass unchanged, confirming the API behavior is untouched.
- The raw BSON layout is asserted in tests (the `edits` refs serialize as ObjectIds), so it matches what the migration script writes.

## Notes for reviewers

- Already-affected production documents are fully unblocked by the migration.
- `AddGoalToUserEdit` now decides add-vs-replace from the atomic `ReplaceEdit` result instead of a prior read, and `UpdateStepInEdit` requires the target step to exist in its filter, so neither the goal write nor an out-of-bounds step write can corrupt data under concurrency.
  - One pre-existing, low-risk race remains and is intentionally out of scope: `UserEditController.UpdateUserEditStep` still reads the step count to choose append-vs-overwrite, so concurrent step writes to the *same* goal could pick the wrong branch. Fixing it would require reshaping the wire contract (the client sends `StepIndex ?? append`), and the atomic bounds guard already rules out the only data-corruption outcome, so this is left for a follow-up.
- The `EditsCollection` index is `{ projectId, userEditId, guid }`, covering both the per-user-edit listing and the single-edit replace/step queries.
  - The backend doesn't manage indexes anywhere today, so new `database/init/01-indexes.js` creates it from the database pod's postStart hook on every container start, alongside `00-replica-set.js`. Fresh installs are therefore covered, and the index outlives the migration script's eventual removal. The migration creates it too, so a just-migrated database is indexed before its next restart.
- `UserEditController.UpdateUserEditStep` now takes the *first* edit with a given guid rather than the last, agreeing with the repository's `UpdateOne` step writes; previously a duplicate guid would have had the step count read from one edit and the write land on another.
- The migration script called `Object.bsonsize`, which mongosh does not provide, so it aborted on its first document with a `TypeError`. Document sizes now come from the server-side `$bsonSize` operator. The script has since been exercised end to end against a real mongod: a clean run, an idempotent rerun, recovery from an interrupted run, and each of five injected corruptions detected with a non-zero exit.

Co-authored by Claude.

Devin: https://app.devin.ai/review/sillsdev/TheCombine/pull/4328

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4328)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for adding, replacing, and updating individual goals and steps within user edits.
  * Improved handling of missing edits and invalid step positions with clear operation results.

* **Bug Fixes**
  * Improved project-level data isolation when retrieving and deleting user edits.
  * Ensured project removal also cleans up associated edit data.
  * Improved reliability when migrating and validating existing user-edit data.
  * Corrected updates to target the intended matching edit.

* **Tests**
  * Expanded coverage for user-edit operations, persistence, ordering, isolation, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
