### PR TITLE
Prep backend for .NET 10: replace obsolete hosting/crypto APIs

### DIFF
--- a/Backend/Helper/PasswordHash.cs
+++ b/Backend/Helper/PasswordHash.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Security.Cryptography;
+using System.Text;
 using static System.Linq.Enumerable;
 
 namespace BackendFramework.Helper
@@ -65,8 +66,8 @@ namespace BackendFramework.Helper
         private static byte[] HashPassword(string password, byte[] salt)
         {
             // SHA256 is the recommended PBKDF2 hash algorithm.
-            using var pbkdf2 = new Rfc2898DeriveBytes(password, salt, HashIterations, HashAlgorithmName.SHA256);
-            return pbkdf2.GetBytes(HashLength);
+            return Rfc2898DeriveBytes.Pbkdf2(
+                Encoding.UTF8.GetBytes(password), salt, HashIterations, HashAlgorithmName.SHA256, HashLength);
         }
 
         /// <summary> Create cryptographically-secure randomized salt. </summary>

--- a/Backend/Program.cs
+++ b/Backend/Program.cs
@@ -1,7 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace BackendFramework
 {
@@ -11,34 +9,11 @@ namespace BackendFramework
         public static void Main(string[] args)
         {
             var builder = WebApplication.CreateBuilder(args);
-
-            WebApplication app;
-            using (var startupServices = CreateStartupServiceProvider(builder.Services))
-            {
-                var startup = new Startup(
-                    startupServices.GetRequiredService<ILoggerFactory>().CreateLogger<Startup>(),
-                    builder.Configuration);
-                startup.ConfigureServices(builder.Services);
-
-                app = builder.Build();
-                startup.Configure(app, app.Environment, app.Lifetime);
-            }
-
+            var startup = new Startup(builder.Configuration);
+            startup.ConfigureServices(builder.Services);
+            var app = builder.Build();
+            startup.Configure(app, app.Environment, app.Lifetime);
             app.Run();
-        }
-
-        /// <summary>
-        /// Build a service provider from a copy of <paramref name="services"/>, so that <see cref="Startup"/>'s
-        /// bootstrap logger shares the same providers as the app. The caller must dispose the returned provider.
-        /// </summary>
-        private static ServiceProvider CreateStartupServiceProvider(IServiceCollection services)
-        {
-            IServiceCollection startupServices = new ServiceCollection();
-            foreach (ServiceDescriptor service in services)
-            {
-                startupServices.Add(service);
-            }
-            return startupServices.BuildServiceProvider();
         }
     }
 }

--- a/Backend/Program.cs
+++ b/Backend/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace BackendFramework
@@ -11,14 +12,27 @@ namespace BackendFramework
         {
             var builder = WebApplication.CreateBuilder(args);
 
-            using var startupLoggerFactory = LoggerFactory.Create(logging =>
-                logging.AddConfiguration(builder.Configuration.GetSection("Logging")).AddConsole());
+            using var startupLoggerFactory = CreateStartupLoggerFactory(builder.Services);
             var startup = new Startup(startupLoggerFactory.CreateLogger<Startup>(), builder.Configuration);
             startup.ConfigureServices(builder.Services);
 
             var app = builder.Build();
             startup.Configure(app, app.Environment, app.Lifetime);
             app.Run();
+        }
+
+        /// <summary>
+        /// Build a logger factory from a copy of <paramref name="services"/>, so that <see cref="Startup"/> logs
+        /// through the same providers as the app, before the real provider is built.
+        /// </summary>
+        private static ILoggerFactory CreateStartupLoggerFactory(IServiceCollection services)
+        {
+            IServiceCollection startupLoggingServices = new ServiceCollection();
+            foreach (ServiceDescriptor service in services)
+            {
+                startupLoggingServices.Add(service);
+            }
+            return startupLoggingServices.BuildServiceProvider().GetRequiredService<ILoggerFactory>();
         }
     }
 }

