### PR TITLE
Add transactional semantic domain sense-count collection

### DIFF
--- a/Backend.Tests/Controllers/WordControllerTests.cs
+++ b/Backend.Tests/Controllers/WordControllerTests.cs
@@ -15,6 +15,7 @@ namespace Backend.Tests.Controllers
     internal sealed class WordControllerTests : IDisposable
     {
         private WordRepositoryMock _wordRepo = null!;
+        private SemanticDomainCountRepositoryMock _semDomCountRepo = null!;
         private IPermissionService _permissionService = null!;
         private IWordService _wordService = null!;
         private WordController _wordController = null!;
@@ -32,9 +33,10 @@ namespace Backend.Tests.Controllers
         public void Setup()
         {
             _wordRepo = new WordRepositoryMock();
+            _semDomCountRepo = new SemanticDomainCountRepositoryMock();
             _wordService = new WordService(_wordRepo);
             _permissionService = new PermissionServiceMock();
-            _wordController = new WordController(_wordRepo, _wordService, _permissionService);
+            _wordController = new WordController(_wordRepo, _wordService, _semDomCountRepo, _permissionService);
         }
 
         [Test]
@@ -464,8 +466,11 @@ namespace Backend.Tests.Controllers
         [Test]
         public async Task TestGetDomainWordCount()
         {
+            _semDomCountRepo.SetCount(ProjId, "1", 3);
+
             var result = await _wordController.GetDomainWordCount(ProjId, "1");
             Assert.That(result, Is.InstanceOf<OkObjectResult>());
+            Assert.That(((OkObjectResult)result).Value, Is.EqualTo(3));
         }
     }
 }

--- a/Backend.Tests/Mocks/SemanticDomainCountRepositoryMock.cs
+++ b/Backend.Tests/Mocks/SemanticDomainCountRepositoryMock.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BackendFramework.Interfaces;
+using BackendFramework.Models;
+using MongoDB.Driver;
+
+namespace Backend.Tests.Mocks
+{
+    internal sealed class SemanticDomainCountRepositoryMock : ISemanticDomainCountRepository
+    {
+        private readonly List<ProjectSemanticDomainCount> _counts = [];
+
+        public Task<int> GetCount(string projectId, string domainId)
+        {
+            var count = _counts
+                .FirstOrDefault(c => c.ProjectId == projectId && c.DomainId == domainId)?.Count ?? 0;
+            return Task.FromResult(count);
+        }
+
+        public Task<List<ProjectSemanticDomainCount>> GetAllCounts(string projectId)
+        {
+            return Task.FromResult(_counts.Where(c => c.ProjectId == projectId).Select(c => c.Clone()).ToList());
+        }
+
+        // The session is ignored: this mock does not simulate transactions.
+        public Task ApplyDeltas(
+            IClientSessionHandle session, string projectId, IReadOnlyDictionary<string, int> domainDeltas)
+        {
+            foreach (var (domainId, delta) in domainDeltas)
+            {
+                if (delta == 0)
+                {
+                    continue;
+                }
+
+                var existing = _counts.FirstOrDefault(c => c.ProjectId == projectId && c.DomainId == domainId);
+                if (existing is null)
+                {
+                    _counts.Add(new ProjectSemanticDomainCount(projectId, domainId, delta));
+                }
+                else
+                {
+                    existing.Count += delta;
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteAllCounts(IClientSessionHandle session, string projectId)
+        {
+            _counts.RemoveAll(c => c.ProjectId == projectId);
+            return Task.CompletedTask;
+        }
+
+        /// <summary> Test helper to seed a count directly, without a transaction. </summary>
+        public void SetCount(string projectId, string domainId, int count)
+        {
+            var existing = _counts.FirstOrDefault(c => c.ProjectId == projectId && c.DomainId == domainId);
+            if (existing is null)
+            {
+                _counts.Add(new ProjectSemanticDomainCount(projectId, domainId, count));
+            }
+            else
+            {
+                existing.Count = count;
+            }
+        }
+    }
+}

--- a/Backend.Tests/Mocks/WordRepositoryMock.cs
+++ b/Backend.Tests/Mocks/WordRepositoryMock.cs
@@ -306,12 +306,5 @@ namespace Backend.Tests.Mocks
 
             return true;
         }
-
-        public Task<int> CountFrontierWordsWithDomain(string projectId, string domainId)
-        {
-            var count = _frontier.Count(
-                w => w.ProjectId == projectId && w.Senses.Any(s => s.SemanticDomains.Any(sd => sd.Id == domainId)));
-            return Task.FromResult(count);
-        }
     }
 }

--- a/Backend.Tests/Repositories/MongoDbSetUpFixture.cs
+++ b/Backend.Tests/Repositories/MongoDbSetUpFixture.cs
@@ -1,0 +1,26 @@
+using NUnit.Framework;
+
+namespace Backend.Tests.Repositories
+{
+    /// <summary>
+    /// Starts a single shared MongoDB instance for all repository integration tests.
+    /// Fixtures isolate themselves by using distinct database names.
+    /// </summary>
+    [SetUpFixture]
+    public sealed class MongoDbSetUpFixture
+    {
+        internal static MongoDbTestRunner Runner { get; private set; } = null!;
+
+        [OneTimeSetUp]
+        public void StartMongo()
+        {
+            Runner = MongoDbTestRunner.Start();
+        }
+
+        [OneTimeTearDown]
+        public void StopMongo()
+        {
+            Runner?.Dispose();
+        }
+    }
+}

--- a/Backend.Tests/Repositories/MongoDbTestRunner.cs
+++ b/Backend.Tests/Repositories/MongoDbTestRunner.cs
@@ -173,9 +173,16 @@ namespace Backend.Tests.Repositories
                 {
                     var admin = client.GetDatabase("admin");
                     var status = admin.RunCommand<BsonDocument>(new BsonDocument("replSetGetStatus", 1));
+                    // myState == 1 means PRIMARY, but a freshly elected primary briefly rejects writes with
+                    // "not primary" until it finishes transitioning. Also confirm it is writable via hello so
+                    // callers that write immediately (e.g. index creation) don't race that window.
                     if (status["ok"].ToInt32() == 1 && status["myState"].ToInt32() == 1)
                     {
-                        return;
+                        var hello = admin.RunCommand<BsonDocument>(new BsonDocument("hello", 1));
+                        if (hello.GetValue("isWritablePrimary", BsonBoolean.False).ToBoolean())
+                        {
+                            return;
+                        }
                     }
                 }
                 catch (Exception ex)

