### PR TITLE
Redo the semantic domain import until it finishes

### DIFF
--- a/database/init/update-semantic-domains.sh
+++ b/database/init/update-semantic-domains.sh
@@ -3,6 +3,10 @@
 # completion here and only on success.  Doing it here rather than in the caller
 # means a manual run also counts, and stops the next container start from
 # redoing the whole import.
+#
+# Stop at the first failure and report it: The Combine cannot be used without the
+# semantic domains, so the database's postStart hook restarts the container on a
+# non-zero exit rather than leave a database that looks healthy without them.
 set -eo pipefail
 
 mongoimport -d CombineDatabase -c SemanticDomainTree /data/semantic-domains/tree.json --mode=merge --upsertFields=id,guid,lang

--- a/database/init/update-semantic-domains.sh
+++ b/database/init/update-semantic-domains.sh
@@ -1,4 +1,7 @@
 #! /usr/bin/bash
+# The caller records the import as complete only if this script succeeds, so a
+# failed import must not be reported as success.
+set -eo pipefail
 
 mongoimport -d CombineDatabase -c SemanticDomainTree /data/semantic-domains/tree.json --mode=merge --upsertFields=id,guid,lang
 mongoimport -d CombineDatabase -c SemanticDomains /data/semantic-domains/nodes.json --mode=merge --upsertFields=id,guid,lang

--- a/database/init/update-semantic-domains.sh
+++ b/database/init/update-semantic-domains.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/bash
 # A partial import leaves the collections non-empty but incomplete, so record
-# completion here and only on success.  Doing it here rather than in the caller
+# completion here and only on success. Doing it here rather than in the caller
 # means a manual run also counts, and stops the next container start from
 # redoing the whole import.
 #

--- a/database/init/update-semantic-domains.sh
+++ b/database/init/update-semantic-domains.sh
@@ -1,7 +1,11 @@
 #! /usr/bin/bash
-# The caller records the import as complete only if this script succeeds, so a
-# failed import must not be reported as success.
+# A partial import leaves the collections non-empty but incomplete, so record
+# completion here and only on success.  Doing it here rather than in the caller
+# means a manual run also counts, and stops the next container start from
+# redoing the whole import.
 set -eo pipefail
 
 mongoimport -d CombineDatabase -c SemanticDomainTree /data/semantic-domains/tree.json --mode=merge --upsertFields=id,guid,lang
 mongoimport -d CombineDatabase -c SemanticDomains /data/semantic-domains/nodes.json --mode=merge --upsertFields=id,guid,lang
+
+mongosh --quiet --host 127.0.0.1 --eval "db.getSiblingDB('CombineDatabase').SemanticDomainImportStatus.replaceOne({ _id: 'semantic-domains' }, { _id: 'semantic-domains', completed: true }, { upsert: true });"

--- a/deploy/helm/thecombine/charts/database/templates/database.yaml
+++ b/deploy/helm/thecombine/charts/database/templates/database.yaml
@@ -56,7 +56,13 @@ spec:
                   - /bin/sh
                   - -c
                   - |
-                    exec >> /data/db/postStart.log 2>&1
+                    log=/data/db/postStart.log
+                    # One block is appended per container start, so keep the most
+                    # recent starts and drop the rest.
+                    if [ -f "${log}" ]; then
+                      tail -n 200 "${log}" > "${log}.trim" && mv "${log}.trim" "${log}"
+                    fi
+                    exec >> "${log}" 2>&1
                     set -e
                     echo "[postStart] $(date -Is) starting"
                     echo "[postStart] Waiting for mongod to accept connections"
@@ -79,7 +85,6 @@ spec:
                     if [ "${import_state}" = "needed" ]; then
                       echo "[postStart] Importing semantic domains"
                       /bin/bash /opt/thecombine/update-semantic-domains.sh