--- a/Backend/Program.cs
+++ b/Backend/Program.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using Microsoft.AspNetCore;
-using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
 
 namespace BackendFramework
 {
@@ -9,11 +9,16 @@ namespace BackendFramework
     {
         public static void Main(string[] args)
         {
-            CreateWebHostBuilder(args).Build().Run();
-        }
+            var builder = WebApplication.CreateBuilder(args);
 
-        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>();
+            using var startupLoggerFactory = LoggerFactory.Create(logging =>
+                logging.AddConfiguration(builder.Configuration.GetSection("Logging")).AddConsole());
+            var startup = new Startup(startupLoggerFactory.CreateLogger<Startup>(), builder.Configuration);
+            startup.ConfigureServices(builder.Services);
+
+            var app = builder.Build();
+            startup.Configure(app, app.Environment, app.Lifetime);
+            app.Run();
+        }
     }
 }

--- a/Backend/Program.cs
+++ b/Backend/Program.cs
@@ -12,27 +12,33 @@ namespace BackendFramework
         {
             var builder = WebApplication.CreateBuilder(args);
 
-            using var startupLoggerFactory = CreateStartupLoggerFactory(builder.Services);
-            var startup = new Startup(startupLoggerFactory.CreateLogger<Startup>(), builder.Configuration);
-            startup.ConfigureServices(builder.Services);
+            WebApplication app;
+            using (var startupServices = CreateStartupServiceProvider(builder.Services))
+            {
+                var startup = new Startup(
+                    startupServices.GetRequiredService<ILoggerFactory>().CreateLogger<Startup>(),
+                    builder.Configuration);
+                startup.ConfigureServices(builder.Services);
 
-            var app = builder.Build();
-            startup.Configure(app, app.Environment, app.Lifetime);
+                app = builder.Build();
+                startup.Configure(app, app.Environment, app.Lifetime);
+            }
+
             app.Run();
         }
 
         /// <summary>
-        /// Build a logger factory from a copy of <paramref name="services"/>, so that <see cref="Startup"/> logs
-        /// through the same providers as the app, before the real provider is built.
+        /// Build a service provider from a copy of <paramref name="services"/>, so that <see cref="Startup"/>'s
+        /// bootstrap logger shares the same providers as the app. The caller must dispose the returned provider.
         /// </summary>
-        private static ILoggerFactory CreateStartupLoggerFactory(IServiceCollection services)
+        private static ServiceProvider CreateStartupServiceProvider(IServiceCollection services)
         {
-            IServiceCollection startupLoggingServices = new ServiceCollection();
+            IServiceCollection startupServices = new ServiceCollection();
             foreach (ServiceDescriptor service in services)
             {
-                startupLoggingServices.Add(service);
+                startupServices.Add(service);
             }
-            return startupLoggingServices.BuildServiceProvider().GetRequiredService<ILoggerFactory>();
+            return startupServices.BuildServiceProvider();
         }
     }
 }