--- a/Backend.Tests/Repositories/SemanticDomainCountRepositoryTests.cs
+++ b/Backend.Tests/Repositories/SemanticDomainCountRepositoryTests.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BackendFramework.Contexts;
+using BackendFramework.Models;
+using BackendFramework.Repositories;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+using NUnit.Framework;
+
+namespace Backend.Tests.Repositories
+{
+    /// <summary>
+    /// Integration tests for <see cref="SemanticDomainCountRepository"/> that spin up an actual MongoDB instance.
+    /// A single-node replica set is required because the write methods run inside transactions.
+    /// </summary>
+    [TestFixture]
+    [Category("IntegrationTest")]
+    public sealed class SemanticDomainCountRepositoryTests
+    {
+        private static MongoDbTestRunner _runner = null!;
+        private MongoDbContext _dbContext = null!;
+        private SemanticDomainCountRepository _repo = null!;
+        private string _projectId = null!;
+
+        [OneTimeSetUp]
+        public static void StartMongo()
+        {
+            _runner?.Dispose();
+            _runner = MongoDbTestRunner.Start();
+        }
+
+        [OneTimeTearDown]
+        public static void StopMongo()
+        {
+            _runner?.Dispose();
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            _projectId = Guid.NewGuid().ToString();
+            var options = Options.Create(new BackendFramework.Startup.Settings
+            {
+                ConnectionString = _runner.ConnectionString,
+                CombineDatabase = "SemanticDomainCountRepositoryTests",
+            });
+            _dbContext = new MongoDbContext(options);
+            _repo = new SemanticDomainCountRepository(_dbContext);
+        }
+
+        private Task ApplyDeltas(IReadOnlyDictionary<string, int> deltas)
+        {
+            return _dbContext.ExecuteInTransaction(async session =>
+            {
+                await _repo.ApplyDeltas(session, _projectId, deltas);
+                return true;
+            });
+        }
+
+        [Test]
+        public async Task ApplyDeltasUpsertsThenIncrements()
+        {
+            await ApplyDeltas(new Dictionary<string, int> { ["1"] = 2, ["1.1"] = 1 });
+            Assert.That(await _repo.GetCount(_projectId, "1"), Is.EqualTo(2));
+            Assert.That(await _repo.GetCount(_projectId, "1.1"), Is.EqualTo(1));
+
+            await ApplyDeltas(new Dictionary<string, int> { ["1"] = 3 });
+            Assert.That(await _repo.GetCount(_projectId, "1"), Is.EqualTo(5));
+        }
+
+        [Test]
+        public async Task ApplyDeltasDecrements()
+        {
+            await ApplyDeltas(new Dictionary<string, int> { ["1"] = 5 });
+            await ApplyDeltas(new Dictionary<string, int> { ["1"] = -2 });
+            Assert.That(await _repo.GetCount(_projectId, "1"), Is.EqualTo(3));
+        }
+
+        [Test]
+        public async Task ApplyDeltasSkipsZeroDeltas()
+        {
+            await ApplyDeltas(new Dictionary<string, int> { ["1"] = 0 });
+            Assert.That(await _repo.GetAllCounts(_projectId), Is.Empty);
+        }
+
+        [Test]
+        public async Task GetCountReturnsZeroWhenAbsent()
+        {
+            Assert.That(await _repo.GetCount(_projectId, "9.9"), Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task GetAllCountsReturnsProjectCounts()
+        {
+            await ApplyDeltas(new Dictionary<string, int> { ["1"] = 1, ["2"] = 4 });
+            var all = await _repo.GetAllCounts(_projectId);
+            Assert.That(all, Has.Count.EqualTo(2));
+            Assert.That(all.Find(c => c.DomainId == "2")!.Count, Is.EqualTo(4));
+        }
+
+        [Test]
+        public async Task GetAllCountsIsolatesByProject()
+        {
+            await ApplyDeltas(new Dictionary<string, int> { ["1"] = 1 });
+            Assert.That(await _repo.GetAllCounts(Guid.NewGuid().ToString()), Is.Empty);
+        }
+
+        [Test]
+        public async Task DeleteAllCountsRemovesProjectCounts()
+        {
+            await ApplyDeltas(new Dictionary<string, int> { ["1"] = 1, ["2"] = 2 });
+            await _dbContext.ExecuteInTransaction(async session =>
+            {
+                await _repo.DeleteAllCounts(session, _projectId);
+                return true;
+            });
+            Assert.That(await _repo.GetAllCounts(_projectId), Is.Empty);
+        }
+
+        [Test]
+        public void UniqueIndexPreventsDuplicatePairs()
+        {
+            var collection =
+                _dbContext.Db.GetCollection<ProjectSemanticDomainCount>("SemanticDomainCountCollection");
+            collection.InsertOne(new ProjectSemanticDomainCount(_projectId, "1", 1));
+            Assert.That(
+                async () => await collection.InsertOneAsync(new ProjectSemanticDomainCount(_projectId, "1", 1)),
+                Throws.InstanceOf<MongoWriteException>());
+        }
+
+        [Test]
+        public void CountDomainsTalliesEachSenseOccurrence()
+        {
+            var word = new Word
+            {
+                Senses =
+                [
+                    new Sense { SemanticDomains = [new SemanticDomain { Id = "1" }, new SemanticDomain { Id = "2" }] },
+                    new Sense { SemanticDomains = [new SemanticDomain { Id = "1" }] },
+                ],
+            };
+
+            var counts = SemanticDomainCountRepository.CountDomains(word);
+            Assert.That(counts["1"], Is.EqualTo(2));
+            Assert.That(counts["2"], Is.EqualTo(1));
+        }
+    }
+}

--- a/Backend.Tests/Repositories/SemanticDomainCountRepositoryTests.cs
+++ b/Backend.Tests/Repositories/SemanticDomainCountRepositoryTests.cs
@@ -18,23 +18,9 @@ namespace Backend.Tests.Repositories
     [Category("IntegrationTest")]
     public sealed class SemanticDomainCountRepositoryTests
     {
-        private static MongoDbTestRunner _runner = null!;
         private MongoDbContext _dbContext = null!;
         private SemanticDomainCountRepository _repo = null!;
         private string _projectId = null!;
-
-        [OneTimeSetUp]
-        public static void StartMongo()
-        {
-            _runner?.Dispose();
-            _runner = MongoDbTestRunner.Start();
-        }
-
-        [OneTimeTearDown]
-        public static void StopMongo()
-        {
-            _runner?.Dispose();
-        }
 
         [SetUp]
         public void SetUp()
@@ -42,7 +28,7 @@ namespace Backend.Tests.Repositories
             _projectId = Guid.NewGuid().ToString();
             var options = Options.Create(new BackendFramework.Startup.Settings
             {
-                ConnectionString = _runner.ConnectionString,
+                ConnectionString = MongoDbSetUpFixture.Runner.ConnectionString,
                 CombineDatabase = "SemanticDomainCountRepositoryTests",
             });
             _dbContext = new MongoDbContext(options);

--- a/Backend.Tests/Repositories/WordRepositoryTests.cs
+++ b/Backend.Tests/Repositories/WordRepositoryTests.cs
@@ -17,23 +17,9 @@ namespace Backend.Tests.Repositories
     [Category("IntegrationTest")]
     public sealed class WordRepositoryTests
     {
-        private static MongoDbTestRunner _runner = null!;
         private WordRepository _repo = null!;
         private SemanticDomainCountRepository _semDomCountRepo = null!;
         private string _projectId = null!;
-
-        [OneTimeSetUp]
-        public static void StartMongo()
-        {
-            _runner?.Dispose();
-            _runner = MongoDbTestRunner.Start();
-        }
-
-        [OneTimeTearDown]
-        public static void StopMongo()
-        {
-            _runner?.Dispose();
-        }
 
         [SetUp]
         public void SetUp()
@@ -41,7 +27,7 @@ namespace Backend.Tests.Repositories
             _projectId = Guid.NewGuid().ToString();
             var options = Options.Create(new BackendFramework.Startup.Settings
             {
-                ConnectionString = _runner.ConnectionString,
+                ConnectionString = MongoDbSetUpFixture.Runner.ConnectionString,
                 CombineDatabase = "WordRepositoryTests",
             });
             var dbContext = new MongoDbContext(options);
@@ -704,26 +690,6 @@ namespace Backend.Tests.Repositories
             var word = await CreateWord();
             Assert.ThrowsAsync<ArgumentException>(() =>
                 _repo.RevertReplaceFrontier(_projectId, [word.Id], [word.Id], _ => { }));
-        }
-
-        [Test]
-        public async Task TestCountFrontierWordsWithDomainReturnsCorrectCount()
-        {
-            const string domainId = "1.1";
-            await CreateWord(domainId: domainId);
-            await CreateWord(domainId: domainId);
-            await CreateWord();
-
-            var count = await _repo.CountFrontierWordsWithDomain(_projectId, domainId);
-            Assert.That(count, Is.EqualTo(2));
-        }
-
-        [Test]
-        public async Task TestCountFrontierWordsWithDomainNoneMatchReturnsZero()
-        {
-            await CreateWord();
-            var count = await _repo.CountFrontierWordsWithDomain(_projectId, "99.99");
-            Assert.That(count, Is.Zero);
         }
 
         [Test]

--- a/Backend.Tests/Repositories/WordRepositoryTests.cs
+++ b/Backend.Tests/Repositories/WordRepositoryTests.cs
@@ -19,6 +19,7 @@ namespace Backend.Tests.Repositories
     {
         private static MongoDbTestRunner _runner = null!;
         private WordRepository _repo = null!;
+        private SemanticDomainCountRepository _semDomCountRepo = null!;
         private string _projectId = null!;
 
         [OneTimeSetUp]
@@ -43,7 +44,9 @@ namespace Backend.Tests.Repositories
                 ConnectionString = _runner.ConnectionString,
                 CombineDatabase = "WordRepositoryTests",
             });
-            _repo = new WordRepository(new MongoDbContext(options));
+            var dbContext = new MongoDbContext(options);
+            _semDomCountRepo = new SemanticDomainCountRepository(dbContext);
+            _repo = new WordRepository(dbContext, _semDomCountRepo);
         }
 
         private Task<Word> CreateWord(string? vernacular = null, string? domainId = null)
@@ -721,6 +724,91 @@ namespace Backend.Tests.Repositories
             await CreateWord();
             var count = await _repo.CountFrontierWordsWithDomain(_projectId, "99.99");
             Assert.That(count, Is.Zero);
+        }
+
+        [Test]
+        public async Task TestCreateIncrementsDomainCount()
+        {
+            const string domainId = "1.1";
+            await CreateWord(domainId: domainId);
+            await CreateWord(domainId: domainId);
+            Assert.That(await _semDomCountRepo.GetCount(_projectId, domainId), Is.EqualTo(2));
+        }
+
+        [Test]
+        public async Task TestDeleteFrontierDecrementsDomainCount()
+        {
+            const string domainId = "1.1";
+            var word = await CreateWord(domainId: domainId);
+            await _repo.DeleteFrontier(_projectId, word.Id, _ => { });
+            Assert.That(await _semDomCountRepo.GetCount(_projectId, domainId), Is.Zero);
+        }
+
+        [Test]
+        public async Task TestUpdateFrontierAdjustsDomainCounts()
+        {
+            const string oldDomain = "1.1";
+            const string newDomain = "2.2";
+            var word = await CreateWord(domainId: oldDomain);
+
+            await _repo.UpdateFrontier(_projectId, word.Id,
+                w => w.Senses[0].SemanticDomains = [new SemanticDomain { Id = newDomain, Name = "Test" }]);
+
+            Assert.That(await _semDomCountRepo.GetCount(_projectId, oldDomain), Is.Zero);
+            Assert.That(await _semDomCountRepo.GetCount(_projectId, newDomain), Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task TestReplaceFrontierAdjustsDomainCounts()
+        {
+            const string oldDomain = "1.1";
+            const string newDomain = "2.2";
+            var word = await CreateWord(domainId: oldDomain);
+            var updated = word.Clone();
+            updated.Senses[0].SemanticDomains = [new SemanticDomain { Id = newDomain, Name = "Test" }];
+
+            await _repo.ReplaceFrontier(_projectId, [updated], [word.Id], (_, _) => { }, _ => { });
+
+            Assert.That(await _semDomCountRepo.GetCount(_projectId, oldDomain), Is.Zero);
+            Assert.That(await _semDomCountRepo.GetCount(_projectId, newDomain), Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task TestRestoreFrontierRestoresDomainCount()
+        {
+            const string domainId = "1.1";
+            var word = await CreateWord(domainId: domainId);
+            await _repo.DeleteFrontier(_projectId, word.Id, _ => { });
+            Assert.That(await _semDomCountRepo.GetCount(_projectId, domainId), Is.Zero);
+
+            await _repo.RestoreFrontier(_projectId, word.Id);
+            Assert.That(await _semDomCountRepo.GetCount(_projectId, domainId), Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task TestDeleteAllFrontierWordsClearsDomainCounts()
+        {
+            await CreateWord(domainId: "1.1");
+            await CreateWord(domainId: "2.2");
+
+            await _repo.DeleteAllFrontierWords(_projectId);
+
+            Assert.That(await _semDomCountRepo.GetAllCounts(_projectId), Is.Empty);
+        }
+
+        [Test]
+        public async Task TestDeleteFrontierModifyThrowsRollsBackDomainCount()
+        {
+            const string domainId = "1.1";
+            var word = await CreateWord(domainId: domainId);
+            Assert.That(await _semDomCountRepo.GetCount(_projectId, domainId), Is.EqualTo(1));
+
+            // The count delta is applied inside the same transaction as the word write; when the modify
+            // action throws, the whole transaction aborts and the delta must roll back with it.
+            Assert.ThrowsAsync<InvalidOperationException>(() =>
+                _repo.DeleteFrontier(_projectId, word.Id, _ => throw new InvalidOperationException()));
+
+            Assert.That(await _semDomCountRepo.GetCount(_projectId, domainId), Is.EqualTo(1));
         }
     }
 }

--- a/Backend.Tests/Services/StatisticsServiceTests.cs
+++ b/Backend.Tests/Services/StatisticsServiceTests.cs
@@ -12,6 +12,7 @@ namespace Backend.Tests.Services
     internal sealed class StatisticsServiceTests
     {
         private ISemanticDomainRepository _domainRepo = null!;
+        private SemanticDomainCountRepositoryMock _semDomCountRepo = null!;
         private IUserRepository _userRepo = null!;
         private WordRepositoryMock _wordRepo = null!;
         private IStatisticsService _statsService = null!;
@@ -46,16 +47,17 @@ namespace Backend.Tests.Services
         public void Setup()
         {
             _domainRepo = new SemanticDomainRepositoryMock();
+            _semDomCountRepo = new SemanticDomainCountRepositoryMock();
             _userRepo = new UserRepositoryMock();
             _wordRepo = new WordRepositoryMock();
-            _statsService = new StatisticsService(_wordRepo, _domainRepo, _userRepo);
+            _statsService = new StatisticsService(_wordRepo, _domainRepo, _semDomCountRepo, _userRepo);
         }
 
         [Test]
         public void GetSemanticDomainCountsTestNullDomainList()
         {
-            // Add a word to the database and leave the semantic domain list null
-            _wordRepo.AddFrontier(GetWordWithDomain());
+            // Leave the semantic domain tree-node list null; the cached count is irrelevant without domains.
+            _semDomCountRepo.SetCount(ProjId, SemDomId, 1);
 
             var result = _statsService.GetSemanticDomainCounts(ProjId, "").Result;
             Assert.That(result, Is.Empty);
@@ -64,42 +66,41 @@ namespace Backend.Tests.Services
         [Test]
         public void GetSemanticDomainCountsTestEmptyDomainList()
         {
-            // Add to the database a word and an empty list of semantic domains
             ((SemanticDomainRepositoryMock)_domainRepo).SetNextResponse(new List<SemanticDomainTreeNode>());
-            _wordRepo.AddFrontier(GetWordWithDomain());
+            _semDomCountRepo.SetCount(ProjId, SemDomId, 1);
 
             var result = _statsService.GetSemanticDomainCounts(ProjId, "").Result;
             Assert.That(result, Is.Empty);
         }
 
         [Test]
-        public void GetSemanticDomainCountsTestEmptyFrontier()
+        public void GetSemanticDomainCountsTestEmptyCounts()
         {
-            // Add to the database a semantic domain but no word
+            // With domains present but no cached counts, every node is reported with a count of 0.
             ((SemanticDomainRepositoryMock)_domainRepo).SetNextResponse(TreeNodes);
 
             var result = _statsService.GetSemanticDomainCounts(ProjId, "").Result;
-            Assert.That(result, Is.Empty);
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result.First().Count, Is.Zero);
         }
 
         [Test]
         public void GetSemanticDomainCountsTestIdMismatch()
         {
-            // Add to the database a semantic domain and a word with a different semantic domain
+            // Cache a count for a different domain than the one in the tree; the node's count stays 0.
             ((SemanticDomainRepositoryMock)_domainRepo).SetNextResponse(TreeNodes);
-            _wordRepo.AddFrontier(GetWordWithDomain("different-id"));
+            _semDomCountRepo.SetCount(ProjId, "different-id", 1);
 
             var result = _statsService.GetSemanticDomainCounts(ProjId, "").Result;
             Assert.That(result, Has.Count.EqualTo(1));
-            Assert.That(result.First(), Is.Empty);
+            Assert.That(result.First().Count, Is.Zero);
         }
 
         [Test]
         public void GetSemanticDomainCountsTestIdMatch()
         {
-            // Add to the database a semantic domain and a word with the same semantic domain
             ((SemanticDomainRepositoryMock)_domainRepo).SetNextResponse(TreeNodes);
-            _wordRepo.AddFrontier(GetWordWithDomain());
+            _semDomCountRepo.SetCount(ProjId, SemDomId, 1);
 
             var result = _statsService.GetSemanticDomainCounts(ProjId, "").Result;
             Assert.That(result, Has.Count.EqualTo(1));

--- a/Backend/Controllers/WordController.cs
+++ b/Backend/Controllers/WordController.cs
@@ -13,10 +13,11 @@ namespace BackendFramework.Controllers
     [Authorize]
     [Produces("application/json")]
     [Route("v1/projects/{projectId}/words")]
-    public class WordController(
-        IWordRepository wordRepo, IWordService wordService, IPermissionService permissionService) : Controller
+    public class WordController(IWordRepository wordRepo, IWordService wordService,
+        ISemanticDomainCountRepository semDomCountRepo, IPermissionService permissionService) : Controller
     {
         private readonly IWordRepository _wordRepo = wordRepo;
+        private readonly ISemanticDomainCountRepository _semDomCountRepo = semDomCountRepo;
         private readonly IPermissionService _permissionService = permissionService;
         private readonly IWordService _wordService = wordService;
 
@@ -299,7 +300,7 @@ namespace BackendFramework.Controllers
             return Ok(updates);
         }
 
-        /// <summary> Get the count of frontier words with senses in a specific semantic domain </summary>
+        /// <summary> Get the count of frontier word senses in a specific semantic domain </summary>
         /// <returns> An integer count </returns>
         [HttpGet("domainwordcount/{domainId}", Name = "GetDomainWordCount")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(int))]
@@ -313,7 +314,7 @@ namespace BackendFramework.Controllers
                 return Forbid();
             }
 
-            return Ok(await _wordRepo.CountFrontierWordsWithDomain(projectId, domainId));
+            return Ok(await _semDomCountRepo.GetCount(projectId, domainId));
         }
     }
 }

--- a/Backend/Interfaces/ISemanticDomainCountRepository.cs
+++ b/Backend/Interfaces/ISemanticDomainCountRepository.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BackendFramework.Models;
+using MongoDB.Driver;
+
+namespace BackendFramework.Interfaces
+{
+    /// <summary>
+    /// Database functions for cached per-project semantic domain sense counts
+    /// (see <see cref="ProjectSemanticDomainCount"/>).
+    /// </summary>
+    /// <remarks>
+    /// Writes take an <see cref="IClientSessionHandle"/> so they can run inside the same transaction as the
+    /// word write that changed the Frontier, keeping the counts atomically in sync. Reads run outside any
+    /// transaction (used by the statistics and word-count endpoints).
+    /// </remarks>
+    public interface ISemanticDomainCountRepository
+    {
+        /// <summary> Gets the cached count for a single semantic domain in a project (0 when absent). </summary>
+        Task<int> GetCount(string projectId, string domainId);
+
+        /// <summary> Gets all cached semantic domain counts for a project. </summary>
+        Task<List<ProjectSemanticDomainCount>> GetAllCounts(string projectId);
+
+        /// <summary>
+        /// Applies signed per-domain deltas to a project's cached counts within a transaction, upserting as needed.
+        /// </summary>
+        /// <param name="session">Mongo transaction session.</param>
+        /// <param name="projectId">Id of the project whose counts are updated.</param>
+        /// <param name="domainDeltas">Map of semantic domain id to the signed amount to add (may be negative).</param>
+        Task ApplyDeltas(IClientSessionHandle session, string projectId, IReadOnlyDictionary<string, int> domainDeltas);
+
+        /// <summary> Removes all cached counts for a project within a transaction. </summary>
+        /// <param name="session">Mongo transaction session.</param>
+        /// <param name="projectId">Id of the project whose counts are removed.</param>
+        Task DeleteAllCounts(IClientSessionHandle session, string projectId);
+    }
+}

--- a/Backend/Interfaces/IWordRepository.cs
+++ b/Backend/Interfaces/IWordRepository.cs
@@ -28,6 +28,5 @@ namespace BackendFramework.Interfaces
             Action<Word, Word?> modifyUpdatedWord, Action<Word> modifyDeletedWord);
         Task<bool> RevertReplaceFrontier(string projectId, List<string> idsToRestore, List<string> idsToDelete,
             Action<Word> modifyDeletedWord);
