### PR TITLE
Allow building the net-installer from a branch

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -74,6 +74,9 @@ jobs:
           path: installer/combine-net-installer.run
           retention-days: 5
       - name: Make installer with release version
+        # A manual run exists to publish a net-installer for the branch; the full
+        # installer is not uploaded, and building it needs a reachable release tag.
+        if: github.event_name != 'workflow_dispatch'
         run: |
           cd installer
           ./make-combine-installer.sh $(git describe --tags --abbrev=0) --debug

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -193,5 +193,5 @@ jobs:
         env:
           TARGET_FILE: ${{ steps.target.outputs.file }}
         run: |
-          aws s3 cp installer/combine-net-installer.run "s3://software.thecombine.app/$TARGET_FILE"             --content-type application/octet-stream
+          aws s3 cp installer/combine-net-installer.run "s3://software.thecombine.app/$TARGET_FILE" --content-type application/octet-stream
         shell: bash

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -11,10 +11,13 @@ on:
       - "deploy/**/*.yaml"
       - "deploy/**/*.yml"
       - "installer/**"
+  workflow_dispatch:
 
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.workflow }}-${{ github.ref_protected && github.run_id || github.event.pull_request.number }}
+  group:
+    ${{ github.workflow }}-${{ github.ref_protected && github.run_id || github.event.pull_request.number ||
+    github.ref_name }}
 
 permissions:
   contents: read
@@ -154,31 +157,41 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 2
-      - name: Detect changes to installer scripts
-        id: changed-installer
+      - name: Determine upload target
+        id: target
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           paths="^installer/make-combine-installer.sh$|^deploy/.*\.sh$|^deploy/.*\.ya?ml$"
-          if git diff --name-only HEAD~1.. | grep -Eq "$paths"; then
-            echo "changed=true" >> $GITHUB_OUTPUT
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # Manual runs are published under a branch-specific name so that they cannot
+            # clobber the installer that the release documentation points users to.
+            echo "file=combine-net-installer-${REF_NAME//\//-}.run" >> $GITHUB_OUTPUT
+            echo "upload=true" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "push" ]] && git diff --name-only HEAD~1.. | grep -Eq "$paths"; then
+            echo "file=combine-net-installer.run" >> $GITHUB_OUTPUT
+            echo "upload=true" >> $GITHUB_OUTPUT
           else
-            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "upload=false" >> $GITHUB_OUTPUT
           fi
         shell: bash
       - name: Download net-installer artifact
-        if: steps.changed-installer.outputs.changed == 'true' && github.event_name == 'push'
+        if: steps.target.outputs.upload == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: combine-net-installer
           path: installer/
       - name: Configure AWS credentials
-        if: steps.changed-installer.outputs.changed == 'true' && github.event_name == 'push'
+        if: steps.target.outputs.upload == 'true'
         uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Upload net-installer to S3
-        if: steps.changed-installer.outputs.changed == 'true' && github.event_name == 'push'
+        if: steps.target.outputs.upload == 'true'
+        env:
+          TARGET_FILE: ${{ steps.target.outputs.file }}
         run: |
-          aws s3 cp installer/combine-net-installer.run s3://software.thecombine.app/combine-net-installer.run --content-type application/octet-stream
+          aws s3 cp installer/combine-net-installer.run "s3://software.thecombine.app/$TARGET_FILE"             --content-type application/octet-stream
         shell: bash

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -74,8 +74,6 @@ jobs:
           path: installer/combine-net-installer.run
           retention-days: 5
       - name: Make installer with release version
-        # A manual run exists to publish a net-installer for the branch; the full
-        # installer is not uploaded, and building it needs a reachable release tag.
         if: github.event_name != 'workflow_dispatch'
         run: |
           cd installer
@@ -167,9 +165,8 @@ jobs:
         run: |
           paths="^installer/make-combine-installer.sh$|^deploy/.*\.sh$|^deploy/.*\.ya?ml$"
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            # Manual runs are published under a branch-specific name so that they cannot
-            # clobber the installer that the release documentation points users to.
-            echo "file=combine-net-installer-${REF_NAME//\//-}.run" >> $GITHUB_OUTPUT
+            # Manual runs publish with a branch-specific name, sanitized for use as an S3 key.
+            echo "file=combine-net-installer-${REF_NAME//[^A-Za-z0-9._-]/-}.run" >> $GITHUB_OUTPUT
             echo "upload=true" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" == "push" ]] && git diff --name-only HEAD~1.. | grep -Eq "$paths"; then
             echo "file=combine-net-installer.run" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger to the `installer` workflow so the
net-installer can be built and published from any branch.

- Manual runs upload to `combine-net-installer-<branch>.run`
  (non-alphanumeric characters in the branch name become dashes), so as not
  to overwrite the `combine-net-installer.run` that users download.
- Pushes to `master` behave exactly as before: they still upload to
  `combine-net-installer.run`, and still only when `make-combine-installer.sh`
  or a `deploy/` script/manifest changed. Pull request runs still build the
  artifact without uploading.
- The concurrency group gets a `github.ref_name` fallback. For a manual run on
  an unprotected branch neither `run_id` nor a pull request number is
  available, so without it every branch dispatch would share one group and
  cancel the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/TheCombine/4357)
<!-- Reviewable:end -->