--- a/Backend/Startup.cs
+++ b/Backend/Startup.cs
@@ -22,11 +22,9 @@ using static System.Text.Encoding;
 namespace BackendFramework
 {
     [ExcludeFromCodeCoverage]
-    public class Startup(ILogger<Startup> logger, IConfiguration configuration)
+    public class Startup(IConfiguration configuration)
     {
         private const string LocalhostCorsPolicy = "LocalhostCorsPolicy";
-
-        private readonly ILogger<Startup> _logger = logger;
 
         private IConfiguration Configuration { get; } = configuration;
 
@@ -58,8 +56,8 @@ namespace BackendFramework
 
         private sealed class EnvironmentNotConfiguredException : Exception { }
 
-        private string? CheckedEnvironmentVariable(
-            string name, string? defaultValue, string error = "", bool info = false)
+        private static string? CheckedEnvironmentVariable(
+            ILogger<Startup> logger, string name, string? defaultValue, string error = "", bool info = false)
         {
             var contents = Environment.GetEnvironmentVariable(name);
             if (contents is not null)
@@ -69,22 +67,23 @@ namespace BackendFramework
 
             if (info)
             {
-                _logger.LogInformation("Environment variable: {Name} is not defined. {Error}", name, error);
+                logger.LogInformation("Environment variable: {Name} is not defined. {Error}", name, error);
             }
             else
             {
-                _logger.LogError("Environment variable: {Name} is not defined. {Error}", name, error);
+                logger.LogError("Environment variable: {Name} is not defined. {Error}", name, error);
             }
             return defaultValue;
         }
 
-        private int CheckedEnvironmentVariablePositiveInt(string name, int defaultValue)
+        private static int CheckedEnvironmentVariablePositiveInt(
+            ILogger<Startup> logger, string name, int defaultValue)
         {
             var info = $"Using default value: {defaultValue}";
-            var strContents = CheckedEnvironmentVariable(name, defaultValue.ToString(), info, true);
+            var strContents = CheckedEnvironmentVariable(logger, name, defaultValue.ToString(), info, true);
             if (!int.TryParse(strContents, out var intContents) || intContents <= 0)
             {
-                _logger.LogInformation(
+                logger.LogInformation(
                     "Environment variable: {Name} failed to parse as a positive int. {Info}", name, info);
                 return defaultValue;
             }
@@ -127,8 +126,9 @@ namespace BackendFramework
             const int minKeyLength = 256 / 8;
             if (secretKey is null || secretKey.Length < minKeyLength)
             {
-                _logger.LogError("Must set {EnvName} environment variable to string of length {MinLength} or longer.",
-                    secretKeyEnvName, minKeyLength);
+                // The logging pipeline isn't available until the app is built, so write straight to stderr.
+                Console.Error.WriteLine(
+                    $"Must set {secretKeyEnvName} environment variable to string of length {minKeyLength} or longer.");
                 throw new EnvironmentNotConfiguredException();
             }
 
@@ -164,8 +164,8 @@ namespace BackendFramework
             // https://docs.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-swashbuckle
             services.AddSwaggerGen();
 
-            services.Configure<Settings>(
-                options =>
+            services.AddOptions<Settings>().Configure<ILogger<Startup>>(
+                (options, logger) =>
                 {
                     var connectionStringKey = IsInContainer() ? "ContainerConnectionString" : "ConnectionString";
                     options.ConnectionString = Configuration[$"MongoDB:{connectionStringKey}"]
@@ -174,16 +174,19 @@ namespace BackendFramework
                         ?? throw new EnvironmentNotConfiguredException();
 
                     options.CaptchaEnabled = bool.Parse(CheckedEnvironmentVariable(
+                        logger,
                         "COMBINE_CAPTCHA_REQUIRED",
                         "true",
                         "CAPTCHA should be explicitly required or not required.")!);
                     if (options.CaptchaEnabled)
                     {
                         options.CaptchaSecretKey = CheckedEnvironmentVariable(
+                            logger,
                             "COMBINE_CAPTCHA_SECRET_KEY",
                             null,
                             "CAPTCHA secret key required.");
                         options.CaptchaVerifyUrl = CheckedEnvironmentVariable(
+                            logger,
                             "COMBINE_CAPTCHA_VERIFY_URL",
                             null,
                             "CAPTCHA verification URL required.");
@@ -191,6 +194,7 @@ namespace BackendFramework
 
                     const string emailServiceFailureMessage = "Email services will not work.";
                     options.EmailEnabled = bool.Parse(CheckedEnvironmentVariable(
+                        logger,
                         "COMBINE_EMAIL_ENABLED",
                         "false",
                         emailServiceFailureMessage,
@@ -198,32 +202,44 @@ namespace BackendFramework
                     if (options.EmailEnabled)
                     {
                         options.ExpireTimeEmailVerify = TimeSpan.FromMinutes(CheckedEnvironmentVariablePositiveInt(
-                            "COMBINE_EXPIRE_EMAIL_VERIFY_MINUTES", Settings.DefaultExpireEmailVerifyMinutes));
+                            logger,
+                            "COMBINE_EXPIRE_EMAIL_VERIFY_MINUTES",
+                            Settings.DefaultExpireEmailVerifyMinutes));
                         options.ExpireTimePasswordReset = TimeSpan.FromMinutes(CheckedEnvironmentVariablePositiveInt(
-                            "COMBINE_EXPIRE_PASSWORD_RESET_MINUTES", Settings.DefaultExpirePasswordResetMinutes));
+                            logger,
+                            "COMBINE_EXPIRE_PASSWORD_RESET_MINUTES",
+                            Settings.DefaultExpirePasswordResetMinutes));
                         options.ExpireTimeProjectInvite = TimeSpan.FromDays(CheckedEnvironmentVariablePositiveInt(
-                            "COMBINE_EXPIRE_PROJECT_INVITE_DAYS", Settings.DefaultExpireProjectInviteDays));
+                            logger,
+                            "COMBINE_EXPIRE_PROJECT_INVITE_DAYS",
+                            Settings.DefaultExpireProjectInviteDays));
                         options.SmtpServer = CheckedEnvironmentVariable(
+                            logger,
                             "COMBINE_SMTP_SERVER",
                             null,
                             emailServiceFailureMessage);
                         options.SmtpPort = int.Parse(CheckedEnvironmentVariable(
+                            logger,
                             "COMBINE_SMTP_PORT",
                             IEmailContext.InvalidPort.ToString(),
                             emailServiceFailureMessage)!);
                         options.SmtpUsername = CheckedEnvironmentVariable(
+                            logger,
                             "COMBINE_SMTP_USERNAME",
                             null,
                             emailServiceFailureMessage);
                         options.SmtpPassword = CheckedEnvironmentVariable(
+                            logger,
                             "COMBINE_SMTP_PASSWORD",
                             null,
                             emailServiceFailureMessage);
                         options.SmtpAddress = CheckedEnvironmentVariable(
+                            logger,
                             "COMBINE_SMTP_ADDRESS",
                             null,
                             emailServiceFailureMessage);
                         options.SmtpFrom = CheckedEnvironmentVariable(
+                            logger,
                             "COMBINE_SMTP_FROM",
                             null,
                             emailServiceFailureMessage);
@@ -350,11 +366,12 @@ namespace BackendFramework
 
             // If an admin user has been created via the command line, treat that as a single action and shut the
             // server down so the calling script knows it's been completed successfully or unsuccessfully.
+            var logger = app.ApplicationServices.GetRequiredService<ILogger<Startup>>();
             using var startupScope = app.ApplicationServices.CreateScope();
             var userRepo = startupScope.ServiceProvider.GetService<IUserRepository>();
-            if (userRepo is not null && CreateAdminUser(userRepo))
+            if (userRepo is not null && CreateAdminUser(userRepo, logger))
             {
-                _logger.LogInformation("Stopping application");
+                logger.LogInformation("Stopping application");
                 appLifetime.StopApplication();
             }
         }
@@ -370,7 +387,7 @@ namespace BackendFramework
         /// <exception cref="AdminUserCreationException">
         /// If the requested admin user could not be created or updated.
         /// </exception>
-        private bool CreateAdminUser(IUserRepository userRepo)
+        private bool CreateAdminUser(IUserRepository userRepo, ILogger<Startup> logger)
         {
             const string createAdminUsernameArg = "create-admin-username";
             const string createAdminPasswordEnv = "COMBINE_ADMIN_PASSWORD";
@@ -379,53 +396,53 @@ namespace BackendFramework
             var username = Configuration.GetValue<string>(createAdminUsernameArg);
             if (username is null)
             {
-                _logger.LogInformation("No admin user name provided, skipped admin creation");
+                logger.LogInformation("No admin user name provided, skipped admin creation");
                 return false;
             }
 
             var password = Environment.GetEnvironmentVariable(createAdminPasswordEnv);
             if (password is null)
             {
-                _logger.LogError($"Must set {createAdminPasswordEnv} environment variable " +
-                                 $"when using {createAdminUsernameArg} command line option.");
+                logger.LogError($"Must set {createAdminPasswordEnv} environment variable " +
+                                $"when using {createAdminUsernameArg} command line option.");
                 throw new EnvironmentNotConfiguredException();
             }
 
             var adminEmail = Environment.GetEnvironmentVariable(createAdminEmailEnv);
             if (adminEmail is null)
             {
-                _logger.LogError($"Must set {createAdminEmailEnv} environment variable " +
-                                 $"when using {createAdminUsernameArg} command line option.");
+                logger.LogError($"Must set {createAdminEmailEnv} environment variable " +
+                                $"when using {createAdminUsernameArg} command line option.");
                 throw new EnvironmentNotConfiguredException();
             }
 
             var existingUser = userRepo.GetAllUsers().Result.Find(x => x.Username == username);
             if (existingUser is not null)
             {
-                _logger.LogInformation(
+                logger.LogInformation(
                     "User {User} already exists. Updating password and granting admin permissions.", username);
                 if (userRepo.ChangePassword(existingUser.Id, password).Result == ResultOfUpdate.NotFound)
                 {
-                    _logger.LogError("Failed to find user {User}.", username);
+                    logger.LogError("Failed to find user {User}.", username);
                     throw new AdminUserCreationException();
                 }
 
                 existingUser.IsAdmin = true;
                 if (userRepo.Update(existingUser.Id, existingUser, true).Result == ResultOfUpdate.NotFound)
                 {
-                    _logger.LogError("Failed to find user {User}.", username);
+                    logger.LogError("Failed to find user {User}.", username);
                     throw new AdminUserCreationException();
                 }
 
                 return true;
             }
 
-            _logger.LogInformation("Creating admin user: {User} ({Email}).", username, adminEmail);
+            logger.LogInformation("Creating admin user: {User} ({Email}).", username, adminEmail);
             var user = new User { Username = username, Password = password, Email = adminEmail, IsAdmin = true };
             var returnedUser = userRepo.Create(user).Result;
             if (returnedUser is null)
             {
-                _logger.LogError("Failed to create admin user {User} ({Email}).", username, adminEmail);
+                logger.LogError("Failed to create admin user {User} ({Email}).", username, adminEmail);
                 throw new AdminUserCreationException();
             }
 


### PR DESCRIPTION
## Summary

Prep work toward #4254 (Update .NET from 8 to 10). Replaces two APIs that are already obsolete-marked as of
.NET 9/10 and would fail the build outright once the TargetFramework is bumped, since the project builds with
`TreatWarningsAsErrors=true`. Neither replacement requires .NET 10, so landing them separately shrinks the scope of
the eventual TFM-bump PR.

No behavior changes: same password hashes, same service registrations, same middleware pipeline, same log messages.

## `Backend/Helper/PasswordHash.cs` — `SYSLIB0060`

The `Rfc2898DeriveBytes` constructor is obsolete. Replaced with the static `Rfc2898DeriveBytes.Pbkdf2(...)` method,
passing the password as UTF-8 bytes. The old constructor also used UTF-8 internally, so existing stored hashes
continue to validate.

## `Backend/Program.cs` — `ASPDEPR008`

`WebHost.CreateDefaultBuilder(...).UseStartup<Startup>()` is obsolete. `Main` now uses `WebApplicationBuilder`
minimal hosting and invokes `Startup`'s two methods directly:

```csharp
var builder = WebApplication.CreateBuilder(args);
var startup = new Startup(builder.Configuration);
startup.ConfigureServices(builder.Services);
var app = builder.Build();
startup.Configure(app, app.Environment, app.Lifetime);
app.Run();
```

`CreateWebHostBuilder` is removed; it had no other callers.

## `Backend/Startup.cs`

The old hosting model injected `ILogger<Startup>` into `Startup`'s constructor, resolving it from the host's
internal service provider. Minimal hosting has no equivalent provider, and one can't be conjured before
`builder.Build()` without building a throwaway container. Rather than do that, each logger use now gets the real
application logger at the point where one is actually available:

- **Constructor** takes only `IConfiguration`; the `_logger` field is gone.
- **`Settings` configuration** (the only pre-`Build()` code path that logs) moves from
  `services.Configure<Settings>(options => ...)` to
  `services.AddOptions<Settings>().Configure<ILogger<Startup>>((options, logger) => ...)`. The callback already ran
  lazily — on first `IOptions<Startup.Settings>` resolution, after the app is built — so this only changes where its
  logger comes from. `CheckedEnvironmentVariable` and `CheckedEnvironmentVariablePositiveInt` are now `static` and
  take the logger as a parameter.
- **`Configure(...)`** resolves `ILogger<Startup>` from `app.ApplicationServices` and passes it to
  `CreateAdminUser`.
- **The JWT secret key check** is the one message emitted during `ConfigureServices`, where no logging pipeline
  exists yet. It writes to stderr and then throws, as before.

Every consumer of `Startup.Settings` injects `IOptions<Startup.Settings>` (singleton), not `IOptionsSnapshot` or
`IOptionsMonitor`, so the configure callback still runs exactly once and the environment-variable warnings are not
repeated per scope.

## Verification

- `dotnet build` — clean, 0 warnings.
- `dotnet test` — 1175 passed.
- `npm run fmt-backend-check` — clean.
- Manual run: the environment-variable messages and `No admin user name provided, skipped admin creation` appear as
  `BackendFramework.Startup` records through the application's logging pipeline; unsetting `COMBINE_JWT_SECRET_KEY`
  prints the stderr message before the exception. Neither path is covered by unit tests.

Created by Claude Sonnet 5 and Claude Opus 5

---

Devin: https://app.devin.ai/review/sillsdev/TheCombine/pull/4347

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4347)
<!-- Reviewable:end -->
