### PR TITLE
Bound the installer's wait for The Combine to come up

### DIFF
--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -13,9 +13,9 @@ set -eo pipefail
 #   - single-step - run the next "step" in the installation process and stop.
 #   - start-at <step-name> - start at the step named <step-name> and run to completion.
 #
-# The WAIT_TIMEOUT_SECONDS environment variable overrides how long the
-# "Wait-for-combine" step waits for the deployments to become available, and then
-# again for the semantic domain import, before giving up.
+# The WAIT_TIMEOUT_SECONDS environment variable overrides how long the "Wait-for-combine"
+# step waits for the deployments to become available. The check that follows, which
+# normally passes at once, is given the same budget again.
 #
 #########################################################################################
 
@@ -32,9 +32,9 @@ error () {
   exit 1
 }
 
-# Set the environment variables that are required by The Combine.
-# In addition, the values are stored in a file so that they do not
-# need to be re-entered on subsequent installations.
+# Set the environment variables that are required by The Combine. In addition,
+# the values are stored in a file so that they do not need to be re-entered on
+# subsequent installations.
 set-combine-env () {
   if [ ! -f "${CONFIG_DIR}/env" ] ; then
     # Generate JWT Secret Key
@@ -101,9 +101,8 @@ install-kubernetes () {
   ansible-playbook playbook_desktop_setup.yml -K ${EXTRA_VARS} $(((DEBUG == 1)) && echo "-vv")
 }
 
-# Set the KUBECONFIG environment variable so that the cluster can
-# be reached by the installation scripts.  It also starts the k3s
-# service if it is not already running.
+# Set the KUBECONFIG env var so the cluster can be reached by the installation
+# scripts. It also starts the k3s service if it is not already running.
 set-k3s-env () {
   #####
   # Setup kubectl configuration file
@@ -159,7 +158,7 @@ install-the-combine () {
 }
 
 # Exit if the deadline for the current wait has passed, printing the state of
-# the pods so that the user has somewhere to start looking.  $1 names what is
+# the pods so that the user has somewhere to start looking. $1 names what is
 # still being waited for and $2 optionally replaces the default error hint.
 check-wait-deadline () {
   if (( SECONDS < WAIT_DEADLINE )) ; then
@@ -173,8 +172,9 @@ check-wait-deadline () {
   error "Timed out after ${WAIT_TIMEOUT_SECONDS}s; still waiting for $1."
 }
 
-# Wait until all The Combine deployments are available.  One deadline covers all
-# of them, so a database that takes most of it leaves the rest less time.
+# Wait until all The Combine deployments are available. One deadline covers all
+# of them, so the database, which is not available until its postStart hook has
+# imported the semantic domains, leaves the rest of them less time.
 wait-for-combine () {
   set-k3s-env
   WAIT_DEADLINE=$(( SECONDS + WAIT_TIMEOUT_SECONDS ))
@@ -197,10 +197,15 @@ wait-for-combine () {
   done
 }
 
-# Wait until the database has recorded a completed semantic domain import. The
-# import runs from the database's postStart hook and takes several minutes on a
-# first install. It is redone on the next start if it is interrupted, so waiting
-# here keeps the shutdown below from silently costing the user another import.
+# Check that the database has recorded a completed semantic domain import, which
+# is redone on the next pod start if it was interrupted, so that the shutdown
+# below does not silently cost the user another import.
+#
+# The import runs from the database's postStart hook, and the kubelet does not
+# report a container ready until its hook returns, so wait-for-combine has
+# already waited the import out and this normally passes on its first check. It
+# is here for what that wait cannot see: a database pod that an install left
+# running, and so never ran the hook, with no import recorded.
 wait-for-semantic-domains () {
   echo "Waiting for the semantic domain import."
   WAIT_DEADLINE=$(( SECONDS + WAIT_TIMEOUT_SECONDS ))
@@ -277,10 +282,10 @@ SINGLE_STEP=0
 IS_SERVER=0
 DEBUG=0
 ERROR_HINT=""
-# Only a timeout given as an option is checked for a valid format, so ignore any
-# value that happens to be set in the environment.
+# Only a timeout given as an option is checked for a valid format, so ignore
+# any value that happens to be set in the environment.
 HELM_TIMEOUT=""
-# Maximum time to wait for each stage of The Combine to come up.  A first
+# Maximum time to wait for each stage of The Combine to come up. A first
 # install pulls several images and imports the semantic domains, so a generous
 # default is better than one that gives up on a slow machine or connection.
 WAIT_TIMEOUT_SECONDS=${WAIT_TIMEOUT_SECONDS:-3600}

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -295,10 +295,6 @@ HELM_TIMEOUT=""
 # Maximum time to wait for each stage of The Combine to come up. A first install
 # pulls several images and imports the semantic domains, so be generous.
 WAIT_TIMEOUT_SECONDS=${WAIT_TIMEOUT_SECONDS:-3600}
-# Prevent silently bad values: non-number (reads as 0); leading zero (octal).
-if [[ ! ${WAIT_TIMEOUT_SECONDS} =~ ^[1-9][0-9]*$ ]] ; then
-  error "Invalid WAIT_TIMEOUT_SECONDS, '${WAIT_TIMEOUT_SECONDS}'; it must be a whole number greater than zero."
-fi
 # The deployments wait already covers the import, so this only covers one slow call.
 IMPORT_CHECK_TIMEOUT_SECONDS=120
 
@@ -371,6 +367,10 @@ fi
 
 SETUP_OPTS=""
 if [ "${STATE}" != "Uninstall-combine" ] ; then
+  # Prevent silently bad values: non-number (reads as 0); leading zero (octal).
+  if [[ ! ${WAIT_TIMEOUT_SECONDS} =~ ^[1-9][0-9]*$ ]] ; then
+    error "Invalid WAIT_TIMEOUT_SECONDS, '${WAIT_TIMEOUT_SECONDS}'; it must be a whole number greater than zero."
+  fi
   # Every helm command runs after the restart that the Pre-reqs step usually
   # requires, so record a timeout and reuse it until the install finishes.
   if [ -z "${HELM_TIMEOUT}" ] ; then

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -154,25 +154,34 @@ install-the-combine () {
   deactivate
 }
 
-# Wait until all The Combine deployments are "Running"
+# Wait until all The Combine deployments are available. There is no timeout;
+# the caller tells the user how to interrupt.
 wait-for-combine () {
-  # Wait for all The Combine deployments to be up
-  while true ; do
-    combine_status=`kubectl -n thecombine get deployments`
-    # Assert The Combine is up; if any components are not up, set it to false
-    combine_up=true
-    for deployment in frontend backend database maintenance ; do
-      deployment_status=$(echo ${combine_status} | grep "${deployment}" | sed "s/^.*\([0-9]\)\/1.*/\1/")
-      if [ "$deployment_status" == "0" ] ; then
-        combine_up=false
-        break
-      fi
-    done
-    if [ ${combine_up} != true ] ; then
+  set-k3s-env
+  # The database is checked first because everything else depends on it and it
+  # is the slowest to come up on a first install.
+  for deployment in database backend frontend maintenance ; do
+    echo "Waiting for deployment/${deployment}."
+    until kubectl -n thecombine get deployment/${deployment} > /dev/null 2>&1 ; do
       sleep 5
-    else
-      break
-    fi
+    done
+    until kubectl -n thecombine wait --for=condition=Available \
+        --timeout=1m deployment/${deployment} > /dev/null 2>&1 ; do
+      echo "  still waiting for deployment/${deployment}."
+    done
+  done
+}
+
+# Wait until the database has recorded a completed semantic domain import. The
+# import runs from the database's postStart hook and takes several minutes on a
+# first install. It is redone on the next start if it is interrupted, so waiting
+# here keeps the shutdown below from silently costing the user another import.
+wait-for-semantic-domains () {
+  echo "Waiting for the semantic domain import."
+  import_done="quit(db.getSiblingDB('CombineDatabase').SemanticDomainImportStatus.countDocuments({ _id: 'semantic-domains', completed: true }) === 1 ? 0 : 1)"
+  until kubectl -n thecombine exec deployment/database -- \
+      mongosh --quiet --host 127.0.0.1 --eval "${import_done}" > /dev/null 2>&1 ; do
+    sleep 10
   done
 }
 
@@ -374,6 +383,7 @@ while [ "$STATE" != "Done" ] ; do
       echo "This may take some time depending on your Internet connection."
       echo "Press Ctrl-C to interrupt."
       wait-for-combine
+      wait-for-semantic-domains
       echo "The Combine was successfully setup!"
       next-state "Shutdown-combine"
       ;;

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -13,6 +13,9 @@ set -eo pipefail
 #   - single-step - run the next "step" in the installation process and stop.
 #   - start-at <step-name> - start at the step named <step-name> and run to completion.
 #
+# The WAIT_TIMEOUT_SECONDS environment variable overrides how long each stage of
+# the "Wait-for-combine" step waits before giving up.
+#
 #########################################################################################
 
 # Warning and Error reporting functions
@@ -154,20 +157,37 @@ install-the-combine () {
   deactivate
 }
 
-# Wait until all The Combine deployments are available. There is no timeout;
-# the caller tells the user how to interrupt.
+# Exit if the deadline for the current wait has passed, printing the state of
+# the pods so that the user has somewhere to start looking.
+check-wait-deadline () {
+  if (( SECONDS < WAIT_DEADLINE )) ; then
+    return 0
+  fi
+  echo "Current state of the pods in the 'thecombine' namespace:" >&2
+  kubectl -n thecombine get pods --request-timeout=10s >&2 || true
+  ERROR_HINT="Rerun the installer to resume waiting; nothing needs to be undone."
+  error "Timed out after ${WAIT_TIMEOUT_SECONDS}s waiting for $1."
+}
+
+# Wait until all The Combine deployments are available.
 wait-for-combine () {
   set-k3s-env
+  WAIT_DEADLINE=$(( SECONDS + WAIT_TIMEOUT_SECONDS ))
   # The database is checked first because everything else depends on it and it
   # is the slowest to come up on a first install.
   for deployment in database backend frontend maintenance ; do
     echo "Waiting for deployment/${deployment}."
     until kubectl -n thecombine get deployment/${deployment} > /dev/null 2>&1 ; do
+      check-wait-deadline "deployment/${deployment}"
       sleep 5
     done
+    # "kubectl wait" returns at once, rather than blocking for its timeout, when
+    # the API is unreachable or the deployment is gone, so pace the retries.
     until kubectl -n thecombine wait --for=condition=Available \
         --timeout=1m deployment/${deployment} > /dev/null 2>&1 ; do
+      check-wait-deadline "deployment/${deployment}"
       echo "  still waiting for deployment/${deployment}."
+      sleep 5
     done
   done
 }
@@ -178,10 +198,14 @@ wait-for-combine () {
 # here keeps the shutdown below from silently costing the user another import.
 wait-for-semantic-domains () {
   echo "Waiting for the semantic domain import."
+  WAIT_DEADLINE=$(( SECONDS + WAIT_TIMEOUT_SECONDS ))
   import_done="quit(db.getSiblingDB('CombineDatabase').SemanticDomainImportStatus.countDocuments({ _id: 'semantic-domains', completed: true }) === 1 ? 0 : 1)"
+  # Each check starts a mongosh inside the database container, competing with the
+  # import it is waiting on, so check infrequently.
   until kubectl -n thecombine exec deployment/database -- \
       mongosh --quiet --host 127.0.0.1 --eval "${import_done}" > /dev/null 2>&1 ; do
-    sleep 10
+    check-wait-deadline "the semantic domain import"
+    sleep 30
   done
 }
 
@@ -248,6 +272,10 @@ ERROR_HINT=""
 # Only a timeout given as an option is checked for a valid format, so ignore any
 # value that happens to be set in the environment.
 HELM_TIMEOUT=""
+# Maximum time to wait for each stage of The Combine to come up.  A first
+# install pulls several images and imports the semantic domains, so a generous
+# default is better than one that gives up on a slow machine or connection.
+WAIT_TIMEOUT_SECONDS=${WAIT_TIMEOUT_SECONDS:-3600}
 
 # See if we need to continue from a previous install
 STATE_FILE=${CONFIG_DIR}/install-state

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -14,8 +14,8 @@ set -eo pipefail
 #   - start-at <step-name> - start at the step named <step-name> and run to completion.
 #
 # The WAIT_TIMEOUT_SECONDS environment variable overrides how long the "Wait-for-combine"
-# step waits for the deployments to become available. The check that follows, which
-# normally passes at once, is given the same budget again.
+# step waits for the deployments to become available. The check that follows it has a
+# short budget of its own, since it normally passes at once.
 #
 #########################################################################################
 
@@ -157,6 +157,12 @@ install-the-combine () {
   deactivate
 }
 
+# Start a wait of $1 seconds, keeping the budget for check-wait-deadline to report.
+start-wait () {
+  WAIT_BUDGET=$1
+  WAIT_DEADLINE=$(( SECONDS + WAIT_BUDGET ))
+}
+
 # Exit if the deadline for the current wait has passed, printing the state of
 # the pods so that the user has somewhere to start looking. $1 names what is
 # still being waited for and $2 optionally replaces the default error hint.
@@ -169,7 +175,7 @@ check-wait-deadline () {
   ERROR_HINT="${2:-Rerun the installer to resume waiting; nothing needs to be undone.}"
   # The deadline covers the whole wait, so report what it was still waiting for
   # rather than implying that $1 alone had the full timeout.
-  error "Timed out after ${WAIT_TIMEOUT_SECONDS}s; still waiting for $1."
+  error "Timed out after ${WAIT_BUDGET}s; still waiting for $1."
 }
 
 # Wait until all The Combine deployments are available. One deadline covers all
@@ -177,7 +183,7 @@ check-wait-deadline () {
 # imported the semantic domains, leaves the rest of them less time.
 wait-for-combine () {
   set-k3s-env
-  WAIT_DEADLINE=$(( SECONDS + WAIT_TIMEOUT_SECONDS ))
+  start-wait "${WAIT_TIMEOUT_SECONDS}"
   # The database is checked first because everything else depends on it and it
   # is the slowest to come up on a first install.
   for deployment in database backend frontend maintenance ; do
@@ -205,10 +211,11 @@ wait-for-combine () {
 # report a container ready until its hook returns, so wait-for-combine has
 # already waited the import out and this normally passes on its first check. It
 # is here for what that wait cannot see: a database pod that an install left
-# running, and so never ran the hook, with no import recorded.
+# running, and so never ran the hook, with no import recorded. Nothing will write
+# the record then, so the wait is short and ends in the hint below.
 wait-for-semantic-domains () {
   echo "Waiting for the semantic domain import."
-  WAIT_DEADLINE=$(( SECONDS + WAIT_TIMEOUT_SECONDS ))
+  start-wait "${IMPORT_CHECK_TIMEOUT_SECONDS}"
   import_done="quit(db.getSiblingDB('CombineDatabase').SemanticDomainImportStatus.countDocuments({ _id: 'semantic-domains', completed: true }) === 1 ? 0 : 1)"
   # Rerunning the installer does not restart the database pod, so it does not
   # start an import that never ran; point at the manual import instead.
@@ -285,10 +292,15 @@ ERROR_HINT=""
 # Only a timeout given as an option is checked for a valid format, so ignore
 # any value that happens to be set in the environment.
 HELM_TIMEOUT=""
-# Maximum time to wait for each stage of The Combine to come up. A first
-# install pulls several images and imports the semantic domains, so a generous
-# default is better than one that gives up on a slow machine or connection.
+# Maximum time to wait for each stage of The Combine to come up. A first install
+# pulls several images and imports the semantic domains, so be generous.
 WAIT_TIMEOUT_SECONDS=${WAIT_TIMEOUT_SECONDS:-3600}
+# Prevent silently bad values: non-number (reads as 0); leading zero (octal).
+if [[ ! ${WAIT_TIMEOUT_SECONDS} =~ ^[1-9][0-9]*$ ]] ; then
+  error "Invalid WAIT_TIMEOUT_SECONDS, '${WAIT_TIMEOUT_SECONDS}'; it must be a whole number greater than zero."
+fi
+# The deployments wait already covers the import, so this only covers one slow call.
+IMPORT_CHECK_TIMEOUT_SECONDS=120
 
 # See if we need to continue from a previous install
 STATE_FILE=${CONFIG_DIR}/install-state

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -386,6 +386,9 @@ while [ "$STATE" != "Done" ] ; do
       wait-for-semantic-domains
       echo "The Combine was successfully setup!"
       next-state "Shutdown-combine"
+      if [ "$SINGLE_STEP" == "1" ] ; then
+        STATE=Done
+      fi
       ;;
     Shutdown-combine)
       # If not being installed as a server,

--- a/deploy/scripts/install-combine.sh
+++ b/deploy/scripts/install-combine.sh
@@ -13,8 +13,9 @@ set -eo pipefail
 #   - single-step - run the next "step" in the installation process and stop.
 #   - start-at <step-name> - start at the step named <step-name> and run to completion.
 #
-# The WAIT_TIMEOUT_SECONDS environment variable overrides how long each stage of
-# the "Wait-for-combine" step waits before giving up.
+# The WAIT_TIMEOUT_SECONDS environment variable overrides how long the
+# "Wait-for-combine" step waits for the deployments to become available, and then
+# again for the semantic domain import, before giving up.
 #
 #########################################################################################
 
@@ -158,18 +159,22 @@ install-the-combine () {
 }
 
 # Exit if the deadline for the current wait has passed, printing the state of
-# the pods so that the user has somewhere to start looking.
+# the pods so that the user has somewhere to start looking.  $1 names what is
+# still being waited for and $2 optionally replaces the default error hint.
 check-wait-deadline () {
   if (( SECONDS < WAIT_DEADLINE )) ; then
     return 0
   fi
   echo "Current state of the pods in the 'thecombine' namespace:" >&2
   kubectl -n thecombine get pods --request-timeout=10s >&2 || true
-  ERROR_HINT="Rerun the installer to resume waiting; nothing needs to be undone."
-  error "Timed out after ${WAIT_TIMEOUT_SECONDS}s waiting for $1."
+  ERROR_HINT="${2:-Rerun the installer to resume waiting; nothing needs to be undone.}"
+  # The deadline covers the whole wait, so report what it was still waiting for
+  # rather than implying that $1 alone had the full timeout.
+  error "Timed out after ${WAIT_TIMEOUT_SECONDS}s; still waiting for $1."
 }
 
-# Wait until all The Combine deployments are available.
+# Wait until all The Combine deployments are available.  One deadline covers all
+# of them, so a database that takes most of it leaves the rest less time.
 wait-for-combine () {
   set-k3s-env
   WAIT_DEADLINE=$(( SECONDS + WAIT_TIMEOUT_SECONDS ))
@@ -200,11 +205,14 @@ wait-for-semantic-domains () {
   echo "Waiting for the semantic domain import."
   WAIT_DEADLINE=$(( SECONDS + WAIT_TIMEOUT_SECONDS ))
   import_done="quit(db.getSiblingDB('CombineDatabase').SemanticDomainImportStatus.countDocuments({ _id: 'semantic-domains', completed: true }) === 1 ? 0 : 1)"
+  # Rerunning the installer does not restart the database pod, so it does not
+  # start an import that never ran; point at the manual import instead.
+  import_hint="Import the semantic domains manually with: kubectl -n thecombine exec deployment/database -- /opt/thecombine/update-semantic-domains.sh"
   # Each check starts a mongosh inside the database container, competing with the
   # import it is waiting on, so check infrequently.
   until kubectl -n thecombine exec deployment/database -- \
       mongosh --quiet --host 127.0.0.1 --eval "${import_done}" > /dev/null 2>&1 ; do
-    check-wait-deadline "the semantic domain import"
+    check-wait-deadline "the semantic domain import" "${import_hint}"
     sleep 30
   done
 }


### PR DESCRIPTION
Split out of #4352, part 4 of 4 — see
https://github.com/sillsdev/TheCombine/pull/4352#issuecomment-5360053323 for the split and how it was verified.

**Stacked on #4355.** The base is `fix/database-first-boot`, not `master`: `wait-for-semantic-domains` polls
`CombineDatabase.SemanticDomainImportStatus`, and nothing writes that record until #4355 lands. On its own against
`master` this would fail a first install after `IMPORT_CHECK_TIMEOUT_SECONDS` with the manual-import hint. Review the
`deploy/scripts/install-combine.sh` commits here; the four files from #4355 show up in the diff until that merges.

`wait-for-combine` only ever read one deployment's READY count. Collapsing the `kubectl` table with an unquoted
expansion put every row on one line, so `grep` matched the whole line for each name and the greedy `sed` captured the
last `N/1` in it — the alphabetically last deployment, `maintenance`. So the installer could stop k3s while the rest
were still coming up, and stopping k3s SIGKILLs pods, since the unit is patched to `KillMode=mixed`.

- Replace the parsing with `kubectl wait`, checking the database first: everything else depends on it and it is the
  slowest to come up on a first install.
- Wait for the database to record a completed semantic domain import before the shutdown, so that an interrupted
  import does not silently cost the user another one.
- Pace and bound both waits. `kubectl wait` returns at once rather than blocking when the API is unreachable or the
  deployment is gone, so the retry loop could spin, pegging a core and flooding the terminal; and neither wait had an
  upper bound, so a deployment that was never going to come up produced no error, ever. Each stage now has a deadline,
  prints the pods in the namespace before exiting, and resumes if the installer is rerun.
- Validate `WAIT_TIMEOUT_SECONDS`, which went into arithmetic unchecked: bash reads a non-number as 0 and a leading
  zero as octal, so `abc` became a deadline already passed, `007` seven seconds, and `3600s` a bare arithmetic error.
  The check sits with the other install-only setup, so a bad value in the environment cannot stop an uninstall.
- Let `single-step` stop after `Wait-for-combine`, so a running cluster can be inspected before the installer stops it.

### Scope

One file: `deploy/scripts/install-combine.sh`, and all of its hunks except the `Shutdown-combine` one, which is in
#4353. Verified: the only difference between this branch's copy of the script and #4352's is that hunk.

The `timeout` row of `installer/README.md` went to #4355 and the `update` row to #4353, so nothing is left here for
that file. Verified conflict-free against #4353 and #4354.

### QA and prod

None. `install-combine.sh` ships in `combine-installer.run`; QA and prod are deployed by
`.github/actions/combine-deploy-update`, which runs `setup_combine.py` directly. The installer's own `server` option
is the only server-shaped path it touches, and that path skips `Shutdown-combine` entirely.

### Testing

Not yet exercised on hardware. The waits are the whole substance here, so this wants a real first install — including
the timeout paths, which are easiest to reach by setting `WAIT_TIMEOUT_SECONDS` low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4356)
<!-- Reviewable:end -->
