### PR TITLE
Raise memory limit for the cert update jobs

### DIFF
--- a/deploy/helm/cert-proxy-client/templates/update-cert-cronjob.yaml
+++ b/deploy/helm/cert-proxy-client/templates/update-cert-cronjob.yaml
@@ -75,9 +75,9 @@ spec:
                       name: {{ .Values.envName | quote }}
               resources:
                 requests:
-                  memory: 128Mi
+                  memory: {{ .Values.memoryRequest }}
                 limits:
-                  memory: 128Mi
+                  memory: {{ .Values.memoryLimit }}
               securityContext:
                 capabilities: {}
               terminationMessagePath: /dev/termination-log

--- a/deploy/helm/cert-proxy-client/templates/update-cert-oneshot.yaml
+++ b/deploy/helm/cert-proxy-client/templates/update-cert-oneshot.yaml
@@ -9,6 +9,10 @@ metadata:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
+  # A failure of this hook aborts the install, and Helm reports it as a timeout
+  # rather than a failure for as long as the Job keeps retrying. Keep the
+  # retries few so that the real error is what the installer shows.
+  backoffLimit: 3
   ttlSecondsAfterFinished: 300
   template:
     metadata:

--- a/deploy/helm/cert-proxy-client/templates/update-cert-oneshot.yaml
+++ b/deploy/helm/cert-proxy-client/templates/update-cert-oneshot.yaml
@@ -74,9 +74,9 @@ spec:
               name: {{ .Values.envName  | quote }}
         resources:
           requests:
-            memory: 128Mi
+            memory: {{ .Values.memoryRequest }}
           limits:
-            memory: 128Mi
+            memory: {{ .Values.memoryLimit }}
         securityContext:
           capabilities: {}
         terminationMessagePath: /dev/termination-log

--- a/deploy/helm/cert-proxy-client/values.yaml
+++ b/deploy/helm/cert-proxy-client/values.yaml
@@ -31,6 +31,11 @@ certRenewBefore: "60"
 imageName: combine_maint
 envName: env-cert-proxy
 
+# update_cert.py runs in its own pod, where it loads the Kubernetes client
+# library and then invokes the AWS CLI as a subprocess.
+memoryRequest: 256Mi
+memoryLimit: 1Gi
+
 # Run once a minute.  If the cert is not up for renewal, The Combine
 # will not try to reach AWS S3
 schedule: "* * * * *"

--- a/deploy/helm/cert-proxy-server/templates/deployment-cert-proxy-server.yaml
+++ b/deploy/helm/cert-proxy-server/templates/deployment-cert-proxy-server.yaml
@@ -66,9 +66,9 @@ spec:
           resources:
             requests:
               cpu:  2m
-              memory: 128Mi
+              memory: {{ .Values.memoryRequest }}
             limits:
-              memory: 128Mi
+              memory: {{ .Values.memoryLimit }}
       restartPolicy: Always
 {{- if ne .Values.global.pullSecretName "None" }}
       imagePullSecrets:

--- a/deploy/helm/cert-proxy-server/values.yaml
+++ b/deploy/helm/cert-proxy-server/values.yaml
@@ -57,3 +57,8 @@ awsS3CertLoc: certs
 certIssuer: letsencrypt-prod
 # Renew before there are 1440 hours left (60 days)
 certRenewBefore: 1440h
+
+# monitor.py loads the Kubernetes client library and then invokes the AWS CLI
+# as a subprocess.
+memoryRequest: 256Mi
+memoryLimit: 1Gi


### PR DESCRIPTION
`update_cert.py` runs in its own pod, where it imports the Kubernetes client library and then invokes the AWS CLI as a subprocess. Both together need far more than the 128Mi limit these pods were given, so every pod was OOMKilled.

For `update-cert-oneshot` that failed the install: as a post-install hook, the Job has to complete before Helm returns, and with the default `backoffLimit` of 6 it spent roughly 11 minutes being OOMKilled and restarted, so Helm reported the wait as a timeout no matter how large a `--timeout` was given:

```text
Error: failed post-install: resource Job/thecombine/update-cert-oneshot not ready. status: InProgress, message: Job in progress
context deadline exceeded
```

For `update-cert-cronjob` it meant the certificate was never actually renewed on desktop or NUC installs.

## Changes

- `cert-proxy-client`: the memory request and limit for both the oneshot Job and the cronjob now come from new `memoryRequest` (256Mi) and `memoryLimit` (1Gi) values.
- `cert-proxy-server`: the same for its deployment. `monitor.py` uses the same Kubernetes client plus AWS CLI combination as `update_cert.py`, so it carried the same exposure.
- `update-cert-oneshot`: `backoffLimit: 3`. A failure of this hook blocks the install, and Helm reports the wait as a timeout for as long as the Job keeps retrying, so few retries means the real error is what the installer shows. Three attempts take well under a minute.

## Where 128Mi is left alone

- The jobs in the `maintenance` chart only run `kubectl exec`; the Python runs in the maintenance deployment, which is allotted 1Gi/2Gi.
- The other 128Mi pods in `cert-proxy-server` run nginx or an init-container file copy.
- `aws-login`'s job and cronjob do invoke the AWS CLI, but without the Kubernetes client library, and they work in production today.
- The cronjob keeps the default `backoffLimit`. Nothing waits on it, and with the memory fix each run completes in seconds instead of stacking doomed retries against a once-per-minute schedule.

## Testing

- `helm template` renders the expected values for `cert-proxy-client` and `cert-proxy-server`.
- The OOMKilled pods were observed on a desktop install (7 pods, matching one attempt plus the default 6 retries). A desktop install has **not** yet been re-run against these charts, and the `cert-proxy-server` change has not been exercised on the production cluster.

---

Devin review: https://app.devin.ai/review/sillsdev/TheCombine/pull/4350

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable memory requests and limits for certificate update jobs.
  * Set default memory resources to 256Mi requested and 1Gi maximum.
  * Applied the settings consistently to scheduled and one-time certificate update tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4350)
<!-- Reviewable:end -->