-                      mongosh --quiet --host 127.0.0.1 --eval "db.getSiblingDB('CombineDatabase').SemanticDomainImportStatus.replaceOne({ _id: 'semantic-domains' }, { _id: 'semantic-domains', completed: true }, { upsert: true });"
                     fi
                     echo "[postStart] $(date -Is) done"
           env:

--- a/deploy/helm/thecombine/charts/database/templates/database.yaml
+++ b/deploy/helm/thecombine/charts/database/templates/database.yaml
@@ -79,9 +79,13 @@ spec:
                     done
                     echo "[postStart] Ensuring replica set host"
                     mongosh --quiet --host 127.0.0.1 /opt/thecombine/00-replica-set.js || exit $?
-                    # Only a finished import is recorded, so an interrupted one is redone.
-                    import_state="$(mongosh --quiet --host 127.0.0.1 --eval "print(db.getSiblingDB('CombineDatabase').SemanticDomainImportStatus.countDocuments({ _id: 'semantic-domains', completed: true }) === 1 ? 'done' : 'needed');")"
-                    if [ "${import_state}" = "needed" ]; then
+                    # Only a finished import is recorded, so an interrupted one is
+                    # redone. The record is read by exit status; anything short of a
+                    # completed import, including a query that fails, imports again,
+                    # which is a merge and so safe to repeat. Only stdout is discarded,
+                    # to leave any error mongosh reports in this log.
+                    import_done="quit(db.getSiblingDB('CombineDatabase').SemanticDomainImportStatus.countDocuments({ _id: 'semantic-domains', completed: true }) === 1 ? 0 : 1)"
+                    if ! mongosh --quiet --host 127.0.0.1 --eval "${import_done}" > /dev/null; then
                       echo "[postStart] Importing semantic domains"
                       # The Combine cannot be used without the semantic domains, so a
                       # failed import fails the hook, which restarts the container to

--- a/deploy/helm/thecombine/charts/database/templates/database.yaml
+++ b/deploy/helm/thecombine/charts/database/templates/database.yaml
@@ -94,6 +94,10 @@ spec:
                         echo "[postStart] Semantic domain import failed; restarting the container"
                         exit 1
                       fi
+                      # The script records the import too, which is what makes a manual
+                      # rerun count. Recording it here as well is an upsert either way,
+                      # and is what an image whose script predates the record needs.
+                      mongosh --quiet --host 127.0.0.1 --eval "db.getSiblingDB('CombineDatabase').SemanticDomainImportStatus.replaceOne({ _id: 'semantic-domains' }, { _id: 'semantic-domains', completed: true }, { upsert: true });"
                     fi
                     # The kubelet does not probe a container until its postStart hook
                     # returns, so this marker is written last: it cannot make the pod

--- a/deploy/helm/thecombine/charts/database/templates/database.yaml
+++ b/deploy/helm/thecombine/charts/database/templates/database.yaml
@@ -56,8 +56,9 @@ spec:
                   - /bin/sh
                   - -c
                   - |
-                    exec > /data/db/postStart.log 2>&1
+                    exec >> /data/db/postStart.log 2>&1
                     set -e
+                    echo "[postStart] $(date -Is) starting"
                     echo "[postStart] Waiting for mongod to accept connections"
                     attempts=0
                     until mongosh --quiet --host 127.0.0.1 --eval "db.adminCommand({ ping: 1 }).ok" >/dev/null 2>&1; do
@@ -70,10 +71,17 @@ spec:
                     done
                     echo "[postStart] Ensuring replica set host"
                     mongosh --quiet --host 127.0.0.1 /opt/thecombine/00-replica-set.js || exit $?
