### PR TITLE
Make the installer timeout option work as documented

### DIFF
--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -315,9 +315,7 @@ if [ "${STATE}" != "Uninstall-combine" ] ; then
     if [ -f ${TIMEOUT_FILE} ] ; then
       ERROR_HINT="Delete ${TIMEOUT_FILE} or install with the clean option."
       HELM_TIMEOUT=`cat ${TIMEOUT_FILE}` || error "Cannot read ${TIMEOUT_FILE}."
-      if [ -n "${HELM_TIMEOUT}" ] ; then
-        check-opt-value timeout "${HELM_TIMEOUT}"
-      fi
+      check-opt-value timeout "${HELM_TIMEOUT}"
       ERROR_HINT=""
     fi
   else

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -176,8 +176,9 @@ wait-for-combine () {
 next-state () {
   STATE=$1
   if [[ "${STATE}" == "Done" ]] ; then
-    # The recorded timeout applies to the install in progress, so it is
-    # discarded along with the state once that install is finished.
+    # A finished install has no more helm commands to run, so the recorded
+    # timeout is discarded along with the state. "restart" keeps it, since it
+    # resets how far the install got, while "clean" discards saved settings.
     rm -f ${STATE_FILE} ${TIMEOUT_FILE}
   else
     echo -n ${STATE} > ${STATE_FILE}
@@ -204,6 +205,9 @@ mkdir -p ${CONFIG_DIR}
 SINGLE_STEP=0
 IS_SERVER=0
 DEBUG=0
+# Only a timeout given as an option is checked for a valid format, so ignore any
+# value that happens to be set in the environment.
+HELM_TIMEOUT=""
 
 # See if we need to continue from a previous install
 STATE_FILE=${CONFIG_DIR}/install-state

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -21,6 +21,10 @@ warning () {
 }
 error () {
   echo "ERROR: $1" >&2
+  # Set ERROR_HINT where an error has a remedy that the message cannot assume
+  if [ -n "${ERROR_HINT}" ] ; then
+    echo "  ${ERROR_HINT}" >&2
+  fi
   exit 1
 }
 
@@ -184,17 +188,16 @@ next-state () {
   fi
 }
 
-# Check the value ($2) given to an option ($1); $3 names where the value came
-# from when it was not typed on the command line. Every value is checked before
-# any option is applied, since applying one can record a new state.
+# Check the value ($2) given to an option ($1). Every value is checked before any
+# option is applied, since applying one can record a new state.
 check-opt-value () {
   case $1 in
     timeout)
       if [[ ! $2 =~ ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$ ]] ; then
-        error "Invalid timeout, '$2'$3; see https://pkg.go.dev/time#ParseDuration for the format."
+        error "Invalid timeout, '$2'; see https://pkg.go.dev/time#ParseDuration for the format."
       fi
       if [[ $2 =~ ^(0+(\.0+)?(ns|us|µs|ms|s|m|h))+$ ]] ; then
-        error "Invalid timeout, '$2'$3; the timeout must be greater than zero."
+        error "Invalid timeout, '$2'; the timeout must be greater than zero."
       fi
       ;;
     v*)
@@ -225,6 +228,7 @@ mkdir -p ${CONFIG_DIR}
 SINGLE_STEP=0
 IS_SERVER=0
 DEBUG=0
+ERROR_HINT=""
 # Only a timeout given as an option is checked for a valid format, so ignore any
 # value that happens to be set in the environment.
 HELM_TIMEOUT=""
@@ -302,11 +306,12 @@ if [ "${STATE}" != "Uninstall-combine" ] ; then
   # requires, so record a timeout and reuse it until the install finishes.
   if [ -z "${HELM_TIMEOUT}" ] ; then
     if [ -f ${TIMEOUT_FILE} ] ; then
+      ERROR_HINT="Delete ${TIMEOUT_FILE} or install with the clean option."
       HELM_TIMEOUT=`cat ${TIMEOUT_FILE}` || error "Cannot read ${TIMEOUT_FILE}."
       if [ -n "${HELM_TIMEOUT}" ] ; then
-        # The file may have been edited or damaged since this script wrote it.
-        check-opt-value timeout "${HELM_TIMEOUT}" " recorded in ${TIMEOUT_FILE}"
+        check-opt-value timeout "${HELM_TIMEOUT}"
       fi
+      ERROR_HINT=""
     fi
   else
     echo -n ${HELM_TIMEOUT} > ${TIMEOUT_FILE}

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -176,10 +176,11 @@ wait-for-combine () {
 next-state () {
   STATE=$1
   if [[ "${STATE}" == "Done" ]] ; then
-    # The recorded timeout lasts as long as the state does: reaching "Done", by
-    # finishing either an install or an uninstall, discards both. "restart"
-    # keeps the timeout, since it resets how far the install got, while "clean"
-    # discards saved settings.
+    # Reaching "Done", by finishing either an install or an uninstall, discards
+    # the recorded timeout along with the state. Only "clean" discards it
+    # otherwise: it deliberately survives an install that failed or was
+    # interrupted, including one restarted with "restart", so that the value
+    # does not have to be entered again.
     rm -f ${STATE_FILE} ${TIMEOUT_FILE}
   else
     echo -n ${STATE} > ${STATE_FILE}

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -175,8 +175,10 @@ wait-for-combine () {
 # Set the next value for STATE and record it in the STATE_FILE
 next-state () {
   STATE=$1
-  if [[ "${STATE}" == "Done" && -f "${STATE_FILE}" ]] ; then
-    rm ${STATE_FILE}
+  if [[ "${STATE}" == "Done" ]] ; then
+    # The recorded timeout applies to the install in progress, so it is
+    # discarded along with the state once that install is finished.
+    rm -f ${STATE_FILE} ${TIMEOUT_FILE}
   else
     echo -n ${STATE} > ${STATE_FILE}
   fi
@@ -205,6 +207,7 @@ DEBUG=0
 
 # See if we need to continue from a previous install
 STATE_FILE=${CONFIG_DIR}/install-state
+TIMEOUT_FILE=${CONFIG_DIR}/install-timeout
 if [ -f ${STATE_FILE} ] ; then
   STATE=`cat ${STATE_FILE}`
 else
@@ -220,6 +223,7 @@ while (( "$#" )) ; do
       if [ -f ${CONFIG_DIR}/env ] ; then
         rm ${CONFIG_DIR}/env
       fi
+      rm -f ${TIMEOUT_FILE}
       ;;
     debug)
       DEBUG=1
@@ -273,9 +277,21 @@ if [[ "${STATE}" != "Uninstall-combine" && -z "${COMBINE_VERSION}" ]] ; then
 fi
 
 # Set the Helm options here to apply for both a fresh and resumed install.
+# An install can span several invocations of this script, since every helm
+# command runs after the restart that the Pre-reqs step usually requires, so
+# record a timeout given on the command line and reuse it until the install
+# finishes. A timeout on the command line overrides one that was recorded.
+if [ -z "${HELM_TIMEOUT}" ] ; then
+  if [ -f ${TIMEOUT_FILE} ] ; then
+    HELM_TIMEOUT=`cat ${TIMEOUT_FILE}`
+  fi
+else
+  echo -n ${HELM_TIMEOUT} > ${TIMEOUT_FILE}
+fi
 if [ -z "${HELM_TIMEOUT}" ] ; then
   SETUP_OPTS=""
 else
+  echo "Using helm timeout: ${HELM_TIMEOUT}"
   SETUP_OPTS="--timeout ${HELM_TIMEOUT}"
 fi
 

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -124,11 +124,6 @@ install-base-charts () {
   cd ${DEPLOY_DIR}
   . venv/bin/activate
   cd ${DEPLOY_DIR}/scripts
-  if [ -z "${HELM_TIMEOUT}" ] ; then
-    SETUP_OPTS=""
-  else
-    SETUP_OPTS="--timeout ${HELM_TIMEOUT}"
-  fi
   if [ -d "${DEPLOY_DIR}/airgap-charts" ] ; then
     ./setup_cluster.py ${SETUP_OPTS} --chart-dir ${DEPLOY_DIR}/airgap-charts
   else
@@ -269,6 +264,13 @@ done
 # Check that we have a COMBINE_VERSION (not needed for uninstall)
 if [[ "${STATE}" != "Uninstall-combine" && -z "${COMBINE_VERSION}" ]] ; then
   error "Combine version is not specified."
+fi
+
+# Set the Helm options here to apply for both a fresh and resumed install.
+if [ -z "${HELM_TIMEOUT}" ] ; then
+  SETUP_OPTS=""
+else
+  SETUP_OPTS="--timeout ${HELM_TIMEOUT}"
 fi
 
 create-python-venv

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -186,6 +186,25 @@ next-state () {
   fi
 }
 
+# Check the value that an option was given, where $1 is the option and $2 is the
+# argument that follows it. Options are applied as they are parsed, and applying
+# one can record a new state for the install, so every value is checked first;
+# otherwise a typo would leave the install recorded as further along than it is.
+check-opt-value () {
+  case $1 in
+    timeout)
+      if [[ ! $2 =~ ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$ ]] ; then
+        error "Invalid timeout, '$2'; see https://pkg.go.dev/time#ParseDuration for the format."
+      fi
+      ;;
+    v*)
+      if [[ ! $1 =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9-]+\.[0-9]+)?$ ]] ; then
+        error "Invalid version number, $1"
+      fi
+      ;;
+  esac
+}
+
 # Verify that the required network devices have been setup for Kubernetes cluster
 wait-for-k8s-interfaces () {
   echo "Waiting for k8s interfaces: $@"
@@ -219,6 +238,12 @@ else
   STATE=Pre-reqs
 fi
 
+# Check every option value before any option is applied
+OPT_LIST=("$@")
+for OPT_INDEX in "${!OPT_LIST[@]}" ; do
+  check-opt-value "${OPT_LIST[OPT_INDEX]}" "${OPT_LIST[OPT_INDEX+1]}"
+done
+
 # Parse arguments to customize installation
 while (( "$#" )) ; do
   OPT=$1
@@ -247,12 +272,6 @@ while (( "$#" )) ; do
       shift
       ;;
     timeout)
-      # Without this check, a missing value shifts past the end of the argument
-      # list, which aborts the script with no explanation, and a non-duration
-      # value is not caught until helm rejects it several steps later.
-      if [[ ! $2 =~ ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$ ]] ; then
-        error "Invalid timeout, '$2'; see https://pkg.go.dev/time#ParseDuration for the format."
-      fi
       HELM_TIMEOUT=$2
       shift
       ;;
@@ -263,11 +282,7 @@ while (( "$#" )) ; do
       next-state "Install-combine"
       ;;
     v*)