-        Task<int> CountFrontierWordsWithDomain(string projectId, string domainId);
     }
 }

--- a/Backend/Models/ProjectSemanticDomainCount.cs
+++ b/Backend/Models/ProjectSemanticDomainCount.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel.DataAnnotations;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace BackendFramework.Models
+{
+    /// <summary>
+    /// A cached tally of how many frontier sense-occurrences of a semantic domain exist within a project.
+    /// There is one document per (<see cref="ProjectId"/>, <see cref="DomainId"/>) pair.
+    /// </summary>
+    public class ProjectSemanticDomainCount
+    {
+        [Required]
+        [BsonId]
+        [BsonRepresentation(BsonType.ObjectId)]
+        public string Id { get; set; }
+
+        [Required]
+        [BsonElement("projectId")]
+        public string ProjectId { get; set; }
+
+        [Required]
+        [BsonElement("domainId")]
+        public string DomainId { get; set; }
+
+        [Required]
+        [BsonElement("count")]
+        public int Count { get; set; }
+
+        public ProjectSemanticDomainCount()
+        {
+            Id = "";
+            ProjectId = "";
+            DomainId = "";
+            Count = 0;
+        }
+
+        public ProjectSemanticDomainCount(string projectId, string domainId, int count = 0) : this()
+        {
+            ProjectId = projectId;
+            DomainId = domainId;
+            Count = count;
+        }
+
+        /// <summary> Create a deep copy. </summary>
+        public ProjectSemanticDomainCount Clone()
+        {
+            // Shallow copy is sufficient.
+            return (ProjectSemanticDomainCount)MemberwiseClone();
+        }
+    }
+}