-                    needs_semantic_import="$(mongosh --quiet --host 127.0.0.1 --eval "const combineDb = db.getSiblingDB('CombineDatabase'); const treeCount = combineDb.SemanticDomainTree.countDocuments({}); const domainCount = combineDb.SemanticDomains.countDocuments({}); print(treeCount === 0 || domainCount === 0 ? 'yes' : 'no');")"
-                    if [ "${needs_semantic_import}" = "yes" ]; then
+                    # mongod can serve the backend from here on, so let the readiness
+                    # probe pass while the semantic domain import runs.
+                    touch /tmp/replica-set-ready
+                    # Only a finished import is recorded, so an interrupted one is redone.
+                    import_state="$(mongosh --quiet --host 127.0.0.1 --eval "print(db.getSiblingDB('CombineDatabase').SemanticDomainImportStatus.countDocuments({ _id: 'semantic-domains', completed: true }) === 1 ? 'done' : 'needed');")"
+                    if [ "${import_state}" = "needed" ]; then
+                      echo "[postStart] Importing semantic domains"
                       /bin/bash /opt/thecombine/update-semantic-domains.sh
+                      mongosh --quiet --host 127.0.0.1 --eval "db.getSiblingDB('CombineDatabase').SemanticDomainImportStatus.replaceOne({ _id: 'semantic-domains' }, { _id: 'semantic-domains', completed: true }, { upsert: true });"
                     fi
+                    echo "[postStart] $(date -Is) done"
           env:
             - name: POD_IP
               valueFrom:
@@ -83,6 +91,19 @@ spec:
               value: "$(POD_IP):27017"
           ports:
             - containerPort: 27017
+          readinessProbe:
+            # /tmp/replica-set-ready is written by the postStart hook once mongod is
+            # a writable primary advertising this pod's IP.  The pod IP is part of
+            # the replica set config and changes on every restart, so without this
+            # the Service can route the backend to a mongod it cannot use.
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - test -f /tmp/replica-set-ready
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
           resources:
             requests:
               cpu:  25m

--- a/deploy/helm/thecombine/charts/database/templates/database.yaml
+++ b/deploy/helm/thecombine/charts/database/templates/database.yaml
@@ -57,8 +57,10 @@ spec:
                   - -c
                   - |
                     log=/data/db/postStart.log
-                    # One block is appended per container start, so keep the most
-                    # recent starts and drop the rest.
+                    # One block is appended per container start. Keeping the last
+                    # 200 lines keeps the recent starts and drops the rest, but it
+                    # does not respect block boundaries, so the oldest block that
+                    # survives can begin part way through.
                     if [ -f "${log}" ]; then
                       tail -n 200 "${log}" > "${log}.trim" && mv "${log}.trim" "${log}"
                     fi
@@ -106,9 +108,9 @@ spec:
           readinessProbe:
             # /tmp/replica-set-ready is written at the end of the postStart hook,
             # once mongod is a writable primary advertising this pod's IP and the
-            # semantic domains are in place.  The pod IP is part of the replica set
+            # semantic domains are in place. The pod IP is part of the replica set
             # config and changes on every restart, so without this the Service can
-            # route the backend to a mongod it cannot use.  A hook that fails, and
+            # route the backend to a mongod it cannot use. A hook that fails, and
             # so restarts the container, never writes the marker at all.
             exec:
               command:

--- a/deploy/helm/thecombine/charts/database/templates/database.yaml
+++ b/deploy/helm/thecombine/charts/database/templates/database.yaml
@@ -77,15 +77,22 @@ spec:
                     done
                     echo "[postStart] Ensuring replica set host"
                     mongosh --quiet --host 127.0.0.1 /opt/thecombine/00-replica-set.js || exit $?
-                    # mongod can serve the backend from here on, so let the readiness
-                    # probe pass while the semantic domain import runs.
-                    touch /tmp/replica-set-ready
                     # Only a finished import is recorded, so an interrupted one is redone.
                     import_state="$(mongosh --quiet --host 127.0.0.1 --eval "print(db.getSiblingDB('CombineDatabase').SemanticDomainImportStatus.countDocuments({ _id: 'semantic-domains', completed: true }) === 1 ? 'done' : 'needed');")"
                     if [ "${import_state}" = "needed" ]; then
                       echo "[postStart] Importing semantic domains"
