### PR TITLE
Manage The Combine's deployments in combinectl

### DIFF
--- a/deploy/ansible/roles/support_tools/files/combinectl.sh
+++ b/deploy/ansible/roles/support_tools/files/combinectl.sh
@@ -161,8 +161,9 @@ start-combine-deployments () {
 # k3s service is patched to KillMode=mixed, so stopping it SIGKILLs whatever is
 # still running, which can be the database part way through its startup setup.
 #
-# Returns non-zero when the deployments were not stopped, so that the caller can
-# leave k3s running rather than SIGKILL them.
+# Returns non-zero if the cluster could not be reached, so that the caller leaves
+# k3s running. A pod still terminating after two minutes only warns, so that one
+# stuck pod cannot leave The Combine with no way to stop.
 stop-combine-deployments () {
   # An unreachable Kubernetes API looks exactly like an empty namespace, so wait
   # for it: a stop issued while the cluster is still coming up must not be read

--- a/deploy/ansible/roles/support_tools/files/combinectl.sh
+++ b/deploy/ansible/roles/support_tools/files/combinectl.sh
@@ -159,24 +159,32 @@ start-combine-deployments () {
   return ${RESTORE_FAILED}
 }
 
+# Explain a stop that did not happen, given $1 as the reason. The Combine is
+# left running either way, so the way out is the same: stop k3s directly, which
+# kills the containers, and then stop again for the WiFi connection that a
+# refusal skips along with everything else.
+report-stop-refused () {
+  echo "$1" >&2
+  echo "Wait a minute, then run \"combinectl stop\" again." >&2
+  echo "If it keeps failing, stop the cluster with \"sudo systemctl stop k3s\"," >&2
+  echo "which kills the containers instead of shutting them down, then run" >&2
+  echo "\"combinectl stop\" again to restore the WiFi connection." >&2
+}
+
 # Scale The Combine deployments to zero and wait for their pods to exit. The
 # k3s service is patched to KillMode=mixed, so stopping it SIGKILLs whatever is
 # still running, which can be the database part way through its startup setup.
 #
-# Returns non-zero if the cluster could not be reached, so that the caller leaves
-# k3s running. A pod still terminating after two minutes only warns, so that one
-# stuck pod cannot leave The Combine with no way to stop.
+# Returns non-zero if the cluster could not be reached, or if the deployments
+# could not be scaled down, so that the caller leaves k3s running rather than
+# SIGKILL them. A pod still terminating after two minutes only warns, so that
+# one stuck pod cannot leave The Combine with no way to stop.
 stop-combine-deployments () {
   # An unreachable Kubernetes API looks exactly like an empty namespace, so wait
   # for it: a stop issued while the cluster is still coming up must not be read
   # as "nothing is running here."
   if ! wait-for-cluster ; then
-    echo "The cluster is not responding, so nothing was stopped." >&2
-    echo "Wait a minute, then run \"combinectl stop\" again." >&2
-    echo "If it keeps failing, the cluster is broken rather than slow. Stop it" >&2
-    echo "with \"sudo systemctl stop k3s\", which kills the containers instead of" >&2
-    echo "shutting them down, then run \"combinectl stop\" again to restore the" >&2
-    echo "WiFi connection." >&2
+    report-stop-refused "The cluster is not responding, so nothing was stopped."
     return 1
   fi
   DEPLOY_STATUS=$(combine-deployments)
@@ -190,7 +198,14 @@ stop-combine-deployments () {
     echo "${REPLICA_LIST}" > "${CACHED_REPLICAS}"
   fi
   echo "Stopping The Combine deployments."
-  kubectl -n thecombine scale deployment --all --replicas=0 > /dev/null
+  # Nothing was asked to stop if this fails, so refuse here rather than fall
+  # through to the wait below, which would time out, warn, and let the caller
+  # SIGKILL the containers. That warning is for a pod that is slow to stop,
+  # which is not this.
+  if ! kubectl -n thecombine scale deployment --all --replicas=0 > /dev/null ; then
+    report-stop-refused "The deployments could not be scaled down, so The Combine was not stopped."
+    return 1
+  fi
   # A selector-based "kubectl wait" fails immediately when nothing matches it,
   # so only wait when there are pods left to wait for.
   if [[ -n $(kubectl -n thecombine get pods -l combine-component --no-headers 2> /dev/null) ]] ; then

--- a/deploy/ansible/roles/support_tools/files/combinectl.sh
+++ b/deploy/ansible/roles/support_tools/files/combinectl.sh
@@ -113,12 +113,26 @@ start-combine-deployments () {
     return
   fi
   if [ -f "${CACHED_REPLICAS}" ] ; then
-    REPLICA_LIST=$(cat "${CACHED_REPLICAS}")
+    CACHE_FILE="${CACHED_REPLICAS}"
   else
-    REPLICA_LIST=$(awk '$2 == 0 { print $1, 1 }' <<< "${DEPLOY_STATUS}")
-    if [[ -z ${REPLICA_LIST} ]] ; then
-      return
-    fi
+    CACHE_FILE=/dev/null
+  fi
+  # List every deployment that is scaled down, with its saved count.  The saved
+  # counts are reconciled with the cluster rather than replayed as they are: a
+  # cached deployment that no longer exists, for example one renamed by a chart
+  # update, would otherwise fail to scale on every start, and its failure would
+  # keep the stale file, and any deployment the file omits, forever.
+  REPLICA_LIST=$(awk '
+    NR == FNR { if ($2 == 0) { stopped[$1] = 1 } ; next }
+    $1 in stopped && $2 > 0 { print $1, $2 ; delete stopped[$1] }
+    END { for (name in stopped) { print name, 1 } }
+    ' <(printf '%s\n' "${DEPLOY_STATUS}") "${CACHE_FILE}")
+  if [[ -z ${REPLICA_LIST} ]] ; then
+    # Nothing is scaled down, so any saved counts no longer apply.
+    rm -f "${CACHED_REPLICAS}"
+    return
+  fi
+  if [[ ${CACHE_FILE} == /dev/null ]] ; then
     echo "No saved replica counts; starting one replica of each deployment."
   fi
   echo "Starting The Combine deployments."

--- a/deploy/ansible/roles/support_tools/files/combinectl.sh
+++ b/deploy/ansible/roles/support_tools/files/combinectl.sh
@@ -73,6 +73,63 @@ combine-cert () {
   echo $CERT_DATA | base64 -d | openssl x509 -enddate -noout| sed -e "s/^notAfter=/Web certificate expires at /"
 }
 
+# Restore the deployment replica counts saved by stop-combine-deployments.
+start-combine-deployments () {
+  if [ ! -f "${CACHED_REPLICAS}" ] ; then
+    return
+  fi
+  # k3s has only just been started, so give the API server time to answer.
+  ATTEMPTS=0
+  until kubectl -n thecombine get deployments > /dev/null 2>&1 ; do
+    ATTEMPTS=$((ATTEMPTS + 1))
+    if [[ ${ATTEMPTS} -ge 60 ]] ; then
+      echo "The cluster is not responding; run \"combinectl start\" again." >&2
+      return
+    fi
+    sleep 2
+  done
+  echo "Starting The Combine deployments."
+  RESTORE_FAILED=0
+  while IFS="=" read -r DEPLOYMENT REPLICAS ; do
+    if [[ -z ${DEPLOYMENT} || -z ${REPLICAS} ]] ; then
+      continue
+    fi
+    if ! kubectl -n thecombine scale "deployment/${DEPLOYMENT}" --replicas="${REPLICAS}" > /dev/null ; then
+      echo "Could not start deployment/${DEPLOYMENT}." >&2
+      RESTORE_FAILED=1
+    fi
+  done < "${CACHED_REPLICAS}"
+  # Keep the counts for the next attempt if any deployment was not restored.
+  if [[ ${RESTORE_FAILED} -eq 0 ]] ; then
+    rm -f "${CACHED_REPLICAS}"
+  fi
+}
+
+# Scale The Combine deployments to zero and wait for their pods to exit.  The
+# k3s service is patched to KillMode=mixed, so stopping it SIGKILLs whatever is
+# still running, which can be the database part way through its startup setup.
+stop-combine-deployments () {
+  if ! kubectl -n thecombine get deployments > /dev/null 2>&1 ; then
+    return
+  fi
+  REPLICAS=$(kubectl -n thecombine get deployments \
+    -o 'jsonpath={range .items[*]}{.metadata.name}={.spec.replicas}{"\n"}{end}')
+  if [[ -z ${REPLICAS} ]] ; then
+    return
+  fi
+  # Only overwrite the cache when there is something to restore, so that
+  # stopping The Combine when it's already stopped doesn't lose the counts.
+  if echo "${REPLICAS}" | grep -qv "=0$" ; then
+    echo "${REPLICAS}" > "${CACHED_REPLICAS}"
+  fi
+  echo "Stopping The Combine deployments."
+  kubectl -n thecombine scale deployment --all --replicas=0 > /dev/null
+  if ! kubectl -n thecombine wait --for=delete pod -l combine-component \
+      --timeout=2m > /dev/null 2>&1 ; then
+    echo "The Combine did not stop within 2 minutes; stopping anyway." >&2
+  fi
+}
+
 # Start The Combine services
 combine-start () {
   echo "Starting The Combine."
@@ -84,6 +141,7 @@ combine-start () {
   if ! systemctl is-active --quiet k3s ; then
     sudo systemctl start k3s
   fi
+  start-combine-deployments
 }
 
 # Stop The Combine services and restore the WiFI
@@ -91,6 +149,7 @@ combine-start () {
 combine-stop () {
   echo "Stopping The Combine."
   if systemctl is-active --quiet k3s ; then
+    stop-combine-deployments
     sudo systemctl stop k3s
   fi
   if systemctl is-active --quiet create_ap ; then
@@ -160,6 +219,7 @@ WIFI_CONFIG=/etc/create_ap/create_ap.conf
 export KUBECONFIG=${HOME}/.kube/config
 COMBINE_CONFIG=${HOME}/.config/combine
 CACHED_WIFI_CONN=${COMBINE_CONFIG}/wifi-connection.txt
+CACHED_REPLICAS=${COMBINE_CONFIG}/deployment-replicas.txt
 
 # Make sure config directory exists
 mkdir -p "${COMBINE_CONFIG}"

--- a/deploy/ansible/roles/support_tools/files/combinectl.sh
+++ b/deploy/ansible/roles/support_tools/files/combinectl.sh
@@ -226,8 +226,8 @@ combine-stop () {
 
 # Print the status of The Combine services.  When the cluster is up, also
 # distinguish between The Combine being uninstalled, incompletely installed,
-# scaled down, still starting, and fully running, then print the status of the
-# deployments in the "thecombine" namespace.
+# scaled down, partly scaled down, still starting, and fully running, then print
+# the status of the deployments in the "thecombine" namespace.
 #
 # Always exits 0; install-combine.sh calls this under "set -e".
 combine-status () {
@@ -264,15 +264,20 @@ combine-status () {
   done
 
   # Total requested replicas, to tell a scaled down Combine from a running one,
-  # and the deployments that do not have all of the replicas they asked for.
+  # the deployments that ask for no replicas at all, and the ones that do not
+  # have all of the replicas they asked for.  A deployment scaled to zero has
+  # every replica it asked for, so it has to be counted separately from those.
   REQUESTED=0
+  STOPPED=()
   PENDING=()
   while read -r NAME WANT HAVE ; do
     if [[ -z ${NAME} ]] ; then
       continue
     fi
     REQUESTED=$(( REQUESTED + ${WANT:-0} ))
-    if [[ ${HAVE:-0} -lt ${WANT:-0} ]] ; then
+    if [[ ${WANT:-0} -eq 0 ]] ; then
+      STOPPED+=( "${NAME}" )
+    elif [[ ${HAVE:-0} -lt ${WANT:-0} ]] ; then
       PENDING+=( "${NAME}" )
     fi
   done <<< "${DEPLOY_STATUS}"
@@ -283,6 +288,9 @@ combine-status () {
   elif [[ ${REQUESTED} -eq 0 ]] ; then
     echo "The Combine is Stopped; the cluster is up but its services are"
     echo "scaled down.  Run \"combinectl start\" to start them."
+  elif [[ ${#STOPPED[@]} -gt 0 ]] ; then
+    echo "The Combine is Partly Stopped; scaled down deployment(s): ${STOPPED[*]}."
+    echo "Run \"combinectl start\" to start them."
   elif [[ ${#PENDING[@]} -gt 0 ]] ; then
     echo "The Combine is Starting; waiting for: ${PENDING[*]}."
   else

--- a/deploy/ansible/roles/support_tools/files/combinectl.sh
+++ b/deploy/ansible/roles/support_tools/files/combinectl.sh
@@ -169,8 +169,12 @@ stop-combine-deployments () {
   # for it: a stop issued while the cluster is still coming up must not be read
   # as "nothing is running here."
   if ! wait-for-cluster ; then
-    echo "The cluster is not responding, so The Combine was not stopped." >&2
+    echo "The cluster is not responding, so nothing was stopped." >&2
     echo "Wait a minute, then run \"combinectl stop\" again." >&2
+    echo "If it keeps failing, the cluster is broken rather than slow. Stop it" >&2
+    echo "with \"sudo systemctl stop k3s\", which kills the containers instead of" >&2
+    echo "shutting them down, then run \"combinectl stop\" again to restore the" >&2
+    echo "WiFi connection." >&2
     return 1
   fi
   DEPLOY_STATUS=$(combine-deployments)
@@ -218,7 +222,11 @@ combine-stop () {
   echo "Stopping The Combine."
   if systemctl is-active --quiet k3s ; then
     # Stopping k3s SIGKILLs the containers, so only do it once the deployments
-    # have shut down; leave everything running otherwise.
+    # have shut down; leave everything running otherwise. That includes the
+    # hotspot below: the pods keep serving without the Kubernetes API, so a
+    # Combine that is still up stays reachable, and a refused stop really has
+    # stopped nothing. Stopping k3s by hand then leaves "combinectl stop" the
+    # WiFi connection to restore.
     if ! stop-combine-deployments ; then
       return 1
     fi

--- a/deploy/ansible/roles/support_tools/files/combinectl.sh
+++ b/deploy/ansible/roles/support_tools/files/combinectl.sh
@@ -338,6 +338,10 @@ combine-status () {
     echo "The Combine is Running."
   fi
   kubectl -n thecombine get deployments
+  # Whether a pending deployment is stuck or still starting shows in the pods.
+  if [[ ${#PENDING[@]} -gt 0 ]] ; then
+    kubectl -n thecombine get pods
+  fi
   return 0
 }
 

--- a/deploy/ansible/roles/support_tools/files/combinectl.sh
+++ b/deploy/ansible/roles/support_tools/files/combinectl.sh
@@ -78,9 +78,11 @@ cluster-ready () {
   kubectl get --raw='/readyz' --request-timeout=10s > /dev/null 2>&1
 }
 
-# Wait for the Kubernetes API to serve requests: sixty attempts, two seconds
-# apart. About two minutes while the API refuses connections, as it does while
-# k3s starts, and up to twelve if it accepts them and then hangs.
+# Wait for the Kubernetes API to serve requests: 60 attempts, two seconds apart.
+# About two minutes while the API refuses connections, as it does while k3s
+# starts; up to twelve if it accepts them and then hangs.
+#
+# Returns non-zero if API is not ready after the maximum number of attempts.
 wait-for-cluster () {
   ATTEMPTS=0
   until cluster-ready ; do
@@ -101,13 +103,9 @@ combine-deployments () {
     -o 'jsonpath={range .items[*]}{.metadata.name} {.spec.replicas} {.status.availableReplicas}{"\n"}{end}'
 }
 
-# Restore the deployment replica counts saved by stop-combine-deployments. The
-# counts live in a local file, so fall back to one replica each when it is
-# missing: k3s can be started without combinectl, which would otherwise leave
-# the deployments scaled to zero with nothing to bring them back.
+# Restore the deployment replica counts saved by stop-combine-deployments.
 #
-# Returns non-zero if a deployment could not be scaled up. Whether the pods
-# then run is what "combinectl status" reports.
+# Returns non-zero if a deployment could not be scaled up.
 start-combine-deployments () {
   if ! wait-for-cluster ; then
     echo "The cluster is not responding; run \"combinectl start\" again." >&2
@@ -128,10 +126,10 @@ start-combine-deployments () {
     CACHE_FILE=/dev/null
   fi
   # List every deployment that is scaled down, with its saved count. The saved
-  # counts are reconciled with the cluster rather than replayed as they are: a
-  # cached deployment that no longer exists, for example one renamed by a chart
-  # update, would otherwise fail to scale on every start, and its failure would
-  # keep the stale file, and any deployment the file omits, forever.
+  # counts are reconciled with the cluster rather than replayed as is: a cached
+  # deployment that no longer exists (e.g., one renamed by a chart update)
+  # would otherwise fail to scale on every start. Its failure would keep the
+  # stale file, and any deployment the file omits, forever.
   REPLICA_LIST=$(awk '
     NR == FNR { if ($2 == 0) { stopped[$1] = 1 } ; next }
     $1 in stopped && $2 > 0 { print $1, $2 ; delete stopped[$1] }
@@ -205,10 +203,8 @@ stop-combine-deployments () {
     echo "${REPLICA_LIST}" > "${CACHED_REPLICAS}"
   fi
   echo "Stopping The Combine deployments."
-  # Nothing was asked to stop if this fails, so refuse here rather than fall
-  # through to the wait below, which would time out, warn, and let the caller
-  # SIGKILL the containers. That warning is for a pod that is slow to stop,
-  # which is not this.
+  # If the scale fails, nothing is shutting down (and the wait below would just
+  # time out before the caller SIGKILLs the containers).
   if ! kubectl -n thecombine scale deployment --all --replicas=0 > /dev/null ; then
     report-stop-refused "The deployments could not be scaled down, so The Combine was not stopped."
     return 1
@@ -389,8 +385,8 @@ export KUBECONFIG=${HOME}/.kube/config
 COMBINE_CONFIG=${HOME}/.config/combine
 # Deployments match the list in install-combine.sh
 COMBINE_DEPLOYMENTS=(backend database frontend maintenance)
-CACHED_WIFI_CONN=${COMBINE_CONFIG}/wifi-connection.txt
 CACHED_REPLICAS=${COMBINE_CONFIG}/deployment-replicas.txt
+CACHED_WIFI_CONN=${COMBINE_CONFIG}/wifi-connection.txt
 
 # Make sure config directory exists
 mkdir -p "${COMBINE_CONFIG}"

--- a/deploy/ansible/roles/support_tools/files/combinectl.sh
+++ b/deploy/ansible/roles/support_tools/files/combinectl.sh
@@ -93,10 +93,11 @@ wait-for-cluster () {
   return 0
 }
 
-# Print "name requested available" for every deployment in the namespace.
+# Print "name requested available" for every deployment in the namespace, and
+# return kubectl's status: a failed query prints nothing, like an empty one.
 # availableReplicas is absent, rather than 0, when none are available.
 combine-deployments () {
-  kubectl -n thecombine get deployments 2> /dev/null \
+  kubectl -n thecombine get deployments \
     -o 'jsonpath={range .items[*]}{.metadata.name} {.spec.replicas} {.status.availableReplicas}{"\n"}{end}'
 }
 
@@ -112,7 +113,10 @@ start-combine-deployments () {
     echo "The cluster is not responding; run \"combinectl start\" again." >&2
     return 1
   fi
-  DEPLOY_STATUS=$(combine-deployments)
+  if ! DEPLOY_STATUS=$(combine-deployments) ; then
+    echo "The deployments could not be read; run \"combinectl start\" again." >&2
+    return 1
+  fi
   if [[ -z ${DEPLOY_STATUS} ]] ; then
     # Nothing is installed, so there is nothing to start; combine-status is
     # where an empty namespace is reported.
@@ -187,7 +191,10 @@ stop-combine-deployments () {
     report-stop-refused "The cluster is not responding, so nothing was stopped."
     return 1
   fi
-  DEPLOY_STATUS=$(combine-deployments)
+  if ! DEPLOY_STATUS=$(combine-deployments) ; then
+    report-stop-refused "The deployments could not be read, so nothing was stopped."
+    return 1
+  fi
   if [[ -z ${DEPLOY_STATUS} ]] ; then
     return 0
   fi
@@ -280,7 +287,12 @@ combine-status () {
     return 0
   fi
 
-  DEPLOY_STATUS=$(combine-deployments)
+  if ! DEPLOY_STATUS=$(combine-deployments) ; then
+    echo "The Combine's state is Unknown; the cluster is running, but its"
+    echo "deployments could not be read."
+    echo "Wait a minute, then run \"combinectl status\" again."
+    return 0
+  fi
   if [[ -z ${DEPLOY_STATUS} ]] ; then
     echo "The Combine is Not Installed; the Kubernetes cluster is running, but"
     echo "the \"thecombine\" namespace has no deployments."

--- a/deploy/ansible/roles/support_tools/files/combinectl.sh
+++ b/deploy/ansible/roles/support_tools/files/combinectl.sh
@@ -73,24 +73,57 @@ combine-cert () {
   echo $CERT_DATA | base64 -d | openssl x509 -enddate -noout| sed -e "s/^notAfter=/Web certificate expires at /"
 }
 
-# Restore the deployment replica counts saved by stop-combine-deployments.
-start-combine-deployments () {
-  if [ ! -f "${CACHED_REPLICAS}" ] ; then
-    return
-  fi
-  # k3s has only just been started, so give the API server time to answer.
+# Report whether the Kubernetes API is serving requests.  The k3s unit becomes
+# active before the API is up, so an active unit alone is not enough.
+cluster-ready () {
+  kubectl get --raw='/readyz' --request-timeout=10s > /dev/null 2>&1
+}
+
+# Wait up to two minutes for the Kubernetes API to serve requests.
+wait-for-cluster () {
   ATTEMPTS=0
-  until kubectl -n thecombine get deployments > /dev/null 2>&1 ; do
+  until cluster-ready ; do
     ATTEMPTS=$((ATTEMPTS + 1))
     if [[ ${ATTEMPTS} -ge 60 ]] ; then
-      echo "The cluster is not responding; run \"combinectl start\" again." >&2
-      return
+      return 1
     fi
     sleep 2
   done
+  return 0
+}
+
+# Print "name requested available" for every deployment in the namespace.
+# availableReplicas is absent, rather than 0, when none are available.
+combine-deployments () {
+  kubectl -n thecombine get deployments 2> /dev/null \
+    -o 'jsonpath={range .items[*]}{.metadata.name} {.spec.replicas} {.status.availableReplicas}{"\n"}{end}'
+}
+
+# Restore the deployment replica counts saved by stop-combine-deployments.  The
+# counts live in a local file, so fall back to one replica each when it is
+# missing: k3s can be started without combinectl, which would otherwise leave
+# the deployments scaled to zero with nothing to bring them back.
+start-combine-deployments () {
+  if ! wait-for-cluster ; then
+    echo "The cluster is not responding; run \"combinectl start\" again." >&2
+    return
+  fi
+  DEPLOY_STATUS=$(combine-deployments)
+  if [[ -z ${DEPLOY_STATUS} ]] ; then
+    return
+  fi
+  if [ -f "${CACHED_REPLICAS}" ] ; then
+    REPLICA_LIST=$(cat "${CACHED_REPLICAS}")
+  else
+    REPLICA_LIST=$(awk '$2 == 0 { print $1, 1 }' <<< "${DEPLOY_STATUS}")
+    if [[ -z ${REPLICA_LIST} ]] ; then
+      return
+    fi
+    echo "No saved replica counts; starting one replica of each deployment."
+  fi
   echo "Starting The Combine deployments."
   RESTORE_FAILED=0
-  while IFS="=" read -r DEPLOYMENT REPLICAS ; do
+  while read -r DEPLOYMENT REPLICAS ; do
     if [[ -z ${DEPLOYMENT} || -z ${REPLICAS} ]] ; then
       continue
     fi
@@ -98,7 +131,7 @@ start-combine-deployments () {
       echo "Could not start deployment/${DEPLOYMENT}." >&2
       RESTORE_FAILED=1
     fi
-  done < "${CACHED_REPLICAS}"
+  done <<< "${REPLICA_LIST}"
   # Keep the counts for the next attempt if any deployment was not restored.
   if [[ ${RESTORE_FAILED} -eq 0 ]] ; then
     rm -f "${CACHED_REPLICAS}"
@@ -109,24 +142,25 @@ start-combine-deployments () {
 # k3s service is patched to KillMode=mixed, so stopping it SIGKILLs whatever is
 # still running, which can be the database part way through its startup setup.
 stop-combine-deployments () {
-  if ! kubectl -n thecombine get deployments > /dev/null 2>&1 ; then
+  DEPLOY_STATUS=$(combine-deployments)
+  if [[ -z ${DEPLOY_STATUS} ]] ; then
     return
   fi
-  REPLICAS=$(kubectl -n thecombine get deployments \
-    -o 'jsonpath={range .items[*]}{.metadata.name}={.spec.replicas}{"\n"}{end}')
-  if [[ -z ${REPLICAS} ]] ; then
-    return
-  fi
-  # Only overwrite the cache when there is something to restore, so that
-  # stopping The Combine when it's already stopped doesn't lose the counts.
-  if echo "${REPLICAS}" | grep -qv "=0$" ; then
-    echo "${REPLICAS}" > "${CACHED_REPLICAS}"
+  # Only record the deployments that are running, so that stopping The Combine
+  # when it's already stopped doesn't lose the counts.
+  REPLICA_LIST=$(awk '$2 > 0 { print $1, $2 }' <<< "${DEPLOY_STATUS}")
+  if [[ -n ${REPLICA_LIST} ]] ; then
+    echo "${REPLICA_LIST}" > "${CACHED_REPLICAS}"
   fi
   echo "Stopping The Combine deployments."
   kubectl -n thecombine scale deployment --all --replicas=0 > /dev/null
-  if ! kubectl -n thecombine wait --for=delete pod -l combine-component \
-      --timeout=2m > /dev/null 2>&1 ; then
-    echo "The Combine did not stop within 2 minutes; stopping anyway." >&2
+  # A selector-based "kubectl wait" fails immediately when nothing matches it,
+  # so only wait when there are pods left to wait for.
+  if [[ -n $(kubectl -n thecombine get pods -l combine-component --no-headers 2> /dev/null) ]] ; then
+    if ! kubectl -n thecombine wait --for=delete pod -l combine-component \
+        --timeout=2m > /dev/null 2>&1 ; then
+      echo "The Combine did not stop within 2 minutes; stopping anyway." >&2
+    fi
   fi
 }
 
@@ -159,21 +193,72 @@ combine-stop () {
   fi
 }
 
-# Print the status of The Combine services.  If the combine is
-# "up" then also print that status of the deployments in
-# "thecombine" namespace.
+# Print the status of The Combine services.  When the cluster is up, also
+# distinguish between The Combine being uninstalled, incompletely installed,
+# scaled down, still starting, and fully running, then print the status of the
+# deployments in the "thecombine" namespace.
+#
+# Always exits 0; install-combine.sh calls this under "set -e".
 combine-status () {
   if systemctl is-active --quiet create_ap ; then
     echo "WiFi hotspot is Running."
   else
     echo "WiFi hotspot is Stopped."
   fi
-  if systemctl is-active --quiet k3s ; then
-    echo "The Combine  is Running."
-    kubectl -n thecombine get deployments
-  else
+
+  if ! systemctl is-active --quiet k3s ; then
     echo "The Combine is Stopped."
+    return 0
   fi
+
+  if ! cluster-ready ; then
+    echo "The Combine is Starting; the Kubernetes cluster is not ready yet."
+    echo "Wait a minute, then run \"combinectl status\" again."
+    return 0
+  fi
+
+  DEPLOY_STATUS=$(combine-deployments)
+  if [[ -z ${DEPLOY_STATUS} ]] ; then
+    echo "The Combine is Not Installed; the Kubernetes cluster is running, but"
+    echo "the \"thecombine\" namespace has no deployments."
+    echo "Download and run the install package to install The Combine."
+    return 0
+  fi
+
+  MISSING=()
+  for DEPLOYMENT in "${COMBINE_DEPLOYMENTS[@]}" ; do
+    if ! grep -q "^${DEPLOYMENT} " <<< "${DEPLOY_STATUS}" ; then
+      MISSING+=( "${DEPLOYMENT}" )
+    fi
+  done
+
+  # Total requested replicas, to tell a scaled down Combine from a running one,
+  # and the deployments that do not have all of the replicas they asked for.
+  REQUESTED=0
+  PENDING=()
+  while read -r NAME WANT HAVE ; do
+    if [[ -z ${NAME} ]] ; then
+      continue
+    fi
+    REQUESTED=$(( REQUESTED + ${WANT:-0} ))
+    if [[ ${HAVE:-0} -lt ${WANT:-0} ]] ; then
+      PENDING+=( "${NAME}" )
+    fi
+  done <<< "${DEPLOY_STATUS}"
+
+  if [[ ${#MISSING[@]} -gt 0 ]] ; then
+    echo "The Combine is Incomplete; missing deployment(s): ${MISSING[*]}."
+    echo "Download and run the install package to repair the installation."
+  elif [[ ${REQUESTED} -eq 0 ]] ; then
+    echo "The Combine is Stopped; the cluster is up but its services are"
+    echo "scaled down.  Run \"combinectl start\" to start them."
+  elif [[ ${#PENDING[@]} -gt 0 ]] ; then
+    echo "The Combine is Starting; waiting for: ${PENDING[*]}."
+  else
+    echo "The Combine is Running."
+  fi
+  kubectl -n thecombine get deployments
+  return 0
 }
 
 # Update the image used in each of the deployments in The Combine.  This
@@ -214,6 +299,9 @@ combine-wifi-set-password () {
 }
 
 # Main script entrypoint
+# The deployments that make up The Combine, used to detect an installation that
+# is missing components.  Matches the list in install-combine.sh.
+COMBINE_DEPLOYMENTS=(backend database frontend maintenance)
 WIFI_IF=$(get-wifi-if)
 WIFI_CONFIG=/etc/create_ap/create_ap.conf
 export KUBECONFIG=${HOME}/.kube/config

--- a/deploy/ansible/roles/support_tools/files/combinectl.sh
+++ b/deploy/ansible/roles/support_tools/files/combinectl.sh
@@ -106,8 +106,8 @@ combine-deployments () {
 # missing: k3s can be started without combinectl, which would otherwise leave
 # the deployments scaled to zero with nothing to bring them back.
 #
-# Returns non-zero when a deployment that should be running is not, so that a
-# failed start is not reported as a successful one.
+# Returns non-zero if a deployment could not be scaled up. Whether the pods
+# then run is what "combinectl status" reports.
 start-combine-deployments () {
   if ! wait-for-cluster ; then
     echo "The cluster is not responding; run \"combinectl start\" again." >&2
@@ -225,8 +225,7 @@ stop-combine-deployments () {
 }
 
 # Start The Combine services. The status of the last command is the status of
-# the function, so this returns non-zero if the deployments were not started,
-# which matches combine-stop.
+# the function, so a deployment that could not be scaled up is reported.
 combine-start () {
   echo "Starting The Combine."
   if ! systemctl is-active --quiet create_ap ; then

--- a/deploy/ansible/roles/support_tools/files/combinectl.sh
+++ b/deploy/ansible/roles/support_tools/files/combinectl.sh
@@ -31,9 +31,8 @@ usage () {
 .EOM
 }
 
-# Get the name of the first wifi interface.  In general,
-# this script assumes that there is a single WiFi interface
-# installed.
+# Get the name of the first wifi interface. In general, this script assumes
+# that there is a single WiFi interface installed.
 get-wifi-if () {
   IFS=$'\n' WIFI_DEVICES=( $(nmcli d | grep "^wl") )
   if [[ ${#WIFI_DEVICES[@]} -gt 0 ]] ; then
@@ -73,7 +72,7 @@ combine-cert () {
   echo $CERT_DATA | base64 -d | openssl x509 -enddate -noout| sed -e "s/^notAfter=/Web certificate expires at /"
 }
 
-# Report whether the Kubernetes API is serving requests.  The k3s unit becomes
+# Report whether the Kubernetes API is serving requests. The k3s unit becomes
 # active before the API is up, so an active unit alone is not enough.
 cluster-ready () {
   kubectl get --raw='/readyz' --request-timeout=10s > /dev/null 2>&1
@@ -99,25 +98,30 @@ combine-deployments () {
     -o 'jsonpath={range .items[*]}{.metadata.name} {.spec.replicas} {.status.availableReplicas}{"\n"}{end}'
 }
 
-# Restore the deployment replica counts saved by stop-combine-deployments.  The
+# Restore the deployment replica counts saved by stop-combine-deployments. The
 # counts live in a local file, so fall back to one replica each when it is
 # missing: k3s can be started without combinectl, which would otherwise leave
 # the deployments scaled to zero with nothing to bring them back.
+#
+# Returns non-zero when a deployment that should be running is not, so that a
+# failed start is not reported as a successful one.
 start-combine-deployments () {
   if ! wait-for-cluster ; then
     echo "The cluster is not responding; run \"combinectl start\" again." >&2
-    return
+    return 1
   fi
   DEPLOY_STATUS=$(combine-deployments)
   if [[ -z ${DEPLOY_STATUS} ]] ; then
-    return
+    # Nothing is installed, so there is nothing to start; combine-status is
+    # where an empty namespace is reported.
+    return 0
   fi
   if [ -f "${CACHED_REPLICAS}" ] ; then
     CACHE_FILE="${CACHED_REPLICAS}"
   else
     CACHE_FILE=/dev/null
   fi
-  # List every deployment that is scaled down, with its saved count.  The saved
+  # List every deployment that is scaled down, with its saved count. The saved
   # counts are reconciled with the cluster rather than replayed as they are: a
   # cached deployment that no longer exists, for example one renamed by a chart
   # update, would otherwise fail to scale on every start, and its failure would
@@ -130,7 +134,7 @@ start-combine-deployments () {
   if [[ -z ${REPLICA_LIST} ]] ; then
     # Nothing is scaled down, so any saved counts no longer apply.
     rm -f "${CACHED_REPLICAS}"
-    return
+    return 0
   fi
   if [[ ${CACHE_FILE} == /dev/null ]] ; then
     echo "No saved replica counts; starting one replica of each deployment."
@@ -150,9 +154,10 @@ start-combine-deployments () {
   if [[ ${RESTORE_FAILED} -eq 0 ]] ; then
     rm -f "${CACHED_REPLICAS}"
   fi
+  return ${RESTORE_FAILED}
 }
 
-# Scale The Combine deployments to zero and wait for their pods to exit.  The
+# Scale The Combine deployments to zero and wait for their pods to exit. The
 # k3s service is patched to KillMode=mixed, so stopping it SIGKILLs whatever is
 # still running, which can be the database part way through its startup setup.
 #
@@ -190,7 +195,9 @@ stop-combine-deployments () {
   return 0
 }
 
-# Start The Combine services
+# Start The Combine services. The status of the last command is the status of
+# the function, so this returns non-zero if the deployments were not started,
+# which matches combine-stop.
 combine-start () {
   echo "Starting The Combine."
   if ! systemctl is-active --quiet create_ap ; then
@@ -204,8 +211,8 @@ combine-start () {
   start-combine-deployments
 }
 
-# Stop The Combine services and restore the WiFI
-# connection if needed.  Returns non-zero if The Combine is still running.
+# Stop The Combine services and restore the WiFi connection if needed. Returns
+# non-zero if The Combine is still running.
 combine-stop () {
   echo "Stopping The Combine."
   if systemctl is-active --quiet k3s ; then
@@ -224,7 +231,7 @@ combine-stop () {
   return 0
 }
 
-# Print the status of The Combine services.  When the cluster is up, also
+# Print the status of The Combine services. When the cluster is up, also
 # distinguish between The Combine being uninstalled, incompletely installed,
 # scaled down, partly scaled down, still starting, and fully running, then print
 # the status of the deployments in the "thecombine" namespace.
@@ -265,7 +272,7 @@ combine-status () {
 
   # Total requested replicas, to tell a scaled down Combine from a running one,
   # the deployments that ask for no replicas at all, and the ones that do not
-  # have all of the replicas they asked for.  A deployment scaled to zero has
+  # have all of the replicas they asked for. A deployment scaled to zero has
   # every replica it asked for, so it has to be counted separately from those.
   REQUESTED=0
   STOPPED=()
@@ -287,7 +294,7 @@ combine-status () {
     echo "Download and run the install package to repair the installation."
   elif [[ ${REQUESTED} -eq 0 ]] ; then
     echo "The Combine is Stopped; the cluster is up but its services are"
-    echo "scaled down.  Run \"combinectl start\" to start them."
+    echo "scaled down. Run \"combinectl start\" to start them."
   elif [[ ${#STOPPED[@]} -gt 0 ]] ; then
     echo "The Combine is Partly Stopped; scaled down deployment(s): ${STOPPED[*]}."
     echo "Run \"combinectl start\" to start them."
@@ -300,9 +307,9 @@ combine-status () {
   return 0
 }
 
-# Update the image used in each of the deployments in The Combine.  This
-# is akin to our current update process for Production and QA servers.  It
-# does *not* update any configuration files or secrets.
+# Update the image used in each of the deployments in The Combine. This is akin
+# to our current update process for Production and QA servers. It does *not*
+# update any configuration files or secrets.
 combine-update () {
   echo "Updating The Combine to $1"
   IMAGE_TAG=$1
@@ -339,7 +346,7 @@ combine-wifi-set-password () {
 
 # Main script entrypoint
 # The deployments that make up The Combine, used to detect an installation that
-# is missing components.  Matches the list in install-combine.sh.
+# is missing components. Matches the list in install-combine.sh.
 COMBINE_DEPLOYMENTS=(backend database frontend maintenance)
 WIFI_IF=$(get-wifi-if)
 WIFI_CONFIG=/etc/create_ap/create_ap.conf

--- a/deploy/ansible/roles/support_tools/files/combinectl.sh
+++ b/deploy/ansible/roles/support_tools/files/combinectl.sh
@@ -21,7 +21,7 @@ usage () {
                 updated install package.
       wifi [wifi-passphrase]:
                 If no parameters are provided, display the WiFi
-                passphrase.  If a new passphase is provided, the
+                passphrase.  If a new passphrase is provided, the
                 WiFi passphrase is updated to the new phrase.
                 If your passphrase has spaces or special characters,
                 it is best to enclose your pass phrase in quotation marks ("").

--- a/deploy/ansible/roles/support_tools/files/combinectl.sh
+++ b/deploy/ansible/roles/support_tools/files/combinectl.sh
@@ -78,7 +78,9 @@ cluster-ready () {
   kubectl get --raw='/readyz' --request-timeout=10s > /dev/null 2>&1
 }
 
-# Wait up to two minutes for the Kubernetes API to serve requests.
+# Wait for the Kubernetes API to serve requests: sixty attempts, two seconds
+# apart. About two minutes while the API refuses connections, as it does while
+# k3s starts, and up to twelve if it accepts them and then hangs.
 wait-for-cluster () {
   ATTEMPTS=0
   until cluster-ready ; do

--- a/deploy/ansible/roles/support_tools/files/combinectl.sh
+++ b/deploy/ansible/roles/support_tools/files/combinectl.sh
@@ -155,10 +155,21 @@ start-combine-deployments () {
 # Scale The Combine deployments to zero and wait for their pods to exit.  The
 # k3s service is patched to KillMode=mixed, so stopping it SIGKILLs whatever is
 # still running, which can be the database part way through its startup setup.
+#
+# Returns non-zero when the deployments were not stopped, so that the caller can
+# leave k3s running rather than SIGKILL them.
 stop-combine-deployments () {
+  # An unreachable Kubernetes API looks exactly like an empty namespace, so wait
+  # for it: a stop issued while the cluster is still coming up must not be read
+  # as "nothing is running here."
+  if ! wait-for-cluster ; then
+    echo "The cluster is not responding, so The Combine was not stopped." >&2
+    echo "Wait a minute, then run \"combinectl stop\" again." >&2
+    return 1
+  fi
   DEPLOY_STATUS=$(combine-deployments)
   if [[ -z ${DEPLOY_STATUS} ]] ; then
-    return
+    return 0
   fi
   # Only record the deployments that are running, so that stopping The Combine
   # when it's already stopped doesn't lose the counts.
@@ -176,6 +187,7 @@ stop-combine-deployments () {
       echo "The Combine did not stop within 2 minutes; stopping anyway." >&2
     fi
   fi
+  return 0
 }
 
 # Start The Combine services
@@ -193,11 +205,15 @@ combine-start () {
 }
 
 # Stop The Combine services and restore the WiFI
-# connection if needed.
+# connection if needed.  Returns non-zero if The Combine is still running.
 combine-stop () {
   echo "Stopping The Combine."
   if systemctl is-active --quiet k3s ; then
-    stop-combine-deployments
+    # Stopping k3s SIGKILLs the containers, so only do it once the deployments
+    # have shut down; leave everything running otherwise.
+    if ! stop-combine-deployments ; then
+      return 1
+    fi
     sudo systemctl stop k3s
   fi
   if systemctl is-active --quiet create_ap ; then
@@ -205,6 +221,7 @@ combine-stop () {
     restore-wifi-connection
     sudo systemctl restart systemd-resolved
   fi
+  return 0
 }
 
 # Print the status of The Combine services.  When the cluster is up, also

--- a/deploy/ansible/roles/support_tools/files/combinectl.sh
+++ b/deploy/ansible/roles/support_tools/files/combinectl.sh
@@ -20,9 +20,9 @@ usage () {
                 The Combine does not run properly, download and run the
                 updated install package.
       wifi [wifi-passphrase]:
-                If no parameters are provided, display the wifi
+                If no parameters are provided, display the WiFi
                 passphrase.  If a new passphase is provided, the
-                wifi passphrase is updated to the new phrase.
+                WiFi passphrase is updated to the new phrase.
                 If your passphrase has spaces or special characters,
                 it is best to enclose your pass phrase in quotation marks ("").
 
@@ -31,7 +31,7 @@ usage () {
 .EOM
 }
 
-# Get the name of the first wifi interface. In general, this script assumes
+# Get the name of the first WiFi interface. In general, this script assumes
 # that there is a single WiFi interface installed.
 get-wifi-if () {
   IFS=$'\n' WIFI_DEVICES=( $(nmcli d | grep "^wl") )
@@ -239,15 +239,15 @@ combine-stop () {
   echo "Stopping The Combine."
   if systemctl is-active --quiet k3s ; then
     # Stopping k3s SIGKILLs the containers, so only do it once the deployments
-    # have shut down; leave everything running otherwise. That includes the
-    # hotspot below: the pods keep serving without the Kubernetes API, so a
-    # Combine that is still up stays reachable, and a refused stop really has
-    # stopped nothing. Stopping k3s by hand then leaves "combinectl stop" the
-    # WiFi connection to restore.
+    # have shut down; leave everything running otherwise, the hotspot included.
     if ! stop-combine-deployments ; then
       return 1
     fi
-    sudo systemctl stop k3s
+    if ! sudo systemctl stop k3s ; then
+      echo "Could not stop k3s; the deployments are stopped but the cluster is" >&2
+      echo "still running. Run \"combinectl stop\" again." >&2
+      return 1
+    fi
   fi
   if systemctl is-active --quiet create_ap ; then
     sudo systemctl stop create_ap
@@ -258,9 +258,8 @@ combine-stop () {
 }
 
 # Print the status of The Combine services. When the cluster is up, also
-# distinguish between The Combine being uninstalled, incompletely installed,
-# scaled down, partly scaled down, still starting, and fully running, then print
-# the status of the deployments in the "thecombine" namespace.
+# distinguish between various possible installation states, then print the
+# status of the deployments.
 #
 # Always exits 0; install-combine.sh calls this under "set -e".
 combine-status () {
@@ -296,10 +295,8 @@ combine-status () {
     fi
   done
 
-  # Total requested replicas, to tell a scaled down Combine from a running one,
-  # the deployments that ask for no replicas at all, and the ones that do not
-  # have all of the replicas they asked for. A deployment scaled to zero has
-  # every replica it asked for, so it has to be counted separately from those.
+  # A deployment scaled to zero has every replica it asked for, so it has to be
+  # counted separately from the ones that are still short of theirs.
   REQUESTED=0
   STOPPED=()
   PENDING=()
@@ -371,13 +368,12 @@ combine-wifi-set-password () {
 }
 
 # Main script entrypoint
-# The deployments that make up The Combine, used to detect an installation that
-# is missing components. Matches the list in install-combine.sh.
-COMBINE_DEPLOYMENTS=(backend database frontend maintenance)
 WIFI_IF=$(get-wifi-if)
 WIFI_CONFIG=/etc/create_ap/create_ap.conf
 export KUBECONFIG=${HOME}/.kube/config
 COMBINE_CONFIG=${HOME}/.config/combine
+# Deployments match the list in install-combine.sh
+COMBINE_DEPLOYMENTS=(backend database frontend maintenance)
 CACHED_WIFI_CONN=${COMBINE_CONFIG}/wifi-connection.txt
 CACHED_REPLICAS=${COMBINE_CONFIG}/deployment-replicas.txt
 

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -380,7 +380,7 @@ while [ "$STATE" != "Done" ] ; do
     Shutdown-combine)
       # If not being installed as a server,
       if [[ $IS_SERVER != 1 ]] ; then
-        # Shut down The Combine services.  combinectl leaves them running rather
+        # Shut down The Combine services. combinectl leaves them running rather
         # than kill them mid-shutdown, so stop here if it could not stop them.
         ERROR_HINT="Rerun the installer to finish shutting down; nothing needs to be undone."
         combinectl stop || error "Could not stop The Combine."

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -383,11 +383,13 @@ while [ "$STATE" != "Done" ] ; do
         # Shut down The Combine services. combinectl leaves them running rather
         # than kill them mid-shutdown, so stop here if it could not stop them.
         #
-        # k3s still being active is the check, rather than combinectl's exit
-        # status, because the update option does not reinstall combinectl: this
-        # can be an older one that reports a stop it completed as a failure.
-        # combinectl only returns non-zero from before it stops k3s, so for the
-        # current one the two conditions are the same.
+        # k3s still being active is the check rather than combinectl's exit
+        # status, which is not a full account of what happened: combine-stop
+        # does not check its "systemctl stop k3s", so it returns 0 with the
+        # cluster still up if that fails. The update option also does not
+        # reinstall combinectl, so this can be an older one that stops k3s
+        # without draining it first, and returns 0 for that too. What the
+        # cluster is doing afterwards is the same question for either.
         combinectl stop || true
         if systemctl is-active --quiet k3s ; then
           ERROR_HINT="Rerun the installer to finish shutting down; nothing needs to be undone."

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -382,9 +382,17 @@ while [ "$STATE" != "Done" ] ; do
       if [[ $IS_SERVER != 1 ]] ; then
         # Shut down The Combine services. combinectl leaves them running rather
         # than kill them mid-shutdown, so stop here if it could not stop them.
-        ERROR_HINT="Rerun the installer to finish shutting down; nothing needs to be undone."
-        combinectl stop || error "Could not stop The Combine."
-        ERROR_HINT=""
+        #
+        # k3s still being active is the check, rather than combinectl's exit
+        # status, because the update option does not reinstall combinectl: this
+        # can be an older one that reports a stop it completed as a failure.
+        # combinectl only returns non-zero from before it stops k3s, so for the
+        # current one the two conditions are the same.
+        combinectl stop || true
+        if systemctl is-active --quiet k3s ; then
+          ERROR_HINT="Rerun the installer to finish shutting down; nothing needs to be undone."
+          error "Could not stop The Combine."
+        fi
         # Disable The Combine services from starting at boot time
         sudo systemctl disable create_ap
         sudo systemctl disable k3s

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -380,8 +380,11 @@ while [ "$STATE" != "Done" ] ; do
     Shutdown-combine)
       # If not being installed as a server,
       if [[ $IS_SERVER != 1 ]] ; then
-        # Shut down The Combine services
-        combinectl stop
+        # Shut down The Combine services.  combinectl leaves them running rather
+        # than kill them mid-shutdown, so stop here if it could not stop them.
+        ERROR_HINT="Rerun the installer to finish shutting down; nothing needs to be undone."
+        combinectl stop || error "Could not stop The Combine."
+        ERROR_HINT=""
         # Disable The Combine services from starting at boot time
         sudo systemctl disable create_ap
         sudo systemctl disable k3s

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -384,12 +384,7 @@ while [ "$STATE" != "Done" ] ; do
         # than kill them mid-shutdown, so stop here if it could not stop them.
         #
         # k3s still being active is the check rather than combinectl's exit
-        # status, which is not a full account of what happened: combine-stop
-        # does not check its "systemctl stop k3s", so it returns 0 with the
-        # cluster still up if that fails. The update option also does not
-        # reinstall combinectl, so this can be an older one that stops k3s
-        # without draining it first, and returns 0 for that too. What the
-        # cluster is doing afterwards is the same question for either.
+        # status, which can be zero with the cluster still up.
         combinectl stop || true
         if systemctl is-active --quiet k3s ; then
           ERROR_HINT="Rerun the installer to finish shutting down; nothing needs to be undone."

--- a/installer/README.md
+++ b/installer/README.md
@@ -168,7 +168,7 @@ To run `combine-installer.run` with options, the option list must be started wit
 | server          | Install _The Combine_ in a server environment so that _The Combine_ is always running by default. |
 | timeout TIMEOUT | Use a different timeout when installing. (Default: 5 minutes.) With slow internet, it is helpful to extend the timeout. See <https://pkg.go.dev/time#ParseDuration> for timeout formats. The value is used for the rest of the installation, including after a restart, so it does not need to be entered again. |
 | uninstall       | Remove software installed by this script. |
-| update          | Update _The Combine_ to the version number provided. This skips installing support software that was installed previously, which includes the `combinectl` tool, so run the installation without this option to pick up changes to it. |
+| update          | Update _The Combine_ to the version number provided. This skips installing/updating support software that was installed previously (e.g., the `combinectl` tool). |
 | version-number  | Specify a version to install instead of the current version. A version number will have the form `vn.n.n` where `n` represents an integer value, for example, `v1.20.0`. |
 
 ### Examples

--- a/installer/README.md
+++ b/installer/README.md
@@ -121,6 +121,10 @@ To shutdown _The Combine_, open a terminal window and run:
 combinectl stop
 ```
 
+If _The Combine_ is still starting up, `combinectl stop` waits for it to finish before shutting anything down, so the
+command can take a few minutes. If it reports that the cluster is not responding, then nothing was stopped and it is
+safe to run again; the message it prints also says how to stop the cluster directly if the problem does not clear.
+
 ### combinectl Tool
 
 Once installation is complete, you can use the `combinectl` command to manage the installation. The `combinectl` command

--- a/installer/README.md
+++ b/installer/README.md
@@ -164,7 +164,7 @@ To run `combine-installer.run` with options, the option list must be started wit
 | server          | Install _The Combine_ in a server environment so that _The Combine_ is always running by default. |
 | timeout TIMEOUT | Use a different timeout when installing. (Default: 5 minutes.) With slow internet, it is helpful to extend the timeout. See <https://pkg.go.dev/time#ParseDuration> for timeout formats. The value is used for the rest of the installation, including after a restart, so it does not need to be entered again. |
 | uninstall       | Remove software installed by this script. |
-| update          | Update _The Combine_ to the version number provided. This skips installing support software that was installed previously. |
+| update          | Update _The Combine_ to the version number provided. This skips installing support software that was installed previously, which includes the `combinectl` tool, so run the installation without this option to pick up changes to it. |
 | version-number  | Specify a version to install instead of the current version. A version number will have the form `vn.n.n` where `n` represents an integer value, for example, `v1.20.0`. |
 
 ### Examples


### PR DESCRIPTION
Split out of #4352, part 3 of 4 — see
https://github.com/sillsdev/TheCombine/pull/4352#issuecomment-5360053323 for the split and how it was verified.

`combinectl` never took The Combine's deployments into account. The k3s unit is patched to `KillMode=mixed`, so
`combinectl stop` SIGKILLed whatever was still running, and `combinectl status` reported "The Combine is Running."
whenever the k3s unit was active, which covers several states that are not running.

- Scale the deployments to zero and wait for their pods to exit before stopping k3s, restoring the saved replica
  counts on start. The counts are reconciled with the cluster rather than replayed, so a deployment the cache does not
  know about, or one that no longer exists, does not wedge every later start.
- Wait for the Kubernetes API in the stop path as the start path already does: an unreachable API looks exactly like an
  empty namespace, which was read as "nothing to stop" just before k3s was stopped anyway.
- Refuse the stop, rather than let the caller SIGKILL the containers, when the cluster cannot be reached or the
  deployments cannot be scaled down. Both refusals print the way out: stop k3s directly, then stop again for the WiFi
  connection a refusal skips. A pod merely slow to terminate still only warns, so that one stuck pod cannot leave _The
  Combine_ with no way to stop.
- Distinguish, in `combinectl status`, a k3s unit that is active from an API that is serving, an empty namespace, a
  missing deployment, a fully or partly scaled down Combine, and one that is still coming up.
- Return non-zero from `combinectl start` and `combinectl stop` when they did not do what they were asked.
- Have the installer's `Shutdown-combine` step confirm that k3s actually stopped before it disables the services.

### Scope

Three files, and only the parts of them that belong to this change:

- `deploy/ansible/roles/support_tools/files/combinectl.sh` in full
- the `Shutdown-combine` hunk of `deploy/scripts/install-combine.sh`, which decides whether the installer may go on to
  disable the services. It tests whether k3s is still active rather than reading `combinectl`'s exit status, so it does
  not depend on which `combinectl` is on disk — which matters because the installer's `update` option does not
  reinstall it — and it also covers a `systemctl stop k3s` that failed, which `combine-stop` never checks.
- the `update` row of `installer/README.md`, since the support software that option skips includes `combinectl` itself

Independent of the other three parts of #4352 in both directions, textually and functionally, so it can go in at any
point in the sequence.

### Corrections to earlier claims

`aba8b6f7`'s commit message, the split analysis linked above, and an earlier version of this description all said that
the `combine-stop` before this branch "exits 1 whenever the hotspot is not running", because it ends on a
`systemctl is-active --quiet create_ap` test. That is wrong: a bash `if` with a false condition and no `else` exits 0,
so it returns 0. Two things follow.

- The `Shutdown-combine` hunk was never forced to land together with the `combinectl` changes; it could have gone into
  either PR. It is still here, and no longer reads `combinectl`'s exit status at all.
- On the `update` path an older `combinectl` does not abort the installer, as I had it. It stops k3s without draining
  the deployments, SIGKILLs the containers, and returns 0 — the ungraceful stop this PR exists to prevent, still
  unfixed there, because `update` does not reinstall `combinectl`. Picking up this change needs a full installation.

`0557df6e` corrects the code comment that carried the same reasoning. The commit messages stand as written.

### QA and prod

No effect on the QA or prod server clusters. The `support_tools` role that installs `combinectl` is imported only by
`playbook_desktop_setup.yml` (`hosts: localhost`) and `playbook_nuc_setup.yml` (`hosts: nuc`), never for the `server`
or `qa` groups, and those clusters are deployed by `.github/actions/combine-deploy-update` rather than by
`install-combine.sh`. It does reach the NUCs, including the QA NUC and nuc1-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- - -

## Manual Testing

Tested manually on a laptop with the result of this workflow dispatch: https://github.com/sillsdev/TheCombine/actions/runs/32488781733

- - -

## Devin review

https://app.devin.ai/review/sillsdev/TheCombine/pull/4353

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4353)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved cluster startup and shutdown handling with readiness checks, deployment discovery, replica restoration, and graceful pod termination.
  * Status reporting now distinguishes startup, incomplete, scaled-down, partially stopped, and running states.
  * Shutdown now verifies that the cluster has stopped before continuing.

* **Bug Fixes**
  * Added safeguards for failed or incomplete shutdowns, with clear retry guidance.

* **Documentation**
  * Clarified shutdown behavior, retry guidance, and update handling for installed support tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->