--- a/Backend/Repositories/SemanticDomainCountRepository.cs
+++ b/Backend/Repositories/SemanticDomainCountRepository.cs
@@ -1,0 +1,124 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BackendFramework.Interfaces;
+using BackendFramework.Models;
+using BackendFramework.Otel;
+using MongoDB.Driver;
+
+namespace BackendFramework.Repositories
+{
+    /// <summary> Atomic database functions for cached <see cref="ProjectSemanticDomainCount"/>s. </summary>
+    public class SemanticDomainCountRepository : ISemanticDomainCountRepository
+    {
+        private readonly IMongoCollection<ProjectSemanticDomainCount> _counts;
+
+        private const string otelTagName = "otel.SemanticDomainCountRepository";
+
+        public SemanticDomainCountRepository(IMongoDbContext dbContext)
+        {
+            _counts = dbContext.Db.GetCollection<ProjectSemanticDomainCount>("SemanticDomainCountCollection");
+
+            // The unique compound index enforces one document per (project, domain). Creating it here also
+            // guarantees the collection exists before any transactional upsert touches it.
+            var keys = Builders<ProjectSemanticDomainCount>.IndexKeys
+                .Ascending(c => c.ProjectId)
+                .Ascending(c => c.DomainId);
+            _counts.Indexes.CreateOne(
+                new CreateIndexModel<ProjectSemanticDomainCount>(keys, new CreateIndexOptions { Unique = true }));
+        }
+
+        /// <summary> Gets the cached count for a single semantic domain in a project (0 when absent). </summary>
+        public async Task<int> GetCount(string projectId, string domainId)
+        {
+            using var activity = OtelService.StartActivityWithTag(otelTagName, "getting a semantic domain count");
+
+            var count = await _counts.Find(ProjectDomainFilter(projectId, domainId)).FirstOrDefaultAsync();
+            return count?.Count ?? 0;
+        }
+
+        /// <summary> Gets all cached semantic domain counts for a project. </summary>
+        public async Task<List<ProjectSemanticDomainCount>> GetAllCounts(string projectId)
+        {
+            using var activity = OtelService.StartActivityWithTag(otelTagName, "getting all semantic domain counts");
+
+            return await _counts.Find(c => c.ProjectId == projectId).ToListAsync();
+        }
+
+        /// <summary>
+        /// Applies signed per-domain deltas to a project's cached counts within a transaction, upserting as needed.
+        /// </summary>
+        /// <param name="session">Mongo transaction session.</param>
+        /// <param name="projectId">Id of the project whose counts are updated.</param>
+        /// <param name="domainDeltas">Map of semantic domain id to the signed amount to add (may be negative).</param>
+        public async Task ApplyDeltas(
+            IClientSessionHandle session, string projectId, IReadOnlyDictionary<string, int> domainDeltas)
+        {
+            using var activity = OtelService.StartActivityWithTag(otelTagName, "applying semantic domain count deltas");
+
+            var models = new List<WriteModel<ProjectSemanticDomainCount>>();
+            foreach (var (domainId, delta) in domainDeltas)
+            {
+                if (delta == 0)
+                {
+                    continue;
+                }
+
+                var update = Builders<ProjectSemanticDomainCount>.Update.Inc(c => c.Count, delta);
+                models.Add(new UpdateOneModel<ProjectSemanticDomainCount>(ProjectDomainFilter(projectId, domainId),
+                    update)
+                { IsUpsert = true });
+            }
+
+            if (models.Count == 0)
+            {
+                return;
+            }
+
+            await _counts.BulkWriteAsync(session, models);
+        }
+
+        /// <summary> Removes all cached counts for a project within a transaction. </summary>
+        /// <param name="session">Mongo transaction session.</param>
+        /// <param name="projectId">Id of the project whose counts are removed.</param>
+        public async Task DeleteAllCounts(IClientSessionHandle session, string projectId)
+        {
+            using var activity = OtelService.StartActivityWithTag(otelTagName, "deleting all semantic domain counts");
+
+            await _counts.DeleteManyAsync(session, c => c.ProjectId == projectId);
+        }
+
+        /// <summary>
+        /// Tallies, per semantic domain id, how many sense-occurrences of that domain appear across the given words.
+        /// A word with two senses in the same domain contributes 2, matching the historical per-sense statistics.
+        /// </summary>
+        public static Dictionary<string, int> CountDomains(IEnumerable<Word> words)
+        {
+            var counts = new Dictionary<string, int>();
+            foreach (var word in words)
+            {
+                foreach (var sense in word.Senses)
+                {
+                    foreach (var domain in sense.SemanticDomains)
+                    {
+                        counts[domain.Id] = counts.GetValueOrDefault(domain.Id) + 1;
+                    }
+                }
+            }
+
+            return counts;
+        }
+
+        /// <summary> Tallies semantic domain sense-occurrences for a single word. </summary>
+        public static Dictionary<string, int> CountDomains(Word word)
+        {
+            return CountDomains([word]);
+        }
+
+        private static FilterDefinition<ProjectSemanticDomainCount> ProjectDomainFilter(
+            string projectId, string domainId)
+        {
+            var filterDef = new FilterDefinitionBuilder<ProjectSemanticDomainCount>();
+            return filterDef.And(filterDef.Eq(c => c.ProjectId, projectId), filterDef.Eq(c => c.DomainId, domainId));
+        }
+    }
+}