-                      /bin/bash /opt/thecombine/update-semantic-domains.sh
+                      # The Combine cannot be used without the semantic domains, so a
+                      # failed import fails the hook, which restarts the container to
+                      # retry, rather than leaving a database that looks healthy.
+                      if ! /bin/bash /opt/thecombine/update-semantic-domains.sh; then
+                        echo "[postStart] Semantic domain import failed; restarting the container"
+                        exit 1
+                      fi
                     fi
+                    # The kubelet does not probe a container until its postStart hook
+                    # returns, so this marker is written last: it cannot make the pod
+                    # ready any sooner, and everything above it has to succeed first.
+                    touch /tmp/replica-set-ready
                     echo "[postStart] $(date -Is) done"
           env:
             - name: POD_IP
@@ -97,10 +104,12 @@ spec:
           ports:
             - containerPort: 27017
           readinessProbe:
-            # /tmp/replica-set-ready is written by the postStart hook once mongod is
-            # a writable primary advertising this pod's IP.  The pod IP is part of
-            # the replica set config and changes on every restart, so without this
-            # the Service can route the backend to a mongod it cannot use.
+            # /tmp/replica-set-ready is written at the end of the postStart hook,
+            # once mongod is a writable primary advertising this pod's IP and the
+            # semantic domains are in place.  The pod IP is part of the replica set
+            # config and changes on every restart, so without this the Service can
+            # route the backend to a mongod it cannot use.  A hook that fails, and
+            # so restarts the container, never writes the marker at all.
             exec:
               command:
                 - /bin/sh

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -424,24 +424,24 @@ Notes:
   Arabic, English, French, Portuguese, and Spanish. If additional fonts will be required, call the `setup_combine.py`
   commands with the `--langs` option. Use the `--help` option to see the argument syntax.
 - The database pod has a `postStart` lifecycle hook that initializes the `rs0` replica set on every pod start and, if
-  the import has not already been recorded as complete, runs `update-semantic-domains.sh`. The hook records completion
-  in `CombineDatabase.SemanticDomainImportStatus`; a count of the imported collections is not used, because an import
-  that is interrupted part way through leaves them non-empty but incomplete. If the import is interrupted, the next pod
-  start redoes it.
+  the import has not already been recorded as complete, runs `update-semantic-domains.sh`. That script records its own
+  completion in `CombineDatabase.SemanticDomainImportStatus`, and only on success; a count of the imported collections
+  is not used, because an import that is interrupted part way through leaves them non-empty but incomplete. If the
+  import is interrupted, the next pod start redoes it.
 
   The hook also writes `/tmp/replica-set-ready` once the replica set is aligned, which is what the pod's readiness probe
   checks. Until then the pod is kept out of the `database` Service endpoints, since the replica set advertises the pod's
   IP and the backend connects with `?replicaSet=rs0`.
 
   If the Semantic Domain data are updated, for example, adding a new language, then the import needs to be rerun
-  manually:
+  manually. This also refreshes the completion record, so a manual import is not redone on the next pod start:
 
   ```console
   kubectl -n thecombine exec deployment/database -- /opt/thecombine/update-semantic-domains.sh
   ```
 
   The `postStart` hook appends its output to `/data/db/postStart.log`, which is on the database's persistent volume and
