### PR TITLE
Wait for cluster DNS before starting nginx in the frontend

### DIFF
--- a/deploy/helm/thecombine/charts/frontend/templates/deployment-frontend.yaml
+++ b/deploy/helm/thecombine/charts/frontend/templates/deployment-frontend.yaml
@@ -67,6 +67,13 @@ spec:
           ports:
             - containerPort: 80
             - containerPort: 443
+          readinessProbe:
+            # The entrypoint waits for cluster DNS to resolve the backend before
+            # starting nginx, so a running container is not yet a serving one.
+            tcpSocket:
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
           resources:
             requests:
               cpu:  1m

--- a/nginx/init/05-wait-for-backend-dns.sh
+++ b/nginx/init/05-wait-for-backend-dns.sh
@@ -18,15 +18,15 @@ if getent hosts "${BACKEND_HOST}" > /dev/null 2>&1 ; then
 fi
 
 echo "Waiting up to ${MAX_WAIT_SECONDS}s for '${BACKEND_HOST}' to resolve"
-WAITED=0
 until getent hosts "${BACKEND_HOST}" > /dev/null 2>&1 ; do
-    if [ "${WAITED}" -ge "${MAX_WAIT_SECONDS}" ] ; then
+    # SECONDS is wall clock since this shell started, so the cap covers the time
+    # getent spends blocking on resolver timeouts, not just the sleeps.
+    if [ "${SECONDS}" -ge "${MAX_WAIT_SECONDS}" ] ; then
         # Start nginx anyway so that it reports the problem itself, rather than
         # leaving a container that is running but never serving.
-        echo "'${BACKEND_HOST}' did not resolve after ${MAX_WAIT_SECONDS}s"
+        echo "'${BACKEND_HOST}' did not resolve after ${SECONDS}s"
         exit 0
     fi
     sleep 2
-    WAITED=$((WAITED + 2))
 done
-echo "'${BACKEND_HOST}' resolved after ${WAITED}s"
+echo "'${BACKEND_HOST}' resolved after ${SECONDS}s"

--- a/nginx/init/05-wait-for-backend-dns.sh
+++ b/nginx/init/05-wait-for-backend-dns.sh
@@ -1,0 +1,34 @@
+#! /bin/bash
+
+###############################################################
+# nginx resolves the hostnames in its proxy_pass directives when
+# it loads its configuration and exits if any of them cannot be
+# resolved:
+#
+#   [emerg] host not found in upstream "backend"
+#
+# On a cold start the frontend container can be running before
+# the cluster DNS is able to answer for the backend service, so
+# wait for the name before letting nginx start.
+###############################################################
+
+BACKEND_HOST=backend
+MAX_WAIT_SECONDS=120
+
+if getent hosts "${BACKEND_HOST}" > /dev/null 2>&1 ; then
+    exit 0
+fi
+
+echo "Waiting up to ${MAX_WAIT_SECONDS}s for '${BACKEND_HOST}' to resolve"
+WAITED=0
+until getent hosts "${BACKEND_HOST}" > /dev/null 2>&1 ; do
+    if [ "${WAITED}" -ge "${MAX_WAIT_SECONDS}" ] ; then
+        # Start nginx anyway so that it reports the problem itself, rather than
+        # leaving a container that is running but never serving.
+        echo "'${BACKEND_HOST}' did not resolve after ${MAX_WAIT_SECONDS}s"
+        exit 0
+    fi
+    sleep 2
+    WAITED=$((WAITED + 2))
+done
+echo "'${BACKEND_HOST}' resolved after ${WAITED}s"

--- a/nginx/init/05-wait-for-backend-dns.sh
+++ b/nginx/init/05-wait-for-backend-dns.sh
@@ -1,16 +1,14 @@
 #! /bin/bash
 
-###############################################################
-# nginx resolves the hostnames in its proxy_pass directives when
-# it loads its configuration and exits if any of them cannot be
-# resolved:
+###############################################################################
+# nginx resolves the hostnames in its proxy_pass directives when it loads its
+# configuration, and exits if any of them cannot be resolved:
 #
 #   [emerg] host not found in upstream "backend"
 #