--- a/Backend/Repositories/WordRepository.cs
+++ b/Backend/Repositories/WordRepository.cs
@@ -10,9 +10,11 @@ using MongoDB.Driver;
 namespace BackendFramework.Repositories
 {
     /// <summary> Atomic database functions for <see cref="Word"/>s. </summary>
-    public class WordRepository(IMongoDbContext dbContext) : IWordRepository
+    public class WordRepository(IMongoDbContext dbContext, ISemanticDomainCountRepository semDomCountRepo)
+        : IWordRepository
     {
         private readonly IMongoDbContext _dbContext = dbContext;
+        private readonly ISemanticDomainCountRepository _semDomCountRepo = semDomCountRepo;
         private readonly IMongoCollection<Word> _frontier = dbContext.Db.GetCollection<Word>("FrontierCollection");
         private readonly IMongoCollection<Word> _words = dbContext.Db.GetCollection<Word>("WordsCollection");
 
@@ -135,11 +137,8 @@ namespace BackendFramework.Repositories
         {
             using var activity = OtelService.StartActivityWithTag(otelTagName, "deleting all words from Frontier");
 
-            var filterDef = new FilterDefinitionBuilder<Word>();
-            var filter = filterDef.Eq(x => x.ProjectId, projectId);
-
-            var deleted = await _frontier.DeleteManyAsync(filter);
-            return deleted.DeletedCount != 0;
+            return await _dbContext.ExecuteInTransaction(
+                async s => await DeleteAllFrontierWordsWithSession(s, projectId));
         }
 
         /// <summary> Checks if Words collection for specified <see cref="Project"/> has any words. </summary>
@@ -406,6 +405,7 @@ namespace BackendFramework.Repositories
             // The first collection insert will generate the id, which should match in the second collection.
             await _words.InsertManyAsync(session, words);
             await _frontier.InsertManyAsync(session, words);
+            await ApplyDomainDeltas(session, words, 1);
             return words;
         }
 
@@ -427,6 +427,8 @@ namespace BackendFramework.Repositories
             {
                 return null;
             }
+
+            await ApplyDomainDeltas(session, [deletedWord], -1);
 
             var modifiedWord = deletedWord.Clone();
             modifyDeletedWord(modifiedWord);
@@ -462,6 +464,7 @@ namespace BackendFramework.Repositories
             }
 
             await _frontier.InsertOneAsync(session, word);