-      if [[ $OPT =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9-]+\.[0-9]+)?$ ]] ; then
-        COMBINE_VERSION="$OPT"
-      else
-        error "Invalid version number, $OPT"
-      fi
+      COMBINE_VERSION="$OPT"
       ;;
     *)
       warning "Unrecognized option: $OPT"

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -302,7 +302,7 @@ if [ "${STATE}" != "Uninstall-combine" ] ; then
   # requires, so record a timeout and reuse it until the install finishes.
   if [ -z "${HELM_TIMEOUT}" ] ; then
     if [ -f ${TIMEOUT_FILE} ] ; then
-      HELM_TIMEOUT=`cat ${TIMEOUT_FILE}`
+      HELM_TIMEOUT=`cat ${TIMEOUT_FILE}` || error "Cannot read ${TIMEOUT_FILE}."
       if [ -n "${HELM_TIMEOUT}" ] ; then
         # The file may have been edited or damaged since this script wrote it.
         check-opt-value timeout "${HELM_TIMEOUT}" " recorded in ${TIMEOUT_FILE}"

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -176,26 +176,25 @@ wait-for-combine () {
 next-state () {
   STATE=$1
   if [[ "${STATE}" == "Done" ]] ; then
-    # Reaching "Done", by finishing either an install or an uninstall, discards
-    # the recorded timeout along with the state. Only "clean" discards it
-    # otherwise: it deliberately survives an install that failed or was
-    # interrupted, including one restarted with "restart", so that the value
-    # does not have to be entered again.
+    # A recorded timeout is discarded here and by "clean", but deliberately
+    # survives an install that failed or was restarted.
     rm -f ${STATE_FILE} ${TIMEOUT_FILE}
   else
     echo -n ${STATE} > ${STATE_FILE}
   fi
 }
 
-# Check the value that an option was given, where $1 is the option and $2 is the
-# argument that follows it. Options are applied as they are parsed, and applying
-# one can record a new state for the install, so every value is checked first;
-# otherwise a typo would leave the install recorded as further along than it is.
+# Check the value ($2) given to an option ($1); $3 names where the value came
+# from when it was not typed on the command line. Every value is checked before
+# any option is applied, since applying one can record a new state.
 check-opt-value () {
   case $1 in
     timeout)
       if [[ ! $2 =~ ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$ ]] ; then
-        error "Invalid timeout, '$2'; see https://pkg.go.dev/time#ParseDuration for the format."
+        error "Invalid timeout, '$2'$3; see https://pkg.go.dev/time#ParseDuration for the format."
+      fi
+      if [[ $2 =~ ^(0+(\.0+)?(ns|us|µs|ms|s|m|h))+$ ]] ; then
+        error "Invalid timeout, '$2'$3; the timeout must be greater than zero."
       fi
       ;;
     v*)