-# On a cold start the frontend container can be running before
-# the cluster DNS is able to answer for the backend service, so
-# wait for the name before letting nginx start.
-###############################################################
+# On a cold start the frontend container can be running before the cluster DNS
+# can answer for the backend service, so wait for the name before starting.
+###############################################################################
 
 BACKEND_HOST=backend
 MAX_WAIT_SECONDS=120

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -44,6 +44,9 @@ server {
     text/x-cross-domain-policy;
     # text/html is always compressed by gzip module
 
+    # nginx exits if a proxy_pass host cannot be resolved when it loads this
+    # configuration, so every cluster-internal host used below has to be waited
+    # for in nginx/init/05-wait-for-backend-dns.sh.
     location /v1 {
         proxy_pass         http://backend:5000;
         proxy_http_version 1.1;

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -44,7 +44,7 @@ server {
     text/x-cross-domain-policy;
     # text/html is always compressed by gzip module
 
-    # Cluster-internal upstreams must be added to nginx/init/05-wait-for-backend-dns.sh.
+    # Only "backend" is waited for in nginx/init/05-wait-for-backend-dns.sh.
     location /v1 {
         proxy_pass         http://backend:5000;
         proxy_http_version 1.1;

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -44,9 +44,7 @@ server {
     text/x-cross-domain-policy;
     # text/html is always compressed by gzip module
 
-    # nginx exits if a proxy_pass host cannot be resolved when it loads this
-    # configuration, so every cluster-internal host used below has to be waited
-    # for in nginx/init/05-wait-for-backend-dns.sh.
+    # Cluster-internal upstreams must be added to nginx/init/05-wait-for-backend-dns.sh.
     location /v1 {
         proxy_pass         http://backend:5000;
         proxy_http_version 1.1;

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -1,3 +1,6 @@
+# Maintainer note: any new proxy_pass host must also be added to
+# nginx/init/05-wait-for-backend-dns.sh, else nginx will exit at startup when
+# that name is not yet resolvable.
 server {
     listen 80;
     server_name ${SERVER_NAME};
@@ -44,7 +47,6 @@ server {
     text/x-cross-domain-policy;
     # text/html is always compressed by gzip module
 
-    # Only "backend" is waited for in nginx/init/05-wait-for-backend-dns.sh.
     location /v1 {
         proxy_pass         http://backend:5000;
         proxy_http_version 1.1;


### PR DESCRIPTION
**Reviewers can ignore all the stuff below.**

(Much of it is for context and details of this change within a larger effort.)

---

Split out of #4352, part 1 of 4 — see
https://github.com/sillsdev/TheCombine/pull/4352#issuecomment-5360053323 for the split and how it was verified.

nginx resolves the hostnames in its `proxy_pass` directives when it loads its configuration, and exits if any of them
cannot be resolved:

```text
[emerg] host not found in upstream "backend" in /etc/nginx/conf.d/default.conf:48
```

On a cold start the frontend container can be running before the cluster DNS is able to answer for the `backend`
service, which leaves the pod crash looping until the kubelet's restart backoff happens to line up with DNS being
ready.

- Wait for the name in a `docker-entrypoint.d` script, and start nginx anyway after two minutes, so that a real
  misconfiguration is still reported rather than leaving a container that runs but never serves.
- Add a readiness probe to the frontend, since with the wait in place a running container is no longer necessarily a
  serving one.
- Note at the `proxy_pass` directives that a new cluster-internal upstream has to be added to the wait. All three of
  them currently point at `backend`, so the wait covers every one as it stands.

### Scope

Three files, none of them touched by the other parts of #4352:

- `nginx/init/05-wait-for-backend-dns.sh` (new) — `Dockerfile` already copies `nginx/init/*` into
  `/docker-entrypoint.d/`, so nothing else is needed to run it
- `nginx/templates/default.conf.template`
- `deploy/helm/thecombine/charts/frontend/templates/deployment-frontend.yaml`

Independent of the other three parts in both directions, textually and functionally: it shares no file with them and
no behavior, so it can merge at any point in the sequence. Verified conflict-free against #4353 and the database part.

### QA and prod

Affected. Both changes are in the frontend image and the shared frontend chart, with no target conditionals, so they
ship to `qa-kube.thecombine.app` and `thecombine.app` as well as to the NUCs and desktop installs. On a server whose
cluster DNS is already up, the script's first `getent` succeeds and it exits immediately, and the two-minute cap keeps
it from ever hanging a deploy. The readiness probe changes when the frontend joins its Service endpoints on every
target.

### Testing

Not yet exercised on hardware. The failure it fixes needs a cold cluster start to reproduce, so it wants a laptop or
NUC install rather than a QA deploy, where DNS is up before the frontend rolls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4354)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved frontend deployment readiness checks to more reliably confirm that the service is available.
* Improved nginx startup handling when the backend hostname is not immediately resolvable, reducing premature connection failures.
* Added a startup wait period for backend DNS resolution, with a safe timeout so nginx can continue reporting unresolved upstream issues when necessary.

## Documentation

* Clarified hostname requirements for backend proxy configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->