+            await ApplyDomainDeltas(session, [word], 1);
             return true;
         }
 
@@ -481,6 +484,8 @@ namespace BackendFramework.Repositories
             {
                 return null;
             }
+
+            await ApplyDomainDeltas(session, [deletedWord], -1);
 
             var word = deletedWord.Clone();
             modifyUpdatedWord(word);
@@ -510,6 +515,11 @@ namespace BackendFramework.Repositories
             if (deletedWord is null && !createIfNotFound)
             {
                 return null;
+            }
+
+            if (deletedWord is not null)
+            {
+                await ApplyDomainDeltas(session, [deletedWord], -1);
             }
 
             modifyUpdatedWord(word, deletedWord?.Clone());
@@ -597,6 +607,43 @@ namespace BackendFramework.Repositories
                 }
             }
             return true;
+        }
+
+        /// <summary>
+        /// Deletes all Frontier words for a project and clears its cached semantic domain counts in one transaction.
+        /// </summary>
+        /// <param name="session">Mongo transaction session.</param>
+        /// <param name="projectId">Id of the project whose Frontier words are removed.</param>
+        /// <returns>True if at least one Frontier word was deleted; otherwise false.</returns>
+        private async Task<bool> DeleteAllFrontierWordsWithSession(IClientSessionHandle session, string projectId)
+        {
+            var filterDef = new FilterDefinitionBuilder<Word>();
+            var filter = filterDef.Eq(x => x.ProjectId, projectId);
+
+            var deleted = await _frontier.DeleteManyAsync(session, filter);
+            await _semDomCountRepo.DeleteAllCounts(session, projectId);
+            return deleted.DeletedCount != 0;
+        }
+
+        /// <summary>
+        /// Applies semantic domain sense-count deltas for the given words within the transaction session, one
+        /// call per distinct project. <paramref name="sign"/> is +1 when the words enter the Frontier and -1
+        /// when they leave it, so the cached counts commit or roll back with the same transaction as the word write.
+        /// </summary>
+        /// <param name="session">Mongo transaction session.</param>
+        /// <param name="words">Words whose semantic domain occurrences changed in the Frontier.</param>
+        /// <param name="sign">+1 to add the words' domain occurrences, -1 to remove them.</param>
+        private async Task ApplyDomainDeltas(IClientSessionHandle session, IEnumerable<Word> words, int sign)
+        {
+            foreach (var wordsByProject in words.GroupBy(w => w.ProjectId))
+            {
+                var deltas = SemanticDomainCountRepository.CountDomains(wordsByProject);
+                if (sign < 0)
+                {
+                    deltas = deltas.ToDictionary(kv => kv.Key, kv => -kv.Value);
+                }
+                await _semDomCountRepo.ApplyDeltas(session, wordsByProject.Key, deltas);
+            }
         }
 
         #endregion