@@ -297,14 +296,15 @@ if [[ "${STATE}" != "Uninstall-combine" && -z "${COMBINE_VERSION}" ]] ; then
   error "Combine version is not specified."
 fi
 
-# Set the Helm options here to apply for both a fresh and resumed install.
-# An install can span several invocations of this script, since every helm
-# command runs after the restart that the Pre-reqs step usually requires, so
-# record a timeout given on the command line and reuse it until the install
-# finishes. A timeout on the command line overrides one that was recorded.
+# Every helm command runs after the restart that the Pre-reqs step usually
+# requires, so record a timeout and reuse it until the install finishes.
 if [ -z "${HELM_TIMEOUT}" ] ; then
   if [ -f ${TIMEOUT_FILE} ] ; then
     HELM_TIMEOUT=`cat ${TIMEOUT_FILE}`
+    if [ -n "${HELM_TIMEOUT}" ] ; then
+      # The file may have been edited or damaged since this script wrote it.
+      check-opt-value timeout "${HELM_TIMEOUT}" " recorded in ${TIMEOUT_FILE}"
+    fi
   fi
 else
   echo -n ${HELM_TIMEOUT} > ${TIMEOUT_FILE}

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -296,24 +296,25 @@ if [[ "${STATE}" != "Uninstall-combine" && -z "${COMBINE_VERSION}" ]] ; then
   error "Combine version is not specified."
 fi
 