-  so survives restarts:
+  so survives restarts. Only the most recent starts are kept:
 
   ```console
   kubectl -n thecombine exec deployment/database -- cat /data/db/postStart.log

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -427,11 +427,14 @@ Notes:
   the import has not already been recorded as complete, runs `update-semantic-domains.sh`. That script records its own
   completion in `CombineDatabase.SemanticDomainImportStatus`, and only on success; a count of the imported collections
   is not used, because an import that is interrupted part way through leaves them non-empty but incomplete. If the
-  import is interrupted, the next pod start redoes it.
+  import is interrupted, the next pod start redoes it. If the import fails outright, the hook fails, and the kubelet
+  restarts the container to retry; _The Combine_ cannot be used without the semantic domains, so this is preferred over
+  a database that looks healthy without them. Look in the `postStart` log, below, to see why an import is failing.
 
-  The hook also writes `/tmp/replica-set-ready` once the replica set is aligned, which is what the pod's readiness probe
-  checks. Until then the pod is kept out of the `database` Service endpoints, since the replica set advertises the pod's
-  IP and the backend connects with `?replicaSet=rs0`.
+  The hook then writes `/tmp/replica-set-ready`, which is what the pod's readiness probe checks. Until then the pod is
+  kept out of the `database` Service endpoints, since the replica set advertises the pod's IP and the backend connects
+  with `?replicaSet=rs0`. Note that the kubelet does not probe a container until its `postStart` hook returns, so the
+  pod cannot become ready during the import no matter when the marker is written.
 
   If the Semantic Domain data are updated, for example, adding a new language, then the import needs to be rerun
   manually. This also refreshes the completion record, so a manual import is not redone on the next pod start:

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -425,11 +425,13 @@ Notes:
   commands with the `--langs` option. Use the `--help` option to see the argument syntax.
 - The database pod has a `postStart` lifecycle hook that initializes the `rs0` replica set on every pod start and, if
   the import has not already been recorded as complete, runs `update-semantic-domains.sh`. That script records its own
-  completion in `CombineDatabase.SemanticDomainImportStatus`, and only on success; a count of the imported collections
-  is not used, because an import that is interrupted part way through leaves them non-empty but incomplete. If the
-  import is interrupted, the next pod start redoes it. If the import fails outright, the hook fails, and the kubelet
-  restarts the container to retry; _The Combine_ cannot be used without the semantic domains, so this is preferred over
-  a database that looks healthy without them. Look in the `postStart` log, below, to see why an import is failing.
+  completion in `CombineDatabase.SemanticDomainImportStatus`, and only on success, so that a manual rerun counts as
+  well; the hook records it again afterwards, which is what an older image, whose script does not write the record,
+  needs. A count of the imported collections is not used, because an import that is interrupted part way through leaves
+  them non-empty but incomplete. If the import is interrupted, the next pod start redoes it. If the import fails
+  outright, the hook fails, and the kubelet restarts the container to retry; _The Combine_ cannot be used without the
+  semantic domains, so this is preferred over a database that looks healthy without them. Look in the `postStart` log,
+  below, to see why an import is failing.
 
   The hook then writes `/tmp/replica-set-ready`, which is what the pod's readiness probe checks. Until then the pod is
   kept out of the `database` Service endpoints, since the replica set advertises the pod's IP and the backend connects

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -423,12 +423,28 @@ Notes:
 - When the `./setup_combine.py` script is used to install _The Combine_ on a NUC, it will install the fonts required for
   Arabic, English, French, Portuguese, and Spanish. If additional fonts will be required, call the `setup_combine.py`
   commands with the `--langs` option. Use the `--help` option to see the argument syntax.
-- The database pod has a `postStart` lifecycle hook that runs `update-semantic-domains.sh` automatically on every pod
-  start, but only imports data if the `SemanticDomainTree` or `SemanticDomains` collections are empty. If the Semantic
-  Domain data are updated, for example, adding a new language, then the script needs to be rerun manually:
+- The database pod has a `postStart` lifecycle hook that initializes the `rs0` replica set on every pod start and, if
+  the import has not already been recorded as complete, runs `update-semantic-domains.sh`. The hook records completion
+  in `CombineDatabase.SemanticDomainImportStatus`; a count of the imported collections is not used, because an import
+  that is interrupted part way through leaves them non-empty but incomplete. If the import is interrupted, the next pod
+  start redoes it.
+
+  The hook also writes `/tmp/replica-set-ready` once the replica set is aligned, which is what the pod's readiness probe
+  checks. Until then the pod is kept out of the `database` Service endpoints, since the replica set advertises the pod's
+  IP and the backend connects with `?replicaSet=rs0`.
+
+  If the Semantic Domain data are updated, for example, adding a new language, then the import needs to be rerun
+  manually:
 
   ```console
   kubectl -n thecombine exec deployment/database -- /opt/thecombine/update-semantic-domains.sh