--- a/Backend/Repositories/WordRepository.cs
+++ b/Backend/Repositories/WordRepository.cs
@@ -364,24 +364,6 @@ namespace BackendFramework.Repositories
                     s, projectId, idsToRestore, idsToDelete, modifyDeletedWord)) ?? false;
         }
 
-        /// <summary>
-        /// Counts the number of Frontier words that have the specified semantic domain.
-        /// </summary>
-        /// <param name="projectId">The project id</param>
-        /// <param name="domainId">The semantic domain id</param>
-        /// <returns>The count of words containing at least one sense with the specified domain.</returns>
-        public async Task<int> CountFrontierWordsWithDomain(string projectId, string domainId)
-        {
-            using var activity = OtelService.StartActivityWithTag(otelTagName, "counting frontier words with domain");
-
-            var filterDef = new FilterDefinitionBuilder<Word>();
-            var filter = filterDef.And(
-                filterDef.Eq(w => w.ProjectId, projectId),
-                filterDef.ElemMatch(w => w.Senses, s => s.SemanticDomains.Any(sd => sd.Id == domainId)));
-
-            return (int)await _frontier.CountDocumentsAsync(filter);
-        }
-
         #endregion
 
         #region Private with-session helper methods

--- a/Backend/Services/StatisticsService.cs
+++ b/Backend/Services/StatisticsService.cs
@@ -13,15 +13,17 @@ namespace BackendFramework.Services
     {
         private readonly IWordRepository _wordRepo;
         private readonly ISemanticDomainRepository _domainRepo;
+        private readonly ISemanticDomainCountRepository _semDomCountRepo;
         private readonly IUserRepository _userRepo;
 
         private const string otelTagName = "otel.StatisticsService";
 
-        public StatisticsService(
-            IWordRepository wordRepo, ISemanticDomainRepository domainRepo, IUserRepository userRepo)
+        public StatisticsService(IWordRepository wordRepo, ISemanticDomainRepository domainRepo,
+            ISemanticDomainCountRepository semDomCountRepo, IUserRepository userRepo)
         {
             _wordRepo = wordRepo;
             _domainRepo = domainRepo;
+            _semDomCountRepo = semDomCountRepo;
             _userRepo = userRepo;
         }
 
@@ -39,32 +41,17 @@ namespace BackendFramework.Services
         {
             using var activity = OtelService.StartActivityWithTag(otelTagName, "getting semantic domain counts");
 
-            var hashMap = new Dictionary<string, int>();
             var domainTreeNodeList = await _domainRepo.GetAllSemanticDomainTreeNodes(lang);
-            var wordList = await _wordRepo.GetAllFrontier(projectId);
-
-            if (domainTreeNodeList is null || domainTreeNodeList.Count == 0 || wordList.Count == 0)
+            if (domainTreeNodeList is null || domainTreeNodeList.Count == 0)
             {
                 return [];
             }
 
-            foreach (var word in wordList)
-            {
-                foreach (var sense in word.Senses)
-                {
-                    foreach (var sd in sense.SemanticDomains)
-                    {
-                        hashMap[sd.Id] = hashMap.GetValueOrDefault(sd.Id, 0) + 1;
-                    }
-                }
-            }
+            var domainCounts =
+                (await _semDomCountRepo.GetAllCounts(projectId)).ToDictionary(dc => dc.DomainId, dc => dc.Count);
 
-            var resList = new List<SemanticDomainCount>();
-            foreach (var domainTreeNode in domainTreeNodeList)
-            {
-                resList.Add(new(domainTreeNode, hashMap.GetValueOrDefault(domainTreeNode.Id, 0)));
-            }
-            return resList;
+            return domainTreeNodeList
+                .Select(node => new SemanticDomainCount(node, domainCounts.GetValueOrDefault(node.Id, 0))).ToList();
         }
 
         /// <summary>

--- a/Backend/Startup.cs
+++ b/Backend/Startup.cs
@@ -272,6 +272,9 @@ namespace BackendFramework
 
             // Semantic Domain types
             services.AddSingleton<ISemanticDomainRepository, SemanticDomainRepository>();
+            // Singleton so the repository's unique-index creation runs once per process rather than on
+            // every word edit (it is a dependency of the per-word-operation WordRepository).
+            services.AddSingleton<ISemanticDomainCountRepository, SemanticDomainCountRepository>();
 
             // Speaker types
             services.AddTransient<ISpeakerRepository, SpeakerRepository>();

--- a/database/backfill-semantic-domain-counts.js
+++ b/database/backfill-semantic-domain-counts.js
@@ -1,0 +1,97 @@
+// Backfill script: populate SemanticDomainCountCollection from the current Frontier.
+//
+// The backend keeps a cached count, per (project, semantic domain), of how many Frontier
+// sense-occurrences reference that domain. The count is maintained transactionally as words are
+// created/updated/deleted, but existing projects need their counts computed once from the current
+// Frontier. This script does that backfill.
+//
+// Usage (local):
+//   mongosh CombineDatabase database/backfill-semantic-domain-counts.js
+//
+// Usage (Kubernetes, e.g. production):
+//   kubectl -n thecombine cp database/backfill-semantic-domain-counts.js \
+//     <database-pod>:/tmp/backfill-semantic-domain-counts.js
+//   kubectl -n thecombine exec <database-pod> -- \
+//     mongosh CombineDatabase /tmp/backfill-semantic-domain-counts.js
+//
+// IMPORTANT:
+// - This is NOT a breaking schema change: an old backend simply ignores the new collection, and the
+//   new backend maintains it going forward. It is safe to deploy the count-maintaining backend first.
+// - Run the backfill with word editing paused (backend scaled down, or no active users), because a
+//   Frontier write that lands between the aggregation and this run could be double-counted (the new
+//   backend already incremented it) or a delete missed. Editing while stopped avoids drift.
+// - The script is idempotent: it fully rebuilds the collection, which is a pure cache derived from
+//   the Frontier. Re-run it any time the counts are suspected to have drifted, or after restoring a
+//   backup taken before the count collection existed.
+//
+// Count document (must match ProjectSemanticDomainCount in Backend/Models/ProjectSemanticDomainCount.cs):
+//   { _id: ObjectId, projectId: string, domainId: string, count: int }
+
+var frontier = db.getCollection("FrontierCollection");
+var counts = db.getCollection("SemanticDomainCountCollection");
+
+// Rebuild from scratch: the collection is fully derived from the Frontier.
+var removed = counts.deleteMany({}).deletedCount;
+print("Cleared " + removed + " existing count document(s).");
+
+// Tally every (sense, semantic domain) occurrence per project. A word with two senses in the same
+// domain contributes 2, matching how the backend maintains the counts.
+var aggregated = frontier
+  .aggregate(
+    [
+      { $unwind: "$senses" },
+      { $unwind: "$senses.SemanticDomains" },
+      {
+        $group: {
+          _id: { projectId: "$projectId", domainId: "$senses.SemanticDomains.id" },
+          count: { $sum: 1 },
+        },
+      },
+    ],
+    { allowDiskUse: true }
+  )
+  .toArray();
+
+var docs = aggregated.map(function (g) {
+  return {
+    _id: new ObjectId(),
+    projectId: g._id.projectId,
+    domainId: g._id.domainId,
+    count: g.count,
+  };
+});
+
+if (docs.length > 0) {
+  counts.insertMany(docs, { ordered: false });
+}
+print("Inserted " + docs.length + " count document(s).");
+
+// Unique compound index matches the one the backend creates on start-up.
+counts.createIndex({ projectId: 1, domainId: 1 }, { unique: true });
+print("Ensured unique index { projectId: 1, domainId: 1 } on SemanticDomainCountCollection.");
+
+// Verify: total counted occurrences equal the number of (sense, domain) pairs in the Frontier.
+var expected = frontier
+  .aggregate(
+    [
+      { $unwind: "$senses" },
+      { $unwind: "$senses.SemanticDomains" },
+      { $count: "n" },
+    ],
+    { allowDiskUse: true }
+  )
+  .toArray();
+var expectedTotal = expected.length > 0 ? expected[0].n : 0;
+
+var actualTotal = 0;
+counts.find({}, { count: 1 }).forEach(function (d) {
+  actualTotal += d.count;
+});
+
+if (actualTotal === expectedTotal) {
+  print(
+    "Verification passed: " + actualTotal + " occurrence(s) across " + docs.length + " (project, domain) pair(s)."
+  );
+} else {
+  print("WARNING: counted " + actualTotal + " occurrence(s) but Frontier has " + expectedTotal + ".");
+}


### PR DESCRIPTION
Redo of #4065 that keeps the cached counts atomically in sync with the Frontier by leveraging the MongoDB transactions added in #4198 (which post-dated #4065).

## What

Adds a `ProjectSemanticDomainCount` collection caching, per (project, semantic domain), the number of Frontier sense-occurrences of that domain. `StatisticsService.GetSemanticDomainCounts` and the `GetDomainWordCount` endpoint now read from this cache instead of scanning the Frontier.

## How this differs from #4065

#4065 maintained the counts in a separate service invoked from `WordService`, with the count write happening outside the word write's transaction (transactions did not exist when it was written). This version pushes count maintenance **into `WordRepository`'s existing `*WithSession` transaction helpers**, so each count delta commits or rolls back atomically with the word write that caused it:

- increment on create/restore, decrement on delete/update;
- `ReplaceFrontier` / `RevertReplaceFrontier` inherit correct counts by composing those primitives;
- `DeleteAllFrontierWords` now runs in a transaction that also clears the project's counts.

Because the repository owns the counts, this drops most of #4065's churn: there is no `SemanticDomainCountService`, and no changes to `WordService`, `LiftService` / `LiftMerger`, or `MergeService` (imports and merges already flow through the repository transactions).

## Backfill

`database/backfill-semantic-domain-counts.js` (idempotent) populates the collection for existing projects from the current Frontier and creates the unique `(projectId, domainId)` index. This is not a breaking schema change — see the script header for deployment notes.

## Testing

- New `SemanticDomainCountRepository` integration tests and new `WordRepository` tests covering every count path, including a **rollback test** proving an aborted transaction leaves the counts unchanged.
- Full backend suite: **1189 passed / 0 failed**.
- OpenAPI: no generated-client change — the `GetDomainWordCount` signature, route, and return type are unchanged; only its summary text differs, which the generator does not emit.

## Coordination with #4328

This branch was cut from `master` before #4328 and overlaps it on test infrastructure:

- #4328 introduces `Backend.Tests/Repositories/MongoDbSetUpFixture.cs` (a shared single-replica-set fixture) and refactors `WordRepositoryTests` onto it. This PR independently adds a **byte-identical** `MongoDbSetUpFixture.cs` and the same `WordRepositoryTests` refactor, so whichever PR merges second will conflict on those two files. When #4328 lands first, I'll rebase, drop the duplicate fixture, and keep only the incremental `WordRepositoryTests` changes (count assertions + the new repository ctor arg).
- The `MongoDbTestRunner` change here (waiting for `hello.isWritablePrimary`) is **not** in #4328 and remains necessary: this PR's repository constructor creates its index in test `[SetUp]`, which races the primary-election window; #4328's fixtures don't write in setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4340)
<!-- Reviewable:end -->