-# Every helm command runs after the restart that the Pre-reqs step usually
-# requires, so record a timeout and reuse it until the install finishes.
-if [ -z "${HELM_TIMEOUT}" ] ; then
-  if [ -f ${TIMEOUT_FILE} ] ; then
-    HELM_TIMEOUT=`cat ${TIMEOUT_FILE}`
-    if [ -n "${HELM_TIMEOUT}" ] ; then
-      # The file may have been edited or damaged since this script wrote it.
-      check-opt-value timeout "${HELM_TIMEOUT}" " recorded in ${TIMEOUT_FILE}"
+SETUP_OPTS=""
+if [ "${STATE}" != "Uninstall-combine" ] ; then
+  # Every helm command runs after the restart that the Pre-reqs step usually
+  # requires, so record a timeout and reuse it until the install finishes.
+  if [ -z "${HELM_TIMEOUT}" ] ; then
+    if [ -f ${TIMEOUT_FILE} ] ; then
+      HELM_TIMEOUT=`cat ${TIMEOUT_FILE}`
+      if [ -n "${HELM_TIMEOUT}" ] ; then
+        # The file may have been edited or damaged since this script wrote it.
+        check-opt-value timeout "${HELM_TIMEOUT}" " recorded in ${TIMEOUT_FILE}"
+      fi
     fi
+  else
+    echo -n ${HELM_TIMEOUT} > ${TIMEOUT_FILE}
   fi
-else
-  echo -n ${HELM_TIMEOUT} > ${TIMEOUT_FILE}
-fi
-if [ -z "${HELM_TIMEOUT}" ] ; then
-  SETUP_OPTS=""
-else
-  echo "Helm timeout: ${HELM_TIMEOUT}"
-  SETUP_OPTS="--timeout ${HELM_TIMEOUT}"
+  if [ -n "${HELM_TIMEOUT}" ] ; then
+    echo "Helm timeout: ${HELM_TIMEOUT}"
+    SETUP_OPTS="--timeout ${HELM_TIMEOUT}"
+  fi
 fi
 
 create-python-venv

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -192,6 +192,11 @@ next-state () {
 # option is applied, since applying one can record a new state.
 check-opt-value () {
   case $1 in
+    start-at)
+      if [ -z "$2" ] ; then
+        error "The start-at option requires a step name."
+      fi
+      ;;
     timeout)
       if [[ ! $2 =~ ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$ ]] ; then
         error "Invalid timeout, '$2'; see https://pkg.go.dev/time#ParseDuration for the format."