+  ```
+
+  The `postStart` hook appends its output to `/data/db/postStart.log`, which is on the database's persistent volume and
+  so survives restarts:
+
+  ```console
+  kubectl -n thecombine exec deployment/database -- cat /data/db/postStart.log
   ```
 
 ## Maintenance

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -437,10 +437,12 @@ Notes:
   pod cannot become ready during the import no matter when the marker is written.
 
   The completion record is in the database's persistent volume, so it outlives the pod that wrote it: once an import is
-  recorded, no later pod start imports again. Whenever the Semantic Domain data change, the import has to be rerun
-  manually. That is true both of data added by hand, for example a new language, and of a release that ships an updated
-  `tree.json` or `nodes.json`, including one installed with `combinectl update`; neither is picked up on its own. A
-  manual run refreshes the completion record, so it is not redone on the next pod start:
+  recorded, no later pod start imports again. An installation that imported before the record existed does not have one,
+  so its first pod start on this chart imports once more, and the pod stays out of the `database` Service for the few
+  minutes that takes. Whenever the Semantic Domain data change, the import has to be rerun manually. That is true both
+  of data added by hand, for example a new language, and of a release that ships an updated `tree.json` or `nodes.json`,
+  including one installed with `combinectl update`; neither is picked up on its own. A manual run refreshes the
+  completion record, so it is not redone on the next pod start:
 
   ```console
   kubectl -n thecombine exec deployment/database -- /opt/thecombine/update-semantic-domains.sh

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -436,15 +436,18 @@ Notes:
   with `?replicaSet=rs0`. Note that the kubelet does not probe a container until its `postStart` hook returns, so the
   pod cannot become ready during the import no matter when the marker is written.
 
-  If the Semantic Domain data are updated, for example, adding a new language, then the import needs to be rerun
-  manually. This also refreshes the completion record, so a manual import is not redone on the next pod start:
+  The completion record is in the database's persistent volume, so it outlives the pod that wrote it: once an import is
+  recorded, no later pod start imports again. Whenever the Semantic Domain data change, the import has to be rerun
+  manually. That is true both of data added by hand, for example a new language, and of a release that ships an updated
+  `tree.json` or `nodes.json`, including one installed with `combinectl update`; neither is picked up on its own. A
+  manual run refreshes the completion record, so it is not redone on the next pod start:
 
   ```console
   kubectl -n thecombine exec deployment/database -- /opt/thecombine/update-semantic-domains.sh
   ```
 
   The `postStart` hook appends its output to `/data/db/postStart.log`, which is on the database's persistent volume and