@@ -206,6 +211,8 @@ check-opt-value () {
       fi
       ;;
   esac
+  # A failed test at the end would stop the script, so succeed explicitly
+  return 0
 }
 
 # Verify that the required network devices have been setup for Kubernetes cluster

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -238,6 +238,12 @@ while (( "$#" )) ; do
       shift
       ;;
     timeout)
+      # Without this check, a missing value shifts past the end of the argument
+      # list, which aborts the script with no explanation, and a non-duration
+      # value is not caught until helm rejects it several steps later.
+      if [[ ! $2 =~ ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$ ]] ; then
+        error "Invalid timeout, '$2'; see https://pkg.go.dev/time#ParseDuration for the format."
+      fi
       HELM_TIMEOUT=$2
       shift
       ;;

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -176,9 +176,10 @@ wait-for-combine () {
 next-state () {
   STATE=$1
   if [[ "${STATE}" == "Done" ]] ; then
-    # A finished install has no more helm commands to run, so the recorded
-    # timeout is discarded along with the state. "restart" keeps it, since it
-    # resets how far the install got, while "clean" discards saved settings.
+    # The recorded timeout lasts as long as the state does: reaching "Done", by
+    # finishing either an install or an uninstall, discards both. "restart"
+    # keeps the timeout, since it resets how far the install got, while "clean"
+    # discards saved settings.
     rm -f ${STATE_FILE} ${TIMEOUT_FILE}
   else
     echo -n ${STATE} > ${STATE_FILE}
@@ -295,7 +296,7 @@ fi
 if [ -z "${HELM_TIMEOUT}" ] ; then
   SETUP_OPTS=""
 else
-  echo "Using helm timeout: ${HELM_TIMEOUT}"
+  echo "Helm timeout: ${HELM_TIMEOUT}"
   SETUP_OPTS="--timeout ${HELM_TIMEOUT}"
 fi
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -162,7 +162,7 @@ To run `combine-installer.run` with options, the option list must be started wit
 | clean           | Remove the previously saved environment (AWS Access Key, admin user info) before performing the installation. |
 | restart         | Run the installation from the beginning; do not resume a previous installation. |
 | server          | Install _The Combine_ in a server environment so that _The Combine_ is always running by default. |
-| timeout TIMEOUT | Use a different timeout when installing. (Default: 5 minutes.) With slow internet, it is helpful to extend the timeout. See <https://pkg.go.dev/time#ParseDuration> for timeout formats. |
+| timeout TIMEOUT | Use a different timeout when installing. (Default: 5 minutes.) With slow internet, it is helpful to extend the timeout. See <https://pkg.go.dev/time#ParseDuration> for timeout formats. The value is used for the rest of the installation, including after a restart, so it does not need to be entered again. |
 | uninstall       | Remove software installed by this script. |
 | update          | Update _The Combine_ to the version number provided. This skips installing support software that was installed previously. |
 | version-number  | Specify a version to install instead of the current version. A version number will have the form `vn.n.n` where `n` represents an integer value, for example, `v1.20.0`. |

--- a/installer/README.md
+++ b/installer/README.md
@@ -159,7 +159,7 @@ To run `combine-installer.run` with options, the option list must be started wit
 
 | option          | description |
 | ---------------- | ---------------------------------------------------------------------------- |
-| clean           | Remove the previously saved environment (AWS Access Key, admin user info) before performing the installation. |
+| clean           | Remove the previously saved environment (AWS Access Key, admin user info) and any saved timeout before performing the installation. |
 | restart         | Run the installation from the beginning; do not resume a previous installation. |
 | server          | Install _The Combine_ in a server environment so that _The Combine_ is always running by default. |
 | timeout TIMEOUT | Use a different timeout when installing. (Default: 5 minutes.) With slow internet, it is helpful to extend the timeout. See <https://pkg.go.dev/time#ParseDuration> for timeout formats. The value is used for the rest of the installation, including after a restart, so it does not need to be entered again. |

--- a/installer/README.md
+++ b/installer/README.md
@@ -159,7 +159,7 @@ To run `combine-installer.run` with options, the option list must be started wit
 
 | option          | description |
 | ---------------- | ---------------------------------------------------------------------------- |
-| clean           | Remove the previously saved environment (AWS Access Key, admin user info) and any saved timeout before performing the installation. |
+| clean           | Remove the previously saved environment (AWS Access Key, admin user info) and any previously saved timeout before performing the installation. |
 | restart         | Run the installation from the beginning; do not resume a previous installation. |
 | server          | Install _The Combine_ in a server environment so that _The Combine_ is always running by default. |
 | timeout TIMEOUT | Use a different timeout when installing. (Default: 5 minutes.) With slow internet, it is helpful to extend the timeout. See <https://pkg.go.dev/time#ParseDuration> for timeout formats. The value is used for the rest of the installation, including after a restart, so it does not need to be entered again. |


### PR DESCRIPTION
The documented `timeout` option did not work: `SETUP_OPTS` was set inside `install-base-charts` but used by `install-the-combine`, so runs beginning at `Install-combine` — `update`, `start-at` — dropped it and Helm fell back to its 5 minute default. Fixing that exposed several more ways the option failed.

## Changes

- **Apply it on resumed installs** — compute `SETUP_OPTS` once, after parsing.
- **Remember it for the whole installation**, in `${CONFIG_DIR}/install-timeout`
  - every Helm command runs *after* the restart that `Pre-reqs` usually requires, so a timeout given on the first invocation was discarded before anything could use it
  - the command line overrides and updates the record; `clean` and reaching `Done` discard it; `restart` keeps it
- **Check option values before applying any option**
  - `update timeout bogus` recorded the `Install-combine` state and *then* rejected the value, so the next run skipped `Base-charts`
  - `timeout` or `start-at` with no value exited silently; a non-duration value swallowed the next option
  - both checks moved into `check-opt-value`, not copied
- **Reject unusable timeouts** — non-durations, and anything amounting to zero (`0`, `0s`, `0h0m0s`), which Helm treats as an already expired deadline.
- **Ignore `HELM_TIMEOUT` from the environment** — it was never initialized, so it skipped the format check and would have been recorded.
- **Document it** — the `timeout` and `clean` rows of the installer README.

## Behavior

| Input | Before | After |
| --- | --- | --- |
| `timeout 30m0s v3.0.0`, reboot, rerun | dropped at the reboot | reused until the install finishes |
| `update timeout 30m0s` | silently ignored | applied |
| `update timeout bogus` | state advanced, `Base-charts` skipped | error, saved state untouched |
| `v3.0.0 timeout`, or `start-at` | exit 1, no output | names what is missing |
| `timeout restart v3.0.0` | `--timeout restart` handed to helm | error |
| `timeout 0s v3.0.0` | expired deadline, instant failure | error |
| exported `HELM_TIMEOUT=bogus` | handed to helm unchecked | ignored |

## Notes

- A timeout implies `helm --wait`, so an `update` that supplies one now blocks on resources and fails within the timeout, rather than returning at once and falling through to the indefinite poll in `wait-for-combine`.
- A damaged `install-timeout` — unreadable, empty or not a usable duration — stops install and update runs, naming the file and saying to delete it or use `clean`. `uninstall` skips the timeout entirely, so recovery is never blocked.
- `restart` keeps a recorded timeout by design: it resets how far the install got, not saved settings.
- The value pass sees every token, so a value beginning with `v` is version-checked. Only `start-at` takes such a value, and no step name begins with `v`.
- `next-state` no longer writes `Done` into a missing state file — a latent path that left later runs skipping every step.

## Testing

`bash -n`, plus the script's own prologue driven against a throwaway `HOME`:

- rejected input leaves the state, the saved environment and any recorded timeout untouched
- record, reuse, override, `restart` keeps, `clean` drops, `Done` drops
- `restart`, `update`, `start-at`, `clean`, `uninstall`, prerelease versions, the dev flags and unknown options all behave as before

A full desktop install has not been re-run.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4351)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation flow handling so timeout settings are consistently applied during both fresh and resumed installations.
  * Ensured installation options are available before environment setup begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