-  so survives restarts. Only the most recent starts are kept:
+  so survives restarts. Only the last 200 lines are kept, so the oldest entry in it may begin part way through:
 
   ```console
   kubectl -n thecombine exec deployment/database -- cat /data/db/postStart.log

--- a/installer/README.md
+++ b/installer/README.md
@@ -166,7 +166,7 @@ To run `combine-installer.run` with options, the option list must be started wit
 | clean           | Remove the previously saved environment (AWS Access Key, admin user info) and any previously saved timeout before performing the installation. |
 | restart         | Run the installation from the beginning; do not resume a previous installation. |
 | server          | Install _The Combine_ in a server environment so that _The Combine_ is always running by default. |
-| timeout TIMEOUT | Use a different timeout when installing. (Default: 5 minutes.) With slow internet, it is helpful to extend the timeout. See <https://pkg.go.dev/time#ParseDuration> for timeout formats. The value is used for the rest of the installation, including after a restart, so it does not need to be entered again. |
+| timeout TIMEOUT | Use a different timeout when installing. (Default: 5 minutes.) With slow internet, it is helpful to extend the timeout. See <https://pkg.go.dev/time#ParseDuration> for timeout formats. The value is used for the rest of the installation, including after a restart, so it does not need to be entered again. On a first installation the timeout also has to cover the semantic domain import, which takes several minutes; if it runs out, rerun the installer and it continues from where it stopped. |
 | uninstall       | Remove software installed by this script. |
 | update          | Update _The Combine_ to the version number provided. This skips installing/updating support software that was installed previously (e.g., the `combinectl` tool). |
 | version-number  | Specify a version to install instead of the current version. A version number will have the form `vn.n.n` where `n` represents an integer value, for example, `v1.20.0`. |


### PR DESCRIPTION
Split out of #4352, part 2 of 4 — see
https://github.com/sillsdev/TheCombine/pull/4352#issuecomment-5360053323 for the split and how it was verified.

The database pod's `postStart` hook imported the semantic domains whenever either collection was empty. A count cannot
tell a finished import from one killed part way through, so an interrupted import left the collections non-empty but
incomplete and was never redone.

- Guard the import with a completion record in `CombineDatabase.SemanticDomainImportStatus`, written only when the
  import finishes. The record is read by exit status, so anything short of a completed import imports again — a merge,
  and safe to repeat.
- Write the record from `update-semantic-domains.sh` rather than from the hook, so that the documented manual rerun
  counts too and does not leave the next pod start redoing the whole import.
- Fail the hook on a failed import, so the container restarts and retries. _The Combine_ cannot be used without the
  semantic domains, and a database that serves without them looks healthy.
- Add a readiness probe on a marker the hook writes last, so the pod stays out of the `database` Service until the
  replica set advertises the current pod IP — which changes on every restart, and which the backend needs since it
  connects with `?replicaSet=rs0`.
- Append to `/data/db/postStart.log` instead of truncating it, stamp each start, and trim to the last 200 lines, since
  the log is on the database's persistent volume with nothing rotating it.

### Scope

Four files, none of them touched by parts 1 or 4:

- `database/init/update-semantic-domains.sh`
- `deploy/helm/thecombine/charts/database/templates/database.yaml`
- `docs/deploy/README.md`
- the `timeout` row of `installer/README.md`

That last one is a deliberate move from where the split analysis put it. It documents that the installer's timeout has
to cover the semantic domain import, which is a consequence of the readiness probe here, so it belongs with the change
that causes it rather than with part 4. #4353 changes the `update` row of the same table; the two are verified
conflict-free, as is this branch against #4353 and part 1 as a whole.

### QA and prod

Affected, and this is the part to review with prod in mind. The chart template has no target conditionals and
`updateStrategy` is `Recreate` on every profile, so on the first upgrade to this chart the database pod is replaced and
then held out of the `database` Service by the new readiness probe until its `postStart` hook finishes. An existing QA
or prod installation has no completion record, so that hook imports the semantic domains once more: several minutes
with no `database` endpoint.

QA and prod deploys run `setup_combine.py` through `.github/actions/combine-deploy-update` without `--wait`, so helm
itself does not block on the import — but the endpoint gap is real and worth planning around. The manual rerun,
`kubectl -n thecombine exec deployment/database -- /opt/thecombine/update-semantic-domains.sh`, now also writes the
completion record.

### Testing

Not yet exercised on hardware. Worth covering both a fresh install, where the import runs inside the hook, and an
upgrade of an installation that already has the domains but no record, since that is the case QA and prod will hit
first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4355)
<!-- Reviewable:end -